### PR TITLE
feat: complete Phase 1 — Job watch, findings write-back, CI smoke test, docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,88 @@ jobs:
 
       - name: Lint chart
         run: helm lint deploy/helm
+
+  smoke-test:
+    name: Smoke Test (kind)
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: smoke
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Apply CRDs
+        run: kubectl apply -f deploy/helm/templates/crds/
+
+      - name: Verify CRDs registered
+        run: |
+          kubectl wait --for=condition=Established crd/diagnosticruns.k8sai.io --timeout=30s
+          kubectl wait --for=condition=Established crd/diagnosticskills.k8sai.io --timeout=30s
+          kubectl wait --for=condition=Established crd/modelconfigs.k8sai.io --timeout=30s
+
+      - name: Build controller binary
+        run: CGO_ENABLED=0 GOOS=linux go build -o bin/controller ./cmd/controller
+
+      - name: Build MCP server binary
+        run: CGO_ENABLED=0 GOOS=linux go build -o bin/k8s-mcp-server ./cmd/main.go
+
+      - name: Create DiagnosticSkill CR
+        run: |
+          cat <<'EOF' | kubectl apply -f -
+          apiVersion: k8sai.io/v1alpha1
+          kind: DiagnosticSkill
+          metadata:
+            name: pod-health-analyst
+          spec:
+            dimension: health
+            description: "Analyzes pod health"
+            prompt: "Check pod status"
+            tools: ["kubectl_get"]
+            enabled: true
+            priority: 100
+          EOF
+
+      - name: Verify DiagnosticSkill created
+        run: kubectl get diagnosticskills pod-health-analyst -o jsonpath='{.spec.dimension}' | grep health
+
+      - name: Create DiagnosticRun CR
+        run: |
+          cat <<'EOF' | kubectl apply -f -
+          apiVersion: k8sai.io/v1alpha1
+          kind: DiagnosticRun
+          metadata:
+            name: smoke-test
+          spec:
+            target:
+              scope: namespace
+              namespaces: ["default"]
+            skills: ["pod-health-analyst"]
+            modelConfigRef: "anthropic-credentials"
+          EOF
+
+      - name: Verify DiagnosticRun created
+        run: kubectl get diagnosticrun smoke-test -o jsonpath='{.spec.target.scope}' | grep namespace
+
+      - name: Helm template renders
+        run: |
+          helm template test-release deploy/helm \
+            --set anthropic.secretName=test-secret \
+            --namespace test-ns | kubectl apply --dry-run=client -f -
+
+      - name: Cleanup
+        if: always()
+        run: |
+          kubectl delete diagnosticrun smoke-test --ignore-not-found
+          kubectl delete diagnosticskill pod-health-analyst --ignore-not-found

--- a/README.md
+++ b/README.md
@@ -67,26 +67,32 @@ helm install kube-agent-helper deploy/helm \
 ### 3. Run a diagnostic
 
 ```yaml
-apiVersion: diagnostics.kube-agent-helper.io/v1alpha1
+apiVersion: k8sai.io/v1alpha1
 kind: DiagnosticRun
 metadata:
   name: cluster-health-check
   namespace: kube-agent-helper
 spec:
-  targetNamespaces:
-    - default
-  skillNames:
+  target:
+    scope: namespace
+    namespaces:
+      - default
+  skills:
     - pod-health-analyst
+  modelConfigRef: "anthropic-credentials"   # Secret name containing apiKey
 ```
 
 ```bash
 kubectl apply -f the-above.yaml
 
-# Watch progress
+# Watch progress (phase transitions: Pending → Running → Succeeded/Failed)
 kubectl get diagnosticrun cluster-health-check -w
 
-# View findings
+# View findings written back to CR status
 kubectl get diagnosticrun cluster-health-check -o jsonpath='{.status.findings}' | jq .
+
+# View severity counts
+kubectl get diagnosticrun cluster-health-check -o jsonpath='{.status.findingCounts}'
 ```
 
 ## Built-in Skills

--- a/agent-runtime/runtime/orchestrator.py
+++ b/agent-runtime/runtime/orchestrator.py
@@ -120,7 +120,12 @@ def _stream_message(client, tools, messages) -> dict:
     }
 
     base_url = os.environ.get("ANTHROPIC_BASE_URL", "https://api.anthropic.com")
-    url = base_url.rstrip("/") + "/v1/messages"
+    base_url = base_url.rstrip("/")
+    # If base_url already ends with /v1/messages (some proxies), use as-is
+    if base_url.endswith("/v1/messages"):
+        url = base_url
+    else:
+        url = base_url + "/v1/messages"
 
     payload = {
         "model": os.environ.get("MODEL", "claude-sonnet-4-6"),

--- a/deploy/helm/templates/crds/k8sai.io_diagnosticruns.yaml
+++ b/deploy/helm/templates/crds/k8sai.io_diagnosticruns.yaml
@@ -77,6 +77,33 @@ spec:
               completedAt:
                 format: date-time
                 type: string
+              findingCounts:
+                additionalProperties:
+                  type: integer
+                type: object
+              findings:
+                items:
+                  properties:
+                    dimension:
+                      type: string
+                    resourceKind:
+                      type: string
+                    resourceName:
+                      type: string
+                    resourceNamespace:
+                      type: string
+                    severity:
+                      type: string
+                    suggestion:
+                      type: string
+                    title:
+                      type: string
+                  required:
+                  - dimension
+                  - severity
+                  - title
+                  type: object
+                type: array
               message:
                 type: string
               phase:

--- a/docs/design.md
+++ b/docs/design.md
@@ -363,35 +363,39 @@ case_memory(id, embedding vector(1536), finding_id, outcome, created_at)
 ## 10. 技术栈建议
 
 
-| 层                | 选型                                                 | 理由                                               |
+| 层                | 设计选型                                             | 实际实现（Phase 1）                                |
 | ----------------- | ---------------------------------------------------- | -------------------------------------------------- |
-| Controller / HTTP | Go + controller-runtime + gorilla/mux                | 照搬 kagent，单进程 manager 模式                   |
-| DB                | PostgreSQL + pgx + sqlc + golang-migrate + pgvector  | 照搬 kagent                                        |
-| Agent Runtime     | Python +**Claude Agent SDK**（含 Claude CLI 子进程） | SKILL.md 一等公民，胶水最少，agentic loop 质量最强 |
-| 协议              | MCP（工具接入） + A2A（Pod 对外暴露）                | MCP 接 K8s 数据；A2A 只给 Controller/UI 调用       |
-| 内置 MCP Server   | `k8s-mcp-server`（Go）封装 client-go + prometheus    | 避免每个 Agent 重复实现                            |
-| UI                | Next.js 14 + shadcn + Tailwind                       | 照搬 ci-agent，够用                                |
-| LLM 接入          | Anthropic（Claude Sonnet/Opus）                      | 单 vendor 换简洁度，P4 之后再评估多引擎            |
+| Controller / HTTP | Go + controller-runtime + gorilla/mux                | Go + controller-runtime + net/http（stdlib）       |
+| DB                | PostgreSQL + pgx + sqlc + golang-migrate + pgvector  | SQLite（Phase 1 足够；Phase 3 迁移 Postgres）      |
+| Agent Runtime     | Python + Claude Agent SDK（含 Claude CLI 子进程）    | Python + Anthropic API + httpx 原生 SSE streaming  |
+| 协议              | MCP（工具接入） + A2A（Pod 对外暴露）                | MCP stdio（工具接入）；A2A 留 Phase 2              |
+| 内置 MCP Server   | `k8s-mcp-server`（Go）封装 client-go + prometheus    | 已实现，9 个工具                                   |
+| UI                | Next.js 14 + shadcn + Tailwind                       | 留 Phase 2（当前通过 kubectl + REST API 查看）     |
+| LLM 接入          | Anthropic（Claude Sonnet/Opus）                      | Anthropic（支持自定义 proxy + 模型选择）           |
 
 ---
 
 ## 11. 实施路线
 
-### Phase 1 — 最小可用（Operator MVP）
+### Phase 1 — 最小可用（Operator MVP） ✅ 已完成
 
-- [ ]  定义 `DiagnosticSkill` / `DiagnosticRun` / `ModelConfig` 三个 CRD
-- [ ]  Go Controller 单 binary：manager + HTTP server 同进程（照搬 kagent `app.Start`）
-- [ ]  DB 层 sqlc + migrate（可直接拷 kagent 的基础设施代码）
-- [ ]  Translator：把 `DiagnosticRun` 编译成一次性 Job（`kind: Job`），Skill CR 序列化为 ConfigMap 内的 `SKILL.md` 文件树
-- [ ]  Python Agent 镜像：
-  - 基础镜像含 Python + Claude CLI（Node.js）
-  - 读挂载的 `/workspace/skills/*/SKILL.md`
-  - 通过 `claude_agent_sdk.query(options=ClaudeAgentOptions(agents=...))` 跑 agentic loop
-  - 写回 Finding 表（通过 Controller HTTP API）
-- [ ]  `k8s-mcp-server` 最小子集：`kubectl_get`、`kubectl_describe`、`kubectl_logs`、`events_list`
-- [ ]  1-2 个内置 Skill：`pod-health-analyst`、`pod-security-analyst`（SKILL.md 形式）
+- [x]  定义 `DiagnosticSkill` / `DiagnosticRun` / `ModelConfig` 三个 CRD
+- [x]  Go Controller 单 binary：manager + HTTP server 同进程
+- [x]  DB 层 SQLite（Phase 1 简化，Phase 3 迁移 Postgres）
+- [x]  Translator：把 `DiagnosticRun` 编译成一次性 Job + ConfigMap + SA + ClusterRoleBinding
+- [x]  Python Agent 镜像：
+  - 基础镜像含 Python + Go MCP Server 二进制
+  - 读挂载的 `/workspace/skills/*.md`
+  - 通过 Anthropic API + httpx streaming SSE 跑 agentic loop
+  - 写回 findings（通过 Controller HTTP API `POST /internal/runs/{id}/findings`）
+- [x]  `k8s-mcp-server`：9 个工具（4 core + 5 extension）
+- [x]  3 个内置 Skill：`pod-health-analyst`、`pod-security-analyst`、`pod-cost-analyst`
+- [x]  Job completion watch：Running → Succeeded/Failed 自动转换
+- [x]  Findings 写回 DiagnosticRun CR status（`findingCounts` + `findings` 摘要）
+- [x]  Helm chart 一键部署
+- [x]  GitHub Actions CI：unit test + envtest + build + helm lint + kind smoke test
 
-**交付物**：`kubectl apply -f run.yaml` 能跑一次诊断，Report 入库。
+**交付物**：`kubectl apply -f run.yaml` 能跑一次诊断，findings 写回 CR status + SQLite。
 
 ### Phase 2 — Skill 系统与多维度
 

--- a/internal/controller/api/v1alpha1/types.go
+++ b/internal/controller/api/v1alpha1/types.go
@@ -64,11 +64,24 @@ type TargetSpec struct {
 
 type DiagnosticRunStatus struct {
 	// +kubebuilder:validation:Enum=Pending;Running;Succeeded;Failed
-	Phase       string       `json:"phase,omitempty"`
-	StartedAt   *metav1.Time `json:"startedAt,omitempty"`
-	CompletedAt *metav1.Time `json:"completedAt,omitempty"`
-	ReportID    string       `json:"reportId,omitempty"`
-	Message     string       `json:"message,omitempty"`
+	Phase         string            `json:"phase,omitempty"`
+	StartedAt     *metav1.Time      `json:"startedAt,omitempty"`
+	CompletedAt   *metav1.Time      `json:"completedAt,omitempty"`
+	ReportID      string            `json:"reportId,omitempty"`
+	Message       string            `json:"message,omitempty"`
+	FindingCounts map[string]int    `json:"findingCounts,omitempty"`
+	Findings      []FindingSummary  `json:"findings,omitempty"`
+}
+
+// FindingSummary is a compact representation of a finding stored in CR status.
+type FindingSummary struct {
+	Dimension         string `json:"dimension"`
+	Severity          string `json:"severity"`
+	Title             string `json:"title"`
+	ResourceKind      string `json:"resourceKind,omitempty"`
+	ResourceNamespace string `json:"resourceNamespace,omitempty"`
+	ResourceName      string `json:"resourceName,omitempty"`
+	Suggestion        string `json:"suggestion,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/internal/controller/reconciler/run_reconciler.go
+++ b/internal/controller/reconciler/run_reconciler.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
+	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -66,8 +70,10 @@ func (r *DiagnosticRunReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			}
 		}
 
+		now := metav1.Now()
 		run.Status.Phase = string(store.PhaseRunning)
 		run.Status.ReportID = string(run.UID)
+		run.Status.StartedAt = &now
 		if err := r.Status().Update(ctx, &run); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -76,24 +82,95 @@ func (r *DiagnosticRunReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{Requeue: true}, nil
 		}
 		logger.Info("run started", "name", run.Name)
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
+	// Phase: Running → check Job status
+	if run.Status.Phase == string(store.PhaseRunning) {
+		jobName := fmt.Sprintf("agent-%s", run.Name)
+		var job batchv1.Job
+		if err := r.Get(ctx, types.NamespacedName{Name: jobName, Namespace: run.Namespace}, &job); err != nil {
+			if errors.IsNotFound(err) {
+				// Job not created yet or was cleaned up
+				logger.Info("job not found, requeueing", "job", jobName)
+				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+			}
+			return ctrl.Result{}, err
+		}
+
+		if job.Status.Succeeded > 0 {
+			return r.completeRun(ctx, &run, store.PhaseSucceeded, "agent job completed successfully")
+		}
+		if job.Status.Failed > 0 {
+			msg := "agent job failed"
+			for _, c := range job.Status.Conditions {
+				if c.Type == batchv1.JobFailed && c.Status == "True" {
+					msg = fmt.Sprintf("agent job failed: %s", c.Message)
+					break
+				}
+			}
+			return r.completeRun(ctx, &run, store.PhaseFailed, msg)
+		}
+
+		// Still running — requeue
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	return ctrl.Result{}, nil
 }
 
-func (r *DiagnosticRunReconciler) failRun(ctx context.Context, run *k8saiV1.DiagnosticRun, msg string) (ctrl.Result, error) {
-	run.Status.Phase = string(store.PhaseFailed)
-	run.Status.Message = msg
-	if err := r.Status().Update(ctx, run); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failRun status update: %w", err)
+// completeRun transitions a run to a terminal phase and writes findings back to CR status.
+func (r *DiagnosticRunReconciler) completeRun(ctx context.Context, run *k8saiV1.DiagnosticRun, phase store.Phase, msg string) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	// Fetch findings from store
+	runID := string(run.UID)
+	findings, err := r.Store.ListFindings(ctx, runID)
+	if err != nil {
+		logger.Error(err, "failed to list findings")
+		findings = nil
 	}
-	_ = r.Store.UpdateRunStatus(ctx, string(run.UID), store.PhaseFailed, msg)
+
+	// Build severity counts and summaries
+	counts := map[string]int{}
+	var summaries []k8saiV1.FindingSummary
+	for _, f := range findings {
+		counts[f.Severity]++
+		summaries = append(summaries, k8saiV1.FindingSummary{
+			Dimension:         f.Dimension,
+			Severity:          f.Severity,
+			Title:             f.Title,
+			ResourceKind:      f.ResourceKind,
+			ResourceNamespace: f.ResourceNamespace,
+			ResourceName:      f.ResourceName,
+			Suggestion:        f.Suggestion,
+		})
+	}
+
+	now := metav1.Now()
+	run.Status.Phase = string(phase)
+	run.Status.CompletedAt = &now
+	run.Status.Message = msg
+	run.Status.FindingCounts = counts
+	run.Status.Findings = summaries
+
+	if err := r.Status().Update(ctx, run); err != nil {
+		return ctrl.Result{}, fmt.Errorf("completeRun status update: %w", err)
+	}
+	_ = r.Store.UpdateRunStatus(ctx, runID, phase, msg)
+
+	logger.Info("run completed", "name", run.Name, "phase", phase, "findings", len(findings))
 	return ctrl.Result{}, nil
+}
+
+func (r *DiagnosticRunReconciler) failRun(ctx context.Context, run *k8saiV1.DiagnosticRun, msg string) (ctrl.Result, error) {
+	return r.completeRun(ctx, run, store.PhaseFailed, msg)
 }
 
 func (r *DiagnosticRunReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&k8saiV1.DiagnosticRun{}).
+		Owns(&batchv1.Job{}).
 		Complete(r)
 }
 

--- a/internal/controller/reconciler/run_reconciler_test.go
+++ b/internal/controller/reconciler/run_reconciler_test.go
@@ -22,9 +22,19 @@ import (
 	"github.com/kube-agent-helper/kube-agent-helper/internal/store"
 )
 
-type memStore struct{ runs map[string]*store.DiagnosticRun }
+// ── memStore ──────────────────────────────────────────────────────────────────
 
-func newMemStore() *memStore { return &memStore{runs: map[string]*store.DiagnosticRun{}} }
+type memStore struct {
+	runs     map[string]*store.DiagnosticRun
+	findings map[string][]*store.Finding
+}
+
+func newMemStore() *memStore {
+	return &memStore{
+		runs:     map[string]*store.DiagnosticRun{},
+		findings: map[string][]*store.Finding{},
+	}
+}
 func (m *memStore) CreateRun(_ context.Context, r *store.DiagnosticRun) error {
 	if r.ID == "" {
 		r.ID = "test-id"
@@ -38,15 +48,19 @@ func (m *memStore) GetRun(_ context.Context, id string) (*store.DiagnosticRun, e
 func (m *memStore) UpdateRunStatus(_ context.Context, id string, p store.Phase, msg string) error {
 	if r, ok := m.runs[id]; ok {
 		r.Status = p
+		r.Message = msg
 	}
 	return nil
 }
 func (m *memStore) ListRuns(_ context.Context, _ store.ListOpts) ([]*store.DiagnosticRun, error) {
 	return nil, nil
 }
-func (m *memStore) CreateFinding(_ context.Context, _ *store.Finding) error { return nil }
-func (m *memStore) ListFindings(_ context.Context, _ string) ([]*store.Finding, error) {
-	return nil, nil
+func (m *memStore) CreateFinding(_ context.Context, f *store.Finding) error {
+	m.findings[f.RunID] = append(m.findings[f.RunID], f)
+	return nil
+}
+func (m *memStore) ListFindings(_ context.Context, runID string) ([]*store.Finding, error) {
+	return m.findings[runID], nil
 }
 func (m *memStore) UpsertSkill(_ context.Context, _ *store.Skill) error { return nil }
 func (m *memStore) ListSkills(_ context.Context) ([]*store.Skill, error) { return nil, nil }
@@ -55,15 +69,20 @@ func (m *memStore) GetSkill(_ context.Context, _ string) (*store.Skill, error) {
 }
 func (m *memStore) Close() error { return nil }
 
-func TestRunReconciler_PendingToRunning(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = clientgoscheme.AddToScheme(scheme)
-	_ = k8saiV1.AddToScheme(scheme)
-	_ = batchv1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = rbacv1.AddToScheme(scheme)
+// ── helpers ───────────────────────────────────────────────────────────────────
 
-	run := &k8saiV1.DiagnosticRun{
+func testScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(s)
+	_ = k8saiV1.AddToScheme(s)
+	_ = batchv1.AddToScheme(s)
+	_ = corev1.AddToScheme(s)
+	_ = rbacv1.AddToScheme(s)
+	return s
+}
+
+func testRun() *k8saiV1.DiagnosticRun {
+	return &k8saiV1.DiagnosticRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-run", Namespace: "default", UID: "uid-1",
 		},
@@ -73,36 +92,203 @@ func TestRunReconciler_PendingToRunning(t *testing.T) {
 			ModelConfigRef: "claude-default",
 		},
 	}
+}
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(run).
-		WithStatusSubresource(run).
-		Build()
-
-	skill := &store.Skill{
+func testSkill() *store.Skill {
+	return &store.Skill{
 		Name: "pod-health-analyst", Dimension: "health",
 		Prompt: "You are...", ToolsJSON: "[]", Enabled: true,
 	}
-	tr := translator.New(translator.Config{
+}
+
+func testTranslator() *translator.Translator {
+	return translator.New(translator.Config{
 		AgentImage: "agent:test", ControllerURL: "http://ctrl:8080",
-	}, []*store.Skill{skill})
+	}, []*store.Skill{testSkill()})
+}
 
-	ms := newMemStore()
-	r := &reconciler.DiagnosticRunReconciler{
-		Client:     fakeClient,
-		Store:      ms,
-		Translator: tr,
-	}
-
+func reconcileOnce(t *testing.T, r *reconciler.DiagnosticRunReconciler) ctrl.Result {
+	t.Helper()
 	result, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test-run", Namespace: "default"},
 	})
 	require.NoError(t, err)
-	assert.False(t, result.Requeue)
+	return result
+}
+
+func getRunStatus(t *testing.T, cl interface{ Get(context.Context, types.NamespacedName, ...interface{}) error }, name string) k8saiV1.DiagnosticRun {
+	t.Helper()
+	// Use the reconciler's client directly via type assertion
+	return k8saiV1.DiagnosticRun{}
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+func TestRunReconciler_PendingToRunning(t *testing.T) {
+	run := testRun()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(run).
+		WithStatusSubresource(run).
+		Build()
+
+	ms := newMemStore()
+	r := &reconciler.DiagnosticRunReconciler{
+		Client: fakeClient, Store: ms, Translator: testTranslator(),
+	}
+
+	result := reconcileOnce(t, r)
+	assert.NotZero(t, result.RequeueAfter, "should requeue to poll Job status")
 
 	var updated k8saiV1.DiagnosticRun
 	require.NoError(t, fakeClient.Get(context.Background(),
 		types.NamespacedName{Name: "test-run", Namespace: "default"}, &updated))
 	assert.Equal(t, "Running", updated.Status.Phase)
+	assert.NotNil(t, updated.Status.StartedAt)
+}
+
+func TestRunReconciler_RunningToSucceeded(t *testing.T) {
+	run := testRun()
+	run.Status.Phase = "Running"
+	run.Status.ReportID = "uid-1"
+
+	// Create a succeeded Job
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "agent-test-run", Namespace: "default",
+		},
+		Status: batchv1.JobStatus{Succeeded: 1},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(run, job).
+		WithStatusSubresource(run).
+		Build()
+
+	// Pre-populate store
+	ms := newMemStore()
+	ms.runs["uid-1"] = &store.DiagnosticRun{ID: "uid-1", Status: store.PhaseRunning}
+	ms.findings["uid-1"] = []*store.Finding{
+		{RunID: "uid-1", Dimension: "health", Severity: "critical", Title: "Pod CrashLooping", ResourceKind: "Pod", ResourceName: "nginx"},
+		{RunID: "uid-1", Dimension: "health", Severity: "medium", Title: "High restart count", ResourceKind: "Pod", ResourceName: "nginx"},
+	}
+
+	r := &reconciler.DiagnosticRunReconciler{
+		Client: fakeClient, Store: ms, Translator: testTranslator(),
+	}
+
+	result := reconcileOnce(t, r)
+	assert.Zero(t, result.RequeueAfter, "terminal state should not requeue")
+
+	var updated k8saiV1.DiagnosticRun
+	require.NoError(t, fakeClient.Get(context.Background(),
+		types.NamespacedName{Name: "test-run", Namespace: "default"}, &updated))
+
+	assert.Equal(t, "Succeeded", updated.Status.Phase)
+	assert.NotNil(t, updated.Status.CompletedAt)
+	assert.Equal(t, "agent job completed successfully", updated.Status.Message)
+
+	// Findings written back
+	assert.Len(t, updated.Status.Findings, 2)
+	assert.Equal(t, 1, updated.Status.FindingCounts["critical"])
+	assert.Equal(t, 1, updated.Status.FindingCounts["medium"])
+	assert.Equal(t, "Pod CrashLooping", updated.Status.Findings[0].Title)
+
+	// Store also updated
+	assert.Equal(t, store.PhaseSucceeded, ms.runs["uid-1"].Status)
+}
+
+func TestRunReconciler_RunningToFailed(t *testing.T) {
+	run := testRun()
+	run.Status.Phase = "Running"
+	run.Status.ReportID = "uid-1"
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "agent-test-run", Namespace: "default",
+		},
+		Status: batchv1.JobStatus{
+			Failed: 1,
+			Conditions: []batchv1.JobCondition{{
+				Type:    batchv1.JobFailed,
+				Status:  "True",
+				Message: "Back-off limit exceeded",
+			}},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(run, job).
+		WithStatusSubresource(run).
+		Build()
+
+	ms := newMemStore()
+	ms.runs["uid-1"] = &store.DiagnosticRun{ID: "uid-1", Status: store.PhaseRunning}
+
+	r := &reconciler.DiagnosticRunReconciler{
+		Client: fakeClient, Store: ms, Translator: testTranslator(),
+	}
+
+	result := reconcileOnce(t, r)
+	assert.Zero(t, result.RequeueAfter)
+
+	var updated k8saiV1.DiagnosticRun
+	require.NoError(t, fakeClient.Get(context.Background(),
+		types.NamespacedName{Name: "test-run", Namespace: "default"}, &updated))
+
+	assert.Equal(t, "Failed", updated.Status.Phase)
+	assert.Contains(t, updated.Status.Message, "Back-off limit exceeded")
+	assert.NotNil(t, updated.Status.CompletedAt)
+}
+
+func TestRunReconciler_RunningJobStillActive(t *testing.T) {
+	run := testRun()
+	run.Status.Phase = "Running"
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "agent-test-run", Namespace: "default",
+		},
+		Status: batchv1.JobStatus{Active: 1},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(run, job).
+		WithStatusSubresource(run).
+		Build()
+
+	ms := newMemStore()
+	r := &reconciler.DiagnosticRunReconciler{
+		Client: fakeClient, Store: ms, Translator: testTranslator(),
+	}
+
+	result := reconcileOnce(t, r)
+	assert.NotZero(t, result.RequeueAfter, "should requeue while job is active")
+
+	var updated k8saiV1.DiagnosticRun
+	require.NoError(t, fakeClient.Get(context.Background(),
+		types.NamespacedName{Name: "test-run", Namespace: "default"}, &updated))
+	assert.Equal(t, "Running", updated.Status.Phase, "should stay Running")
+}
+
+func TestRunReconciler_TerminalNoOp(t *testing.T) {
+	run := testRun()
+	run.Status.Phase = "Succeeded"
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(run).
+		WithStatusSubresource(run).
+		Build()
+
+	ms := newMemStore()
+	r := &reconciler.DiagnosticRunReconciler{
+		Client: fakeClient, Store: ms, Translator: testTranslator(),
+	}
+
+	result := reconcileOnce(t, r)
+	assert.Zero(t, result.RequeueAfter)
 }

--- a/internal/controller/translator/translator.go
+++ b/internal/controller/translator/translator.go
@@ -130,6 +130,7 @@ func (t *Translator) buildRoleBinding(saName, runID, saNamespace string) *rbacv1
 func (t *Translator) buildJob(run *k8saiV1.DiagnosticRun, runID, saName, cmName string, skills []*store.Skill) *batchv1.Job {
 	ttl := int32(3600)
 	backoff := int32(0)
+	isController := true
 
 	skillNames := make([]string, len(skills))
 	for i, s := range skills {
@@ -140,6 +141,13 @@ func (t *Translator) buildJob(run *k8saiV1.DiagnosticRun, runID, saName, cmName 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   fmt.Sprintf("agent-%s", run.Name),
 			Labels: map[string]string{"run-id": runID},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: run.APIVersion,
+				Kind:       run.Kind,
+				Name:       run.Name,
+				UID:        run.UID,
+				Controller: &isController,
+			}},
 		},
 		Spec: batchv1.JobSpec{
 			TTLSecondsAfterFinished: &ttl,


### PR DESCRIPTION
## Summary

- **Job completion watch**: Reconciler monitors Job status via `Owns(&batchv1.Job{})`, auto-transitions DiagnosticRun from Running → Succeeded/Failed
- **Findings write-back**: On completion, findings are fetched from store and written to CR `status.findings` (summary array) + `status.findingCounts` (severity map)
- **OwnerReference**: Job now has OwnerReference → DiagnosticRun for proper GC
- **CI kind smoke test**: New workflow job creates a kind cluster, applies CRDs, creates Skill/Run CRs, validates helm template
- **URL fix**: Agent orchestrator handles `ANTHROPIC_BASE_URL` that already contains `/v1/messages`
- **Docs**: Fixed CR example (correct apiVersion, field names, modelConfigRef), updated design.md Phase 1 checklist and tech stack table

## Changes since last merge

| Commit | Description |
|--------|-------------|
| `760aa7e` | Job completion watch + findings write-back + kind smoke test |
| `8b2d361` | Fix base URL double `/v1/messages` path |
| `9f5863e` | Fix README CR example + update design.md |
| `015b3be` | Open-source prep (LICENSE, Makefile, CI, README) |
| `8f7a388` | CI: exclude envtest from unit tests |
| `eae1000` | Fix CI badge URL |

## Test plan

- [x] 5 reconciler unit tests (Pending→Running, Running→Succeeded with findings, Running→Failed, JobStillActive, TerminalNoOp)
- [x] All 10 Go test packages pass
- [x] Local minikube e2e: DiagnosticRun completes with `phase: Succeeded`, 2 findings in `status.findings`
- [x] CI green: unit tests, envtest, build, helm lint, kind smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)