### PR TITLE
feat: add 5 MCP tools, 5 new builtin skills, and symptom-driven /diagnose page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,10 @@ jobs:
         working-directory: dashboard
         run: npm run lint
 
+      - name: Type check
+        working-directory: dashboard
+        run: npm run typecheck
+
       - name: Build
         working-directory: dashboard
         run: npm run build
@@ -106,6 +110,30 @@ jobs:
             python3 -c "import ast; ast.parse(open('$f').read())" || exit 1
             echo "  OK: $f"
           done
+
+  skill-lint:
+    name: Skill File Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate skill frontmatter
+        run: |
+          set -e
+          ERRORS=0
+          for f in skills/*.md; do
+            name=$(sed -n 's/^name: //p' "$f")
+            dimension=$(sed -n 's/^dimension: //p' "$f")
+            tools=$(sed -n 's/^tools: //p' "$f")
+            requires_data=$(sed -n 's/^requires_data: //p' "$f")
+            if [ -z "$name" ] || [ -z "$dimension" ] || [ -z "$tools" ] || [ -z "$requires_data" ]; then
+              echo "FAIL: $f missing required frontmatter (name/dimension/tools/requires_data)"
+              ERRORS=$((ERRORS+1))
+            else
+              echo "OK:   $f (name=$name, dimension=$dimension)"
+            fi
+          done
+          if [ $ERRORS -gt 0 ]; then exit 1; fi
 
   helm-lint:
     name: Helm Lint

--- a/README.md
+++ b/README.md
@@ -1,81 +1,76 @@
 # kube-agent-helper
 
-> Kubernetes-native AI diagnostic operator with auto-fix capabilities
+> Kubernetes 原生 AI 诊断 Operator，支持自动修复建议
 
-**kube-agent-helper** is an AI agent that runs inside your Kubernetes cluster, diagnoses workload issues, and generates actionable fix suggestions. Declare a `DiagnosticRun` CR, and the controller spins up an isolated agent Pod that calls Claude via MCP tools, writes structured findings, and optionally produces `DiagnosticFix` CRs with patches or new resource manifests.
+**kube-agent-helper** 是运行在 Kubernetes 集群内的 AI 智能体。声明一个 `DiagnosticRun` CR，控制器即刻拉起隔离的 Agent Pod，通过 MCP 工具调用 Claude，输出结构化诊断结论，并可选生成 `DiagnosticFix` CR（含 patch 或新资源 manifest）。
 
 [![CI](https://github.com/googs1025/kube-agent-helper/actions/workflows/ci.yml/badge.svg)](https://github.com/googs1025/kube-agent-helper/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
-## Features
+[English](README_EN.md)
 
-- **CRD-driven diagnostics** — declare tasks with `DiagnosticRun`; extend with `DiagnosticSkill` CRs
-- **4 CRDs** — `DiagnosticRun`, `DiagnosticSkill`, `ModelConfig`, `DiagnosticFix`
-- **5 built-in skills** — health, security, cost, reliability, config-drift analysis
-- **Claude-powered agentic loop** ��� multi-turn reasoning over live cluster data via MCP
-- **Fix generation** — click "Generate Fix" on any finding; a short-lived Pod produces a patch or full resource manifest via LLM
-- **Before/After diff** — Fix detail page shows resource diff before applying
-- **Human-in-the-loop approval** — Fixes go through `PendingApproval → Approved → Applying → Succeeded` with optional auto-rollback on failure
-- **Dashboard** — Next.js web UI with Chinese/English toggle, dark/light theme, stats, create dialogs
-- **Per-run output language** — `spec.outputLanguage: zh|en` controls whether findings are in Chinese or English
-- **Pod status capture** — reconciler detects ImagePullBackOff, CrashLoopBackOff and writes them to `status.message`
-- **Optional timeout** — `spec.timeoutSeconds` on DiagnosticRun; nil = no timeout
-- **Minimal RBAC** — Translator auto-generates least-privilege ServiceAccount per run
-- **SQLite persistence** — findings and fixes stored locally; no external database required
+## 功能特性
 
-## Architecture
+- **CRD 驱动** — 用 `DiagnosticRun` 声明诊断任务，用 `DiagnosticSkill` CR 扩展技能
+- **4 个 CRD** — `DiagnosticRun`、`DiagnosticSkill`、`ModelConfig`、`DiagnosticFix`
+- **10 个内置 Skill** — 健康、安全、成本、可靠性、配置漂移、告警响应、网络、节点、发布、存储
+- **14 个 MCP 工具** — 覆盖 kubectl、Prometheus、日志、网络策略、PVC、节点等
+- **Claude 驱动的 Agentic 循环** — 多轮推理，实时访问集群数据
+- **Fix 生成** — 在任意 Finding 上点击"生成修复"，短生命周期 Pod 通过 LLM 生成 patch 或资源 manifest
+- **Before/After Diff** — Fix 详情页展示变更前后对比
+- **人工审批流程 (HITL)** — Fix 经过 `PendingApproval → Approved → Applying → Succeeded`，支持自动回滚
+- **症状驱动诊断入口** — `/diagnose` 页面：从监控告警进入，选择症状即可触发精准诊断
+- **Dashboard** — Next.js Web UI，支持中英文切换、深浅色主题、数据统计、快速创建
+- **输出语言可控** — `spec.outputLanguage: zh|en` 控制诊断结论语言
+- **最小化 RBAC** — Translator 为每次运行自动生成最小权限 ServiceAccount
+- **SQLite 持久化** — findings 和 fixes 本地存储，无需外部数据库
+
+## 架构
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
-│  User                                                                       │
+│  用户                                                                        │
 │  kubectl apply  │  Dashboard (Next.js :3000)  │  REST API (:8080)           │
 └────────┬─────────────────┬──────────────────────────┬───────────────────────┘
          │ CR              │ /api/*                    │
          ▼                 ▼                           │
 ┌─────────────────────────────────────────────────────────────────────────────┐
-│  Controller (Go binary)                                                     │
+│  Controller (Go)                                                             │
 │                                                                             │
-│  ┌─────────────────┐  ┌──────────────┐  ┌──────────────────────────────┐  │
-│  │ Run Reconciler   │  │ Fix Reconciler│  │ HTTP Server                  │  │
-│  │ Skill Reconciler │  │              │  │  /api/runs (CRUD)            │  │
-│  │ ModelConfig Ctrl  │  │ apply patch  │  │  /api/skills                 │  │
-│  │                   │  │ create resource│ │  /api/fixes (list/approve)   │  │
-│  │ Pod status capture│  │ auto-rollback│  │  /api/findings/*/generate-fix│  │
-│  │ timeout check     │  │              │  │  /internal/runs/*/findings   │  │
-│  └────────┬──────────┘  └──────────────┘  │  /internal/fixes             │  │
-│           │                                └──────────────────────────────┘  │
+│  ┌─────────────────┐  ┌───────────────┐  ┌──────────────────────────────┐  │
+│  │ Run Reconciler   │  │ Fix Reconciler │  │ HTTP Server                  │  │
+│  │ Skill Reconciler │  │               │  │  /api/runs  /api/skills       │  │
+│  │ ModelConfig Ctrl  │  │ apply patch   │  │  /api/fixes /api/findings     │  │
+│  │ Pod status capture│  │ auto-rollback │  │  /api/k8s/resources           │  │
+│  └────────┬──────────┘  └───────────────┘  └──────────────────────────────┘  │
 │           │ Translator                                                      │
 │           ▼                                                                 │
-│  ┌─────────────────────────────────────────────────┐                       │
-│  │ SQLite (diagnostic_runs, findings, skills, fixes)│                       │
-│  └─────────────────────────────────────────────────┘                       │
+│  ┌──────────────────────────────────────────────────┐                      │
+│  │ SQLite (diagnostic_runs, findings, skills, fixes) │                      │
+│  └──────────────────────────────────────────────────┘                      │
 └────────────┬────────────────────────────────────┬───────────────────────────┘
-             │ creates Job                        │ creates Job
+             │ 创建 Job                            │ 创建 Job
              ▼                                    ▼
 ┌──────────────────────┐        ┌──────────────────────────────┐
 │  Diagnostic Agent Pod │        │  Fix Generator Pod            │
 │  python -m runtime.main│       │  python -m runtime.fix_main   │
-│                        │       │                                │
-│  Multi-turn LLM loop   │       │  Single LLM call → patch JSON │
-│  ┌──────────────────┐ │       │  kubectl_get → before snapshot │
-│  │ k8s-mcp-server   │ │       │  POST /internal/fixes          │
-│  │ (9 read-only     │ │       └──────────────────────────────┘
-│  │  MCP tools)      │ │
+│  多轮 LLM 循环         │       │  单次 LLM 调用 → patch JSON   │
+│  ┌──────────────────┐ │       └──────────────────────────────┘
+│  │ k8s-mcp-server   │ │
+│  │ (14 个 MCP 工具) │ │
 │  └──────────────────┘ │
-│                        │
-│  POST findings → ctrl  │
 └────────────────────────┘
 ```
 
-## Quick Start
+## 快速开始
 
-### Prerequisites
+### 前置条件
 
-- Kubernetes cluster (minikube, kind, or any cloud cluster)
+- Kubernetes 集群（minikube、kind 或云上集群均可）
 - `helm` >= 3.14
-- An Anthropic API key (or compatible proxy)
+- Anthropic API Key（或兼容代理）
 
-### 1. Create the API key secret
+### 1. 创建 API Key Secret
 
 ```bash
 kubectl create namespace kube-agent-helper
@@ -84,14 +79,14 @@ kubectl create secret generic anthropic-credentials \
   --from-literal=apiKey=sk-ant-...
 ```
 
-### 2. Install with Helm
+### 2. Helm 安装
 
 ```bash
 helm install kah deploy/helm \
   --namespace kube-agent-helper
 ```
 
-With a custom proxy and model:
+使用自定义代理和模型：
 
 ```bash
 helm install kah deploy/helm \
@@ -100,7 +95,7 @@ helm install kah deploy/helm \
   --set anthropic.model=claude-3-5-sonnet-20241022
 ```
 
-### 3. Access the Dashboard
+### 3. 访问 Dashboard
 
 ```bash
 kubectl port-forward svc/kah -n kube-agent-helper 8080:8080 &
@@ -108,13 +103,15 @@ kubectl port-forward svc/kah-dashboard -n kube-agent-helper 3000:3000 &
 open http://localhost:3000
 ```
 
-The dashboard supports Chinese (default) and English, with dark/light theme toggle.
+Dashboard 默认中文界面，支持切换英文，深色/浅色主题可切换。
 
-### 4. Run a diagnostic
+### 4. 症状驱动诊断（推荐）
 
-From the dashboard: click "Create Run" and fill in the form.
+打开 Dashboard → 点击 **诊断** → 选择命名空间、资源、勾选症状（如 CPU 高、Pod 频繁重启）→ 提交。
 
-Or via kubectl:
+系统自动匹配 Skill 并触发诊断，结果按严重程度排序展示。
+
+### 5. 通过 kubectl 创建诊断任务
 
 ```yaml
 apiVersion: k8sai.io/v1alpha1
@@ -128,138 +125,143 @@ spec:
     namespaces:
       - default
   modelConfigRef: "anthropic-credentials"
-  timeoutSeconds: 600        # optional, nil = no timeout
-  outputLanguage: zh          # optional, zh|en, controls finding language
+  timeoutSeconds: 600     # 可选，不填则无超时
+  outputLanguage: zh      # 可选：zh | en
 ```
 
 ```bash
 kubectl apply -f the-above.yaml
 kubectl get diagnosticrun cluster-health-check -w
-kubectl get diagnosticrun cluster-health-check -o jsonpath='{.status.findings}' | jq .
 ```
 
-### 5. Generate a Fix
+### 6. 生成修复建议
 
-From the dashboard: open a completed Run, click "Generate Fix" on any finding.
+在 Dashboard 上：打开已完成的 Run → 在任意 Finding 卡片点击"生成修复"。
 
-Or via API:
+或通过 API：
 
 ```bash
 curl -X POST http://localhost:8080/api/findings/<finding-id>/generate-fix
 ```
 
-The fix generator Pod reads the target resource, asks the LLM for a patch, and creates a `DiagnosticFix` CR. Review the Before/After diff in the dashboard, then Approve or Reject.
+Fix 生成后可在 Dashboard 查看 Before/After Diff，然后审批或拒绝。
 
-## CRDs
+## 内置 Skill
 
-| CRD | Purpose |
-|-----|---------|
-| `DiagnosticRun` | Declares a diagnostic task; controller creates an agent Job |
-| `DiagnosticSkill` | Declares a diagnostic skill (dimension, prompt, tools) |
-| `ModelConfig` | LLM provider configuration (API key secret reference) |
-| `DiagnosticFix` | A proposed fix (patch or new resource) with approval workflow |
+| Skill | 维度 | 说明 |
+|-------|------|------|
+| `pod-health-analyst` | health | 检测 CrashLoopBackOff、OOMKilled、Pending 等 |
+| `pod-security-analyst` | security | 检查特权容器、缺失 securityContext 等 |
+| `pod-cost-analyst` | cost | 发现资源过度申请、僵尸 Deployment |
+| `reliability-analyst` | reliability | 分析探针配置、PDB、副本数 |
+| `config-drift-analyst` | reliability | 检测 selector/label 不匹配、ConfigMap/Secret 引用断裂 |
+| `alert-responder` | health | 对 Prometheus 告警逐一定位根因 |
+| `network-troubleshooter` | reliability | 诊断 Service 不通、NetworkPolicy 阻断 |
+| `node-health-analyst` | reliability | 检测节点压力（内存/磁盘/PID）、容量不足 |
+| `rollout-analyst` | health | 诊断发布卡住、新版本起不来 |
+| `storage-analyst` | reliability | 诊断 PVC Pending/Lost、挂载失败 |
 
-### DiagnosticFix Lifecycle
+自定义 Skill：创建 `DiagnosticSkill` CR 或在 `skills/` 目录放置 `.md` 文件。
+
+## CRD 说明
+
+| CRD | 用途 |
+|-----|------|
+| `DiagnosticRun` | 声明诊断任务，控制器创建 Agent Job |
+| `DiagnosticSkill` | 声明诊断技能（维度、Prompt、工具列表） |
+| `ModelConfig` | LLM 提供商配置（API Key Secret 引用） |
+| `DiagnosticFix` | 修复提案（patch 或新资源），含审批流程 |
+
+### DiagnosticFix 生命周期
 
 ```
-DryRunComplete → [user approves] → Approved → Applying → Succeeded
-                                                      → Failed → (auto-rollback) → RolledBack
-                 [user rejects]  → Failed
+DryRunComplete → [用户审批] → Approved → Applying → Succeeded
+                                                   → Failed → (自动回滚) → RolledBack
+               [用户拒绝]  → Failed
 ```
 
-Strategies: `dry-run` (review only), `auto` (apply patch), `create` (create new resource).
+策略：`dry-run`（仅预览）、`auto`（自动 patch）、`create`（创建新资源）。
 
-## Built-in Skills
+## API
 
-| Skill | Dimension | Description |
-|-------|-----------|-------------|
-| `pod-health-analyst` | health | Detects CrashLoopBackOff, OOMKilled, pending pods, high restarts |
-| `pod-security-analyst` | security | Checks privileged containers, missing securityContext, image policies |
-| `pod-cost-analyst` | cost | Finds over-provisioned resource requests, zombie deployments |
-| `reliability-analyst` | reliability | Analyzes probe configuration, PDB, HPA, replica counts |
-| `config-drift-analyst` | reliability | Detects selector/label mismatches, broken ConfigMap/Secret refs, orphan Services |
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/api/runs` | 列出诊断任务 |
+| POST | `/api/runs` | 创建 DiagnosticRun CR |
+| GET | `/api/runs/:id` | 获取任务详情 |
+| GET | `/api/runs/:id/findings` | 列出 findings |
+| GET | `/api/skills` | 列出注册的 Skill |
+| POST | `/api/skills` | 创建 DiagnosticSkill CR |
+| GET | `/api/fixes` | 列出修复提案 |
+| GET | `/api/fixes/:id` | 获取修复详情 |
+| PATCH | `/api/fixes/:id/approve` | 审批修复 |
+| PATCH | `/api/fixes/:id/reject` | 拒绝修复 |
+| POST | `/api/findings/:id/generate-fix` | 触发 Fix 生成 |
+| GET | `/api/k8s/resources` | 列出集群资源（namespace/workload 自动补全） |
 
-Custom skills: create a `DiagnosticSkill` CR or place a `SKILL.md` file in `skills/`.
-
-## API Endpoints
-
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/api/runs` | List diagnostic runs |
-| POST | `/api/runs` | Create a DiagnosticRun CR |
-| GET | `/api/runs/:id` | Get run details |
-| GET | `/api/runs/:id/findings` | List findings (includes `FixID` if fix exists) |
-| GET | `/api/skills` | List registered skills |
-| POST | `/api/skills` | Create a DiagnosticSkill CR |
-| GET | `/api/fixes` | List fixes |
-| GET | `/api/fixes/:id` | Get fix details (includes `BeforeSnapshot`) |
-| PATCH | `/api/fixes/:id/approve` | Approve a fix (triggers reconciler to apply) |
-| PATCH | `/api/fixes/:id/reject` | Reject a fix |
-| POST | `/api/findings/:id/generate-fix` | Trigger fix generation for a finding |
-
-## Development
+## 本地开发
 
 ```bash
-# Run all unit tests
+# 运行所有单元测试
 make test
 
-# Run integration tests (requires kubebuilder binaries)
+# 运行集成测试（需要 kubebuilder 二进制）
 make envtest
 
-# Build binaries
+# 构建二进制
 make build
 
-# Build Docker images
+# 构建 Docker 镜像
 make image
 
-# Run dashboard dev server
+# 启动 Dashboard 开发服务器
 cd dashboard && npm run dev
 ```
 
-## Project Structure
+## 项目结构
 
 ```
-cmd/controller/          Go controller binary entrypoint
+cmd/controller/          Go controller 入口
 internal/
   controller/
-    api/v1alpha1/        CRD type definitions
-    reconciler/          Run, Skill, Fix, ModelConfig reconcilers
-    translator/          Run → Job compiler, FixGenerator → Job compiler
-    httpserver/           REST API handlers
-    registry/            Skill registry (hot-reload from store)
-  store/                 Store interface + SQLite implementation
-  k8sclient/             Kubernetes client wrapper
-  mcptools/              MCP tool implementations
+    api/v1alpha1/        CRD 类型定义
+    reconciler/          Run、Skill、Fix、ModelConfig Reconciler
+    translator/          Run → Job 编译器，FixGenerator → Job 编译器
+    httpserver/          REST API 处理器
+    registry/            Skill 注册表（热加载）
+  store/                 Store 接口 + SQLite 实现
+  mcptools/              MCP 工具实现（14 个）
 agent-runtime/
   runtime/
-    main.py              Diagnostic agent entrypoint (multi-turn LLM)
-    fix_main.py          Fix generator entrypoint (single LLM call)
-    orchestrator.py      Agentic loop with httpx SSE streaming
-    mcp_client.py        MCP stdio client helpers
-    skill_loader.py      SKILL.md file parser
+    main.py              诊断 Agent 入口（多轮 LLM）
+    fix_main.py          Fix 生成器入口（单次 LLM）
+    orchestrator.py      Agentic 循环（httpx SSE 流式）
+    mcp_client.py        MCP stdio 客户端
+    skill_loader.py      SKILL.md 解析器
 dashboard/
   src/
-    app/                 Next.js pages (runs, skills, fixes)
-    components/          UI components (dialogs, badges, diff viewer)
-    i18n/                zh.json + en.json dictionaries
-    theme/               Dark/light theme context
-    lib/                 API hooks (SWR), types, utils
-skills/                  Built-in SKILL.md files
-deploy/helm/             Helm chart (CRDs, RBAC, deployments)
+    app/                 Next.js 页面（runs、skills、fixes、diagnose）
+    components/          UI 组件（对话框、Badge、Diff 查看器）
+    i18n/                zh.json + en.json 字典
+    theme/               深浅色主题 Context
+    lib/                 API hooks（SWR）、类型、工具函数
+skills/                  内置 Skill .md 文件（10 个）
+deploy/helm/             Helm Chart（CRD、RBAC、Deployment）
 ```
 
 ## Roadmap
 
-- [x] **Phase 1** — Operator MVP: 4 CRDs, single-run Job, 5 built-in skills
-- [x] **Phase 2** — Dashboard (Next.js), Skill Registry UI, i18n (zh/en), dark mode
-- [x] **Phase 3** — DiagnosticFix: LLM-generated patches, Before/After diff, HITL approval, auto-rollback
-- [ ] **Phase 4** — Real-time event streaming, vector case memory (RAG), multi-cluster
+- [x] **Phase 1** — Operator MVP：4 CRD、单次 Job 运行、5 个内置 Skill
+- [x] **Phase 2** — Dashboard（Next.js）、Skill Registry UI、i18n（中/英）、深色模式
+- [x] **Phase 3** — DiagnosticFix：LLM 生成 patch、Before/After Diff、HITL 审批、自动回滚
+- [x] **Phase 3.5** — 5 个新 MCP 工具、10 个内置 Skill、症状驱动 /diagnose 页面
+- [ ] **Phase 4** — 实时事件流、向量案例库（RAG）、多集群支持
 
-## References
+## 参考项目
 
-- [kagent](https://github.com/kagent-dev/kagent) — Kubernetes-native agent orchestration framework
-- [ci-agent](https://github.com/googs1025/ci-agent) — GitHub CI pipeline AI analyzer
+- [kagent](https://github.com/kagent-dev/kagent) — Kubernetes 原生 Agent 编排框架
+- [ci-agent](https://github.com/googs1025/ci-agent) — GitHub CI 流水线 AI 分析器
 
 ## License
 
-Apache License 2.0 — see [LICENSE](LICENSE).
+Apache License 2.0 — 详见 [LICENSE](LICENSE)。

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,0 +1,225 @@
+# kube-agent-helper
+
+> Kubernetes-native AI diagnostic operator with auto-fix capabilities
+
+**kube-agent-helper** is an AI agent that runs inside your Kubernetes cluster, diagnoses workload issues, and generates actionable fix suggestions. Declare a `DiagnosticRun` CR, and the controller spins up an isolated agent Pod that calls Claude via MCP tools, writes structured findings, and optionally produces `DiagnosticFix` CRs with patches or new resource manifests.
+
+[![CI](https://github.com/googs1025/kube-agent-helper/actions/workflows/ci.yml/badge.svg)](https://github.com/googs1025/kube-agent-helper/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+
+[中文](README.md)
+
+## Features
+
+- **CRD-driven diagnostics** — declare tasks with `DiagnosticRun`; extend with `DiagnosticSkill` CRs
+- **4 CRDs** — `DiagnosticRun`, `DiagnosticSkill`, `ModelConfig`, `DiagnosticFix`
+- **10 built-in skills** — health, security, cost, reliability, config-drift, alert-responder, network, node, rollout, storage
+- **14 MCP tools** — kubectl, Prometheus, logs, network policies, PVC, node status, and more
+- **Claude-powered agentic loop** — multi-turn reasoning over live cluster data
+- **Fix generation** — click "Generate Fix" on any finding; a short-lived Pod produces a patch or full resource manifest via LLM
+- **Before/After diff** — Fix detail page shows resource diff before applying
+- **Human-in-the-loop approval** — Fixes go through `PendingApproval → Approved → Applying → Succeeded` with optional auto-rollback
+- **Symptom-driven entry** — `/diagnose` page: arrive from a monitoring alert, select symptoms, get targeted diagnosis
+- **Dashboard** — Next.js web UI with Chinese/English toggle, dark/light theme, stats, create dialogs
+- **Per-run output language** — `spec.outputLanguage: zh|en` controls finding language
+- **Minimal RBAC** — Translator auto-generates least-privilege ServiceAccount per run
+- **SQLite persistence** — findings and fixes stored locally; no external database required
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  User                                                                       │
+│  kubectl apply  │  Dashboard (Next.js :3000)  │  REST API (:8080)           │
+└────────┬─────────────────┬──────────────────────────┬───────────────────────┘
+         │ CR              │ /api/*                    │
+         ▼                 ▼                           │
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  Controller (Go)                                                            │
+│                                                                             │
+│  ┌─────────────────┐  ┌───────────────┐  ┌──────────────────────────────┐  │
+│  │ Run Reconciler   │  │ Fix Reconciler │  │ HTTP Server                  │  │
+│  │ Skill Reconciler │  │               │  │  /api/runs  /api/skills       │  │
+│  │ ModelConfig Ctrl  │  │ apply patch   │  │  /api/fixes /api/findings     │  │
+│  │ Pod status capture│  │ auto-rollback │  │  /api/k8s/resources           │  │
+│  └────────┬──────────┘  └───────────────┘  └──────────────────────────────┘  │
+│           │ Translator                                                      │
+│           ▼                                                                 │
+│  ┌──────────────────────────────────────────────────┐                      │
+│  │ SQLite (diagnostic_runs, findings, skills, fixes) │                      │
+│  └──────────────────────────────────────────────────┘                      │
+└────────────┬────────────────────────────────────┬───────────────────────────┘
+             │ creates Job                        │ creates Job
+             ▼                                    ▼
+┌──────────────────────┐        ┌──────────────────────────────┐
+│  Diagnostic Agent Pod │        │  Fix Generator Pod            │
+│  python -m runtime.main│       │  python -m runtime.fix_main   │
+│  Multi-turn LLM loop   │       │  Single LLM call → patch JSON │
+│  ┌──────────────────┐ │       └──────────────────────────────┘
+│  │ k8s-mcp-server   │ │
+│  │ (14 MCP tools)   │ │
+│  └──────────────────┘ │
+└────────────────────────┘
+```
+
+## Quick Start
+
+### Prerequisites
+
+- Kubernetes cluster (minikube, kind, or any cloud cluster)
+- `helm` >= 3.14
+- An Anthropic API key (or compatible proxy)
+
+### 1. Create the API key secret
+
+```bash
+kubectl create namespace kube-agent-helper
+kubectl create secret generic anthropic-credentials \
+  -n kube-agent-helper \
+  --from-literal=apiKey=sk-ant-...
+```
+
+### 2. Install with Helm
+
+```bash
+helm install kah deploy/helm \
+  --namespace kube-agent-helper
+```
+
+With a custom proxy and model:
+
+```bash
+helm install kah deploy/helm \
+  --namespace kube-agent-helper \
+  --set anthropic.baseURL=https://my-proxy.example.com \
+  --set anthropic.model=claude-3-5-sonnet-20241022
+```
+
+### 3. Access the Dashboard
+
+```bash
+kubectl port-forward svc/kah -n kube-agent-helper 8080:8080 &
+kubectl port-forward svc/kah-dashboard -n kube-agent-helper 3000:3000 &
+open http://localhost:3000
+```
+
+### 4. Symptom-driven diagnosis (recommended)
+
+Open Dashboard → click **Diagnose** → select namespace, resource, check symptoms (e.g. high CPU, pod crash-looping) → submit.
+
+The system maps symptoms to skills, triggers a DiagnosticRun, and displays findings sorted by severity.
+
+### 5. Create a run via kubectl
+
+```yaml
+apiVersion: k8sai.io/v1alpha1
+kind: DiagnosticRun
+metadata:
+  name: cluster-health-check
+  namespace: kube-agent-helper
+spec:
+  target:
+    scope: namespace
+    namespaces:
+      - default
+  modelConfigRef: "anthropic-credentials"
+  timeoutSeconds: 600     # optional, nil = no timeout
+  outputLanguage: en      # optional: zh | en
+```
+
+```bash
+kubectl apply -f the-above.yaml
+kubectl get diagnosticrun cluster-health-check -w
+```
+
+### 6. Generate a Fix
+
+From the dashboard: open a completed Run, click "Generate Fix" on any finding.
+
+Or via API:
+
+```bash
+curl -X POST http://localhost:8080/api/findings/<finding-id>/generate-fix
+```
+
+Review the Before/After diff in the dashboard, then Approve or Reject.
+
+## Built-in Skills
+
+| Skill | Dimension | Description |
+|-------|-----------|-------------|
+| `pod-health-analyst` | health | Detects CrashLoopBackOff, OOMKilled, pending pods, high restarts |
+| `pod-security-analyst` | security | Checks privileged containers, missing securityContext |
+| `pod-cost-analyst` | cost | Finds over-provisioned resource requests, zombie deployments |
+| `reliability-analyst` | reliability | Analyzes probe config, PDB, replica counts |
+| `config-drift-analyst` | reliability | Detects selector/label mismatches, broken ConfigMap/Secret refs |
+| `alert-responder` | health | Triages firing Prometheus alerts to root cause |
+| `network-troubleshooter` | reliability | Diagnoses Service connectivity and NetworkPolicy blocks |
+| `node-health-analyst` | reliability | Detects node pressure (memory/disk/PID), capacity issues |
+| `rollout-analyst` | health | Diagnoses stuck rollouts and failing new pod versions |
+| `storage-analyst` | reliability | Diagnoses PVC Pending/Lost and volume mount failures |
+
+Custom skills: create a `DiagnosticSkill` CR or place a `.md` file in `skills/`.
+
+## CRDs
+
+| CRD | Purpose |
+|-----|---------|
+| `DiagnosticRun` | Declares a diagnostic task; controller creates an agent Job |
+| `DiagnosticSkill` | Declares a diagnostic skill (dimension, prompt, tools) |
+| `ModelConfig` | LLM provider configuration (API key secret reference) |
+| `DiagnosticFix` | A proposed fix (patch or new resource) with approval workflow |
+
+### DiagnosticFix Lifecycle
+
+```
+DryRunComplete → [user approves] → Approved → Applying → Succeeded
+                                                      → Failed → (auto-rollback) → RolledBack
+                 [user rejects]  → Failed
+```
+
+Strategies: `dry-run` (review only), `auto` (apply patch), `create` (create new resource).
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/runs` | List diagnostic runs |
+| POST | `/api/runs` | Create a DiagnosticRun CR |
+| GET | `/api/runs/:id` | Get run details |
+| GET | `/api/runs/:id/findings` | List findings |
+| GET | `/api/skills` | List registered skills |
+| POST | `/api/skills` | Create a DiagnosticSkill CR |
+| GET | `/api/fixes` | List fixes |
+| GET | `/api/fixes/:id` | Get fix details |
+| PATCH | `/api/fixes/:id/approve` | Approve a fix |
+| PATCH | `/api/fixes/:id/reject` | Reject a fix |
+| POST | `/api/findings/:id/generate-fix` | Trigger fix generation |
+| GET | `/api/k8s/resources` | List cluster resources for autocomplete |
+
+## Development
+
+```bash
+make test        # unit tests
+make envtest     # integration tests (requires kubebuilder)
+make build       # build binaries
+make image       # build Docker images
+cd dashboard && npm run dev  # dashboard dev server
+```
+
+## Roadmap
+
+- [x] **Phase 1** — Operator MVP: 4 CRDs, single-run Job, 5 built-in skills
+- [x] **Phase 2** — Dashboard, Skill Registry UI, i18n (zh/en), dark mode
+- [x] **Phase 3** — DiagnosticFix: LLM patches, Before/After diff, HITL approval, auto-rollback
+- [x] **Phase 3.5** — 5 new MCP tools, 10 built-in skills, symptom-driven /diagnose page
+- [ ] **Phase 4** — Real-time event streaming, vector case memory (RAG), multi-cluster
+
+## References
+
+- [kagent](https://github.com/kagent-dev/kagent) — Kubernetes-native agent orchestration
+- [ci-agent](https://github.com/googs1025/ci-agent) — GitHub CI pipeline AI analyzer
+
+## License
+
+Apache License 2.0 — see [LICENSE](LICENSE).

--- a/dashboard/next.config.ts
+++ b/dashboard/next.config.ts
@@ -2,15 +2,6 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
-  async rewrites() {
-    const apiURL = process.env.API_URL || "http://localhost:8080";
-    return [
-      {
-        source: "/api/:path*",
-        destination: `${apiURL}/api/:path*`,
-      },
-    ];
-  },
 };
 
 export default nextConfig;

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.0",

--- a/dashboard/src/app/api/[...proxy]/route.ts
+++ b/dashboard/src/app/api/[...proxy]/route.ts
@@ -5,7 +5,8 @@ export const dynamic = "force-dynamic";
 async function handler(req: NextRequest) {
   const apiURL = process.env.API_URL || "http://localhost:8080";
   const path = req.nextUrl.pathname;
-  const url = `${apiURL}${path}`;
+  const search = req.nextUrl.search;
+  const url = `${apiURL}${path}${search}`;
 
   const res = await fetch(url, {
     method: req.method,

--- a/dashboard/src/app/diagnose/[id]/page.tsx
+++ b/dashboard/src/app/diagnose/[id]/page.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { use, useState } from "react";
+import Link from "next/link";
+import { useI18n } from "@/i18n/context";
+import { useRun, useFindings, generateFix } from "@/lib/api";
+import { SeverityBadge } from "@/components/severity-badge";
+import { PhaseBadge } from "@/components/phase-badge";
+import type { Finding } from "@/lib/types";
+
+const SEVERITY_ORDER: Record<string, number> = {
+  critical: 0, high: 1, medium: 2, low: 3, info: 4,
+};
+
+const SEVERITY_STYLES: Record<string, { border: string; bg: string; icon: string }> = {
+  critical: { border: "border-red-300 dark:border-red-700", bg: "bg-red-50 dark:bg-red-900/20", icon: "🔴" },
+  high: { border: "border-orange-300 dark:border-orange-700", bg: "bg-orange-50 dark:bg-orange-900/20", icon: "🟠" },
+  medium: { border: "border-yellow-300 dark:border-yellow-700", bg: "bg-yellow-50 dark:bg-yellow-900/20", icon: "🟡" },
+  low: { border: "border-blue-300 dark:border-blue-700", bg: "bg-blue-50 dark:bg-blue-900/20", icon: "🔵" },
+  info: { border: "border-gray-200 dark:border-gray-700", bg: "bg-gray-50 dark:bg-gray-900/20", icon: "⚪" },
+};
+
+function groupBySeverity(findings: Finding[]): [string, Finding[]][] {
+  const sorted = [...findings].sort(
+    (a, b) => (SEVERITY_ORDER[a.Severity] ?? 99) - (SEVERITY_ORDER[b.Severity] ?? 99)
+  );
+  const groups = new Map<string, Finding[]>();
+  for (const f of sorted) {
+    const g = groups.get(f.Severity) || [];
+    g.push(f);
+    groups.set(f.Severity, g);
+  }
+  return Array.from(groups.entries());
+}
+
+export default function DiagnoseResultPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const { t, lang } = useI18n();
+  const { data: run, error: runError } = useRun(id);
+  const { data: findings } = useFindings(id);
+  const [generatingIds, setGeneratingIds] = useState<Set<string>>(new Set());
+
+  if (runError) return <p className="text-red-600">{t("common.loadFailed")}</p>;
+  if (!run) return <p>{t("common.loading")}</p>;
+
+  const grouped = findings ? groupBySeverity(findings) : [];
+  const totalFindings = findings?.length ?? 0;
+
+  const displayName = run.ID.startsWith("diagnose-")
+    ? run.ID.replace(/^diagnose-/, "").replace(/-[a-z0-9]{4}$/, "").replace(/-/g, " ")
+    : run.ID;
+
+  const handleGenerateFix = async (findingId: string) => {
+    setGeneratingIds((prev) => new Set(prev).add(findingId));
+    try {
+      await generateFix(findingId);
+    } catch {
+      // will show via fix link on next poll
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <Link href="/diagnose" className="text-sm text-blue-600 hover:underline">
+          ← {t("diagnose.title")}
+        </Link>
+      </div>
+
+      <div className="rounded-lg border bg-white p-6 shadow-sm dark:bg-gray-900 dark:border-gray-800">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-xl font-bold">{displayName}</h1>
+            <p className="text-sm text-gray-500 mt-1">{run.ID}</p>
+          </div>
+          <PhaseBadge phase={run.Status} />
+        </div>
+
+        <div className="mt-4 grid grid-cols-3 gap-4 text-sm">
+          <div>
+            <span className="text-gray-500">{t("runs.detail.created")}</span>
+            <p>{new Date(run.CreatedAt).toLocaleString()}</p>
+          </div>
+          <div>
+            <span className="text-gray-500">{t("runs.detail.completed")}</span>
+            <p>{run.CompletedAt ? new Date(run.CompletedAt).toLocaleString() : "-"}</p>
+          </div>
+          <div>
+            <span className="text-gray-500">{t("runs.detail.findings")}</span>
+            <p className="font-semibold">{totalFindings}</p>
+          </div>
+        </div>
+
+        {run.Status === "Running" && (
+          <div className="mt-4 flex items-center gap-2 text-sm text-blue-600">
+            <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+            {lang === "zh" ? "诊断中..." : "Diagnosing..."}
+          </div>
+        )}
+
+        {run.Status === "Failed" && run.Message && (
+          <div className="mt-4 rounded bg-red-50 p-3 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400">
+            {run.Message}
+          </div>
+        )}
+      </div>
+
+      {totalFindings === 0 && run.Status === "Succeeded" && (
+        <p className="text-sm text-gray-500">{t("runs.findings.empty")}</p>
+      )}
+
+      {grouped.map(([severity, items]) => {
+        const style = SEVERITY_STYLES[severity] || SEVERITY_STYLES.info;
+        return (
+          <div key={severity} className="space-y-3">
+            <h2 className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-400">
+              {style.icon} {t(`severity.${severity}` as Parameters<typeof t>[0]) || severity} ({items.length})
+            </h2>
+            {items.map((f) => (
+              <div key={f.ID} className={`rounded-lg border ${style.border} ${style.bg} p-4 space-y-2`}>
+                <div className="flex items-start justify-between gap-2">
+                  <h3 className="font-medium">{f.Title}</h3>
+                  <SeverityBadge severity={f.Severity} />
+                </div>
+                {f.ResourceKind && (
+                  <p className="text-xs text-gray-500">
+                    {f.ResourceKind}: {f.ResourceNamespace}/{f.ResourceName}
+                  </p>
+                )}
+                <p className="text-sm">{f.Description}</p>
+                {f.Suggestion && (
+                  <div className="rounded bg-blue-50 p-3 text-sm text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
+                    💡 {f.Suggestion}
+                  </div>
+                )}
+                <div className="flex justify-end">
+                  {f.FixID ? (
+                    <Link href={`/fixes/${f.FixID}`} className="text-sm text-blue-600 hover:underline">
+                      {t("runs.findings.viewFix")} →
+                    </Link>
+                  ) : (
+                    <button
+                      onClick={() => handleGenerateFix(f.ID)}
+                      disabled={generatingIds.has(f.ID)}
+                      className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+                    >
+                      {generatingIds.has(f.ID) ? t("runs.findings.generating") : t("runs.findings.generateFix")}
+                    </button>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/dashboard/src/app/diagnose/page.tsx
+++ b/dashboard/src/app/diagnose/page.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useI18n } from "@/i18n/context";
+import { useK8sNamespaces, useK8sResources, getK8sResourceDetail, createRun, useRuns } from "@/lib/api";
+import { SYMPTOM_PRESETS, symptomsToSkills } from "@/lib/symptoms";
+import { PhaseBadge } from "@/components/phase-badge";
+import Link from "next/link";
+
+const RESOURCE_TYPES = ["Deployment", "Pod", "StatefulSet", "DaemonSet"];
+
+export default function DiagnosePage() {
+  const { t, lang } = useI18n();
+  const router = useRouter();
+
+  const [namespace, setNamespace] = useState("");
+  const [resourceType, setResourceType] = useState("Deployment");
+  const [resourceName, setResourceName] = useState("");
+  const [symptoms, setSymptoms] = useState<string[]>([]);
+  const [outputLang, setOutputLang] = useState<"zh" | "en">("zh");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  const { data: namespaces } = useK8sNamespaces();
+  const { data: resources } = useK8sResources(resourceType, namespace);
+  const { data: runs } = useRuns();
+
+  const toggleSymptom = (id: string) => {
+    if (id === "full-check") {
+      setSymptoms(["full-check"]);
+      return;
+    }
+    setSymptoms((prev) => {
+      const without = prev.filter((s) => s !== "full-check");
+      return without.includes(id) ? without.filter((s) => s !== id) : [...without, id];
+    });
+  };
+
+  const handleSubmit = async () => {
+    if (!namespace || symptoms.length === 0) return;
+    setSubmitting(true);
+    setError("");
+
+    try {
+      let labelSelector: Record<string, string> | undefined;
+      if (resourceName) {
+        const detail = await getK8sResourceDetail(resourceType, namespace, resourceName);
+        const spec = (detail as Record<string, unknown>).spec as Record<string, unknown> | undefined;
+        const selector = spec?.selector as Record<string, unknown> | undefined;
+        const matchLabels = selector?.matchLabels as Record<string, string> | undefined;
+
+        if (matchLabels && (resourceType === "Deployment" || resourceType === "StatefulSet")) {
+          labelSelector = matchLabels;
+        } else {
+          const meta = (detail as Record<string, unknown>).metadata as Record<string, unknown>;
+          const labels = meta?.labels as Record<string, string> | undefined;
+          if (labels) {
+            const appLabel = labels["app"] || labels["app.kubernetes.io/name"];
+            if (appLabel) {
+              labelSelector = { app: appLabel };
+            }
+          }
+        }
+      }
+
+      const symptomSuffix = symptoms.slice(0, 2).join("-");
+      const runName = resourceName
+        ? `diagnose-${resourceName}-${symptomSuffix}-${Math.random().toString(36).slice(2, 6)}`
+        : `diagnose-${namespace}-${symptomSuffix}-${Math.random().toString(36).slice(2, 6)}`;
+
+      await createRun({
+        name: runName,
+        namespace: "kube-agent-helper",
+        target: {
+          scope: "namespace",
+          namespaces: [namespace],
+          labelSelector,
+        },
+        skills: symptomsToSkills(symptoms),
+        modelConfigRef: "anthropic-credentials",
+        outputLanguage: outputLang,
+      });
+
+      router.push(`/diagnose/${encodeURIComponent(runName)}`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const recentDiagnoses = (runs || [])
+    .filter((r) => r.ID && (r.TargetJSON || "").includes("namespace"))
+    .slice(0, 5);
+
+  return (
+    <div className="space-y-8">
+      <h1 className="text-2xl font-bold">{t("diagnose.title")}</h1>
+
+      <div className="rounded-lg border bg-white p-6 shadow-sm dark:bg-gray-900 dark:border-gray-800 space-y-6">
+        <div>
+          <label className="block text-sm font-medium mb-1">{t("diagnose.namespace")}</label>
+          <select
+            value={namespace}
+            onChange={(e) => { setNamespace(e.target.value); setResourceName(""); }}
+            className="w-full rounded border px-3 py-2 text-sm dark:bg-gray-800 dark:border-gray-700"
+          >
+            <option value="">{t("diagnose.namespacePlaceholder")}</option>
+            {(namespaces || []).map((ns) => (
+              <option key={ns.name} value={ns.name}>{ns.name}</option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1">{t("diagnose.resourceType")}</label>
+          <div className="flex gap-3">
+            {RESOURCE_TYPES.map((rt) => (
+              <label key={rt} className="flex items-center gap-1.5 text-sm cursor-pointer">
+                <input
+                  type="radio" name="resourceType" value={rt}
+                  checked={resourceType === rt}
+                  onChange={() => { setResourceType(rt); setResourceName(""); }}
+                />
+                {rt}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            {t("diagnose.resourceName")}
+            <span className="text-gray-400 ml-1 font-normal">({lang === "zh" ? "可选，留空=全部" : "optional, empty=all"})</span>
+          </label>
+          <select
+            value={resourceName}
+            onChange={(e) => setResourceName(e.target.value)}
+            disabled={!namespace}
+            className="w-full rounded border px-3 py-2 text-sm dark:bg-gray-800 dark:border-gray-700 disabled:opacity-50"
+          >
+            <option value="">{t("diagnose.resourceNamePlaceholder")}</option>
+            {(resources || []).map((r) => (
+              <option key={r.name} value={r.name}>{r.name}</option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1">{t("diagnose.symptoms")}</label>
+          <p className="text-xs text-gray-500 mb-2">{t("diagnose.symptomsHint")}</p>
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+            {SYMPTOM_PRESETS.map((s) => (
+              <label
+                key={s.id}
+                className={`flex items-center gap-2 rounded border px-3 py-2 text-sm cursor-pointer transition-colors ${
+                  symptoms.includes(s.id)
+                    ? "border-blue-500 bg-blue-50 dark:bg-blue-900/30 dark:border-blue-400"
+                    : "border-gray-200 dark:border-gray-700 hover:border-gray-400"
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  checked={symptoms.includes(s.id)}
+                  onChange={() => toggleSymptom(s.id)}
+                  className="sr-only"
+                />
+                {lang === "zh" ? s.label_zh : s.label_en}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1">{t("diagnose.outputLanguage")}</label>
+          <div className="flex gap-4">
+            <label className="flex items-center gap-1.5 text-sm cursor-pointer">
+              <input type="radio" name="outputLang" value="zh" checked={outputLang === "zh"} onChange={() => setOutputLang("zh")} />
+              中文
+            </label>
+            <label className="flex items-center gap-1.5 text-sm cursor-pointer">
+              <input type="radio" name="outputLang" value="en" checked={outputLang === "en"} onChange={() => setOutputLang("en")} />
+              English
+            </label>
+          </div>
+        </div>
+
+        {error && <p className="text-sm text-red-600">{t("diagnose.error")}: {error}</p>}
+        <button
+          onClick={handleSubmit}
+          disabled={submitting || !namespace || symptoms.length === 0}
+          className="rounded bg-blue-600 px-6 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {submitting ? t("diagnose.submitting") : t("diagnose.submit")}
+        </button>
+      </div>
+
+      <div>
+        <h2 className="text-lg font-semibold mb-3">{t("diagnose.recent")}</h2>
+        {recentDiagnoses.length === 0 ? (
+          <p className="text-sm text-gray-500">{t("diagnose.recentEmpty")}</p>
+        ) : (
+          <div className="space-y-2">
+            {recentDiagnoses.map((run) => (
+              <Link
+                key={run.ID}
+                href={`/diagnose/${encodeURIComponent(run.ID)}`}
+                className="flex items-center justify-between rounded border px-4 py-3 hover:bg-gray-50 dark:border-gray-800 dark:hover:bg-gray-800/50"
+              >
+                <div className="flex items-center gap-3">
+                  <PhaseBadge phase={run.Status} />
+                  <span className="text-sm font-medium">{run.ID}</span>
+                </div>
+                <span className="text-xs text-gray-500">
+                  {new Date(run.CreatedAt).toLocaleString()}
+                </span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/app/diagnose/page.tsx
+++ b/dashboard/src/app/diagnose/page.tsx
@@ -69,7 +69,7 @@ export default function DiagnosePage() {
         ? `diagnose-${resourceName}-${symptomSuffix}-${Math.random().toString(36).slice(2, 6)}`
         : `diagnose-${namespace}-${symptomSuffix}-${Math.random().toString(36).slice(2, 6)}`;
 
-      await createRun({
+      const runId = await createRun({
         name: runName,
         namespace: "kube-agent-helper",
         target: {
@@ -82,7 +82,7 @@ export default function DiagnosePage() {
         outputLanguage: outputLang,
       });
 
-      router.push(`/diagnose/${encodeURIComponent(runName)}`);
+      router.push(`/diagnose/${encodeURIComponent(runId)}`);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -17,6 +17,7 @@ function Nav() {
           {t("nav.brand")}
         </Link>
         <div className="flex flex-1 gap-6 text-sm">
+          <Link href="/diagnose" className="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100">{t("nav.diagnose")}</Link>
           <Link href="/" className="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100">{t("nav.runs")}</Link>
           <Link href="/skills" className="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100">{t("nav.skills")}</Link>
           <Link href="/fixes" className="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100">{t("nav.fixes")}</Link>

--- a/dashboard/src/i18n/context.tsx
+++ b/dashboard/src/i18n/context.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useCallback, useContext, useState, ReactNode } from "react";
+import { createContext, useCallback, useContext, useEffect, useState, ReactNode } from "react";
 import zh from "./zh.json";
 import en from "./en.json";
 
@@ -44,16 +44,14 @@ interface I18nCtx {
 
 const Ctx = createContext<I18nCtx | null>(null);
 
-function getInitialLang(): Lang {
-  if (typeof window !== "undefined") {
-    const stored = localStorage.getItem("lang");
-    if (stored === "zh" || stored === "en") return stored;
-  }
-  return "zh";
-}
-
 export function I18nProvider({ children }: { children: ReactNode }) {
-  const [lang, setLangState] = useState<Lang>(getInitialLang);
+  // Always start with "zh" to match SSR; read localStorage after hydration
+  const [lang, setLangState] = useState<Lang>("zh");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("lang");
+    if (stored === "zh" || stored === "en") setLangState(stored);
+  }, []);
 
   const setLang = useCallback((l: Lang) => {
     setLangState(l);

--- a/dashboard/src/i18n/context.tsx
+++ b/dashboard/src/i18n/context.tsx
@@ -49,8 +49,13 @@ export function I18nProvider({ children }: { children: ReactNode }) {
   const [lang, setLangState] = useState<Lang>("zh");
 
   useEffect(() => {
-    const stored = localStorage.getItem("lang");
-    if (stored === "zh" || stored === "en") setLangState(stored);
+    const apply = (v: string | null) => {
+      if (v === "zh" || v === "en") setLangState(v);
+    };
+    apply(localStorage.getItem("lang"));
+    const handler = (e: StorageEvent) => { if (e.key === "lang") apply(e.newValue); };
+    window.addEventListener("storage", handler);
+    return () => window.removeEventListener("storage", handler);
   }, []);
 
   const setLang = useCallback((l: Lang) => {

--- a/dashboard/src/i18n/en.json
+++ b/dashboard/src/i18n/en.json
@@ -4,6 +4,7 @@
     "runs": "Runs",
     "skills": "Skills",
     "fixes": "Fixes",
+    "diagnose": "Diagnose",
     "about": "About"
   },
   "overview": {
@@ -37,8 +38,8 @@
     "flow.step5": "5. Approve & Apply",
     "flow.step5.desc": "Review Before/After diff, approve to let the Reconciler apply. Auto-rollback on failure.",
     "tools.title": "MCP Tool Set",
-    "tools.desc": "Agent Pod embeds k8s-mcp-server (Go) with 9 read-only tools:",
-    "tools.list": "kubectl_get · kubectl_describe · kubectl_logs · kubectl_explain · events_list · top_pods · top_nodes · list_api_resources · prometheus_query"
+    "tools.desc": "Agent Pod embeds k8s-mcp-server (Go) with 14 read-only tools:",
+    "tools.list": "kubectl_get · kubectl_describe · kubectl_logs · kubectl_explain · events_list · top_pods · top_nodes · list_api_resources · prometheus_query · kubectl_rollout_status · node_status_summary · prometheus_alerts · pvc_status · network_policy_check"
   },
   "common": {
     "cancel": "Cancel",
@@ -207,5 +208,22 @@
     "toast.rejected": "Fix suggestion rejected",
     "verify.successHint": "Patch applied successfully. Verify the resource with:",
     "verify.failHint": "Operation did not succeed. Check the resource with:"
+  },
+  "diagnose": {
+    "title": "Quick Diagnose",
+    "namespace": "Namespace",
+    "namespacePlaceholder": "Select namespace",
+    "resourceType": "Resource Type",
+    "resourceName": "Resource Name",
+    "resourceNamePlaceholder": "Select resource",
+    "symptoms": "Observed Symptoms",
+    "symptomsHint": "Select one or more, platform auto-selects diagnostic skills",
+    "outputLanguage": "Output Language",
+    "submit": "Start Diagnosis",
+    "submitting": "Creating...",
+    "error": "Failed to create diagnosis",
+    "recent": "Recent Diagnoses",
+    "recentEmpty": "No diagnoses yet",
+    "findings_count": "findings"
   }
 }

--- a/dashboard/src/i18n/zh.json
+++ b/dashboard/src/i18n/zh.json
@@ -4,6 +4,7 @@
     "runs": "诊断任务",
     "skills": "技能",
     "fixes": "修复建议",
+    "diagnose": "诊断",
     "about": "关于"
   },
   "overview": {
@@ -37,8 +38,8 @@
     "flow.step5": "5. 审批与执行",
     "flow.step5.desc": "查看 Before/After diff，批准后 Reconciler 自动应用，失败时可自动回滚",
     "tools.title": "MCP 工具集",
-    "tools.desc": "Agent Pod 内嵌 k8s-mcp-server（Go），提供 9 个只读工具：",
-    "tools.list": "kubectl_get · kubectl_describe · kubectl_logs · kubectl_explain · events_list · top_pods · top_nodes · list_api_resources · prometheus_query"
+    "tools.desc": "Agent Pod 内嵌 k8s-mcp-server（Go），提供 14 个只读工具：",
+    "tools.list": "kubectl_get · kubectl_describe · kubectl_logs · kubectl_explain · events_list · top_pods · top_nodes · list_api_resources · prometheus_query · kubectl_rollout_status · node_status_summary · prometheus_alerts · pvc_status · network_policy_check"
   },
   "common": {
     "cancel": "取消",
@@ -207,5 +208,22 @@
     "toast.rejected": "修复建议已拒绝",
     "verify.successHint": "补丁已成功应用。可通过以下命令验证资源当前状态：",
     "verify.failHint": "操作未成功。可通过以下命令检查资源当前状态："
+  },
+  "diagnose": {
+    "title": "快速诊断",
+    "namespace": "命名空间",
+    "namespacePlaceholder": "选择命名空间",
+    "resourceType": "资源类型",
+    "resourceName": "资源名称",
+    "resourceNamePlaceholder": "选择资源",
+    "symptoms": "你观察到的症状",
+    "symptomsHint": "可多选，平台自动选择合适的诊断策略",
+    "outputLanguage": "输出语言",
+    "submit": "开始诊断",
+    "submitting": "创建中...",
+    "error": "创建诊断失败",
+    "recent": "最近的诊断",
+    "recentEmpty": "暂无诊断记录",
+    "findings_count": "个问题"
   }
 }

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -19,7 +19,7 @@ export function useSkills() {
   return useSWR<Skill[]>("/api/skills", fetcher, { refreshInterval: 10000 });
 }
 
-export async function createRun(body: CreateRunRequest): Promise<void> {
+export async function createRun(body: CreateRunRequest): Promise<string> {
   const res = await fetch("/api/runs", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -29,6 +29,9 @@ export async function createRun(body: CreateRunRequest): Promise<void> {
     const text = await res.text();
     throw new Error(text || `HTTP ${res.status}`);
   }
+  const obj = await res.json();
+  // Backend returns K8s object; uid is stored as ID in the run store
+  return (obj?.metadata?.uid as string) ?? "";
 }
 
 export async function createSkill(body: CreateSkillRequest): Promise<void> {

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -86,3 +86,26 @@ export async function generateFix(findingID: string): Promise<{ fixID?: string; 
   }
   return res.json();
 }
+
+export function useK8sNamespaces() {
+  return useSWR<{ name: string }[]>("/api/k8s/resources?kind=Namespace", fetcher);
+}
+
+export function useK8sResources(kind: string, namespace: string) {
+  const url = namespace
+    ? `/api/k8s/resources?kind=${kind}&namespace=${namespace}`
+    : null;
+  return useSWR<{ name: string; namespace: string }[]>(url, fetcher);
+}
+
+export async function getK8sResourceDetail(
+  kind: string,
+  namespace: string,
+  name: string
+): Promise<Record<string, unknown>> {
+  const res = await fetch(
+    `/api/k8s/resources?kind=${kind}&namespace=${namespace}&name=${name}`
+  );
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+}

--- a/dashboard/src/lib/symptoms.ts
+++ b/dashboard/src/lib/symptoms.ts
@@ -1,0 +1,69 @@
+export interface SymptomPreset {
+  id: string;
+  label_zh: string;
+  label_en: string;
+  skills: string[];
+}
+
+export const SYMPTOM_PRESETS: SymptomPreset[] = [
+  {
+    id: "cpu-high",
+    label_zh: "CPU 利用率高",
+    label_en: "High CPU usage",
+    skills: ["pod-health-analyst", "pod-cost-analyst"],
+  },
+  {
+    id: "memory-high",
+    label_zh: "内存使用率高 / OOMKill",
+    label_en: "High memory / OOMKill",
+    skills: ["pod-health-analyst", "pod-cost-analyst"],
+  },
+  {
+    id: "request-slow",
+    label_zh: "请求延迟高 / 服务不通",
+    label_en: "Slow requests / service unreachable",
+    skills: ["pod-health-analyst", "config-drift-analyst"],
+  },
+  {
+    id: "pod-restart",
+    label_zh: "Pod 频繁重启",
+    label_en: "Pod frequent restarts",
+    skills: ["pod-health-analyst", "reliability-analyst"],
+  },
+  {
+    id: "pod-not-start",
+    label_zh: "Pod 启动失败",
+    label_en: "Pod failed to start",
+    skills: ["pod-health-analyst", "config-drift-analyst", "reliability-analyst"],
+  },
+  {
+    id: "scaling-issue",
+    label_zh: "扩缩容异常",
+    label_en: "Scaling issues (HPA)",
+    skills: ["pod-cost-analyst", "reliability-analyst"],
+  },
+  {
+    id: "rollout-stuck",
+    label_zh: "滚动更新卡住",
+    label_en: "Rollout stuck",
+    skills: ["pod-health-analyst", "reliability-analyst"],
+  },
+  {
+    id: "full-check",
+    label_zh: "全面体检",
+    label_en: "Full health check",
+    skills: [],
+  },
+];
+
+export function symptomsToSkills(symptomIds: string[]): string[] | undefined {
+  if (symptomIds.includes("full-check")) return undefined;
+  const skills = new Set<string>();
+  for (const id of symptomIds) {
+    const preset = SYMPTOM_PRESETS.find((p) => p.id === id);
+    if (preset) {
+      for (const s of preset.skills) skills.add(s);
+    }
+  }
+  return skills.size > 0 ? Array.from(skills) : undefined;
+}

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -83,3 +83,8 @@ export interface Fix {
   CreatedAt: string;
   UpdatedAt: string;
 }
+
+export interface K8sResourceItem {
+  name: string;
+  namespace?: string;
+}

--- a/deploy/helm/templates/rbac.yaml
+++ b/deploy/helm/templates/rbac.yaml
@@ -34,10 +34,14 @@ rules:
 # DiagnosticFix: patch target resources
 - apiGroups: ["apps"]
   resources: ["deployments","statefulsets","daemonsets"]
-  verbs: ["get","patch"]
+  verbs: ["get","list","watch","patch"]
 - apiGroups: [""]
   resources: ["services"]
   verbs: ["get","patch"]
+# Resource autocomplete API: list namespaces and workloads
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get","list","watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/docs/superpowers/plans/2026-04-17-diagnose-page-and-new-tools.md
+++ b/docs/superpowers/plans/2026-04-17-diagnose-page-and-new-tools.md
@@ -1,0 +1,2406 @@
+# Diagnose Page + New MCP Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add 5 new MCP diagnostic tools, a user-facing `/diagnose` page with symptom-driven entry, a `/diagnose/[id]` result page sorted by severity, and a lightweight K8s resource query API for autocomplete.
+
+**Architecture:** New MCP tools follow existing handler pattern (factory func + `Deps` + `jsonResult`). Dashboard adds two new routes (`/diagnose`, `/diagnose/[id]`) using existing i18n/SWR patterns. One new backend API endpoint (`/api/k8s/resources`) proxies read-only K8s queries for autocomplete. Existing admin pages and CRD schema are unchanged.
+
+**Tech Stack:** Go 1.22 (MCP tools + HTTP handler), Next.js + React + SWR (dashboard), `k8s.io/client-go` (K8s API), `mcp-go` (MCP protocol), `testify` + `client-go/fake` (testing)
+
+---
+
+### Task 1: MCP Tool — `kubectl_rollout_status`
+
+**Files:**
+- Create: `internal/mcptools/rollout_status.go`
+- Create: `internal/mcptools/rollout_status_test.go`
+- Modify: `internal/mcptools/register.go:55-90` (add to RegisterExtension)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/mcptools/rollout_status_test.go`:
+
+```go
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestRolloutStatus_MissingArgs(t *testing.T) {
+	d := &Deps{Typed: k8sfake.NewSimpleClientset()}
+	handler := NewRolloutStatusHandler(d)
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestRolloutStatus_DeploymentWithReplicaSets(t *testing.T) {
+	replicas := int32(3)
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "web", Namespace: "prod",
+			UID: "deploy-uid-1",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "web"},
+			},
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:          3,
+			UpdatedReplicas:   3,
+			ReadyReplicas:     3,
+			AvailableReplicas: 3,
+			Conditions: []appsv1.DeploymentCondition{{
+				Type:    appsv1.DeploymentAvailable,
+				Status:  corev1.ConditionTrue,
+				Message: "Deployment has minimum availability",
+			}},
+		},
+	}
+	isController := true
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "web-abc123", Namespace: "prod",
+			OwnerReferences: []metav1.OwnerReference{{
+				UID:        "deploy-uid-1",
+				Controller: &isController,
+			}},
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.ReplicaSetStatus{
+			Replicas:      3,
+			ReadyReplicas: 3,
+		},
+	}
+
+	client := k8sfake.NewSimpleClientset(deploy, rs)
+	d := &Deps{Typed: client}
+	handler := NewRolloutStatusHandler(d)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{
+		"kind": "Deployment", "name": "web", "namespace": "prod",
+	}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &payload))
+	assert.Equal(t, "web", payload["name"])
+	assert.Equal(t, float64(3), payload["readyReplicas"])
+	rs_list, ok := payload["replicaSets"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, rs_list, 1)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/zhenyu.jiang/kube-agent-helper && go test ./internal/mcptools/ -run TestRolloutStatus -v`
+Expected: FAIL — `NewRolloutStatusHandler` not defined
+
+- [ ] **Step 3: Write implementation**
+
+Create `internal/mcptools/rollout_status.go`:
+
+```go
+package mcptools
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewRolloutStatusHandler(d *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, _ := req.Params.Arguments.(map[string]interface{})
+		kind, _ := args["kind"].(string)
+		name, _ := args["name"].(string)
+		namespace, _ := args["namespace"].(string)
+		if kind == "" || name == "" || namespace == "" {
+			return mcp.NewToolResultError("kind, name, and namespace are required"), nil
+		}
+
+		switch kind {
+		case "Deployment":
+			return rolloutDeployment(ctx, d, namespace, name)
+		case "StatefulSet":
+			return rolloutStatefulSet(ctx, d, namespace, name)
+		default:
+			return mcp.NewToolResultError("kind must be Deployment or StatefulSet"), nil
+		}
+	}
+}
+
+func rolloutDeployment(ctx context.Context, d *Deps, ns, name string) (*mcp.CallToolResult, error) {
+	deploy, err := d.Typed.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("get deployment: %v", err)), nil
+	}
+
+	// List ReplicaSets owned by this Deployment
+	rsList, err := d.Typed.AppsV1().ReplicaSets(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("list replicasets: %v", err)), nil
+	}
+
+	var owned []map[string]interface{}
+	for _, rs := range rsList.Items {
+		for _, ref := range rs.OwnerReferences {
+			if ref.Controller != nil && *ref.Controller && ref.UID == deploy.UID {
+				// Extract image from pod template
+				var image string
+				if len(rs.Spec.Template.Spec.Containers) > 0 {
+					image = rs.Spec.Template.Spec.Containers[0].Image
+				}
+				owned = append(owned, map[string]interface{}{
+					"name":          rs.Name,
+					"replicas":      rs.Status.Replicas,
+					"readyReplicas": rs.Status.ReadyReplicas,
+					"image":         image,
+					"createdAt":     rs.CreationTimestamp.Format("2006-01-02T15:04:05Z"),
+				})
+			}
+		}
+	}
+	// Sort by creation time descending (newest first)
+	sort.SliceStable(owned, func(i, j int) bool {
+		return owned[i]["createdAt"].(string) > owned[j]["createdAt"].(string)
+	})
+
+	// Determine status
+	status := "complete"
+	if deploy.Status.UpdatedReplicas < *deploy.Spec.Replicas {
+		status = "progressing"
+	} else if deploy.Status.AvailableReplicas < *deploy.Spec.Replicas {
+		status = "progressing"
+	}
+	for _, c := range deploy.Status.Conditions {
+		if c.Type == "Progressing" && c.Reason == "ProgressDeadlineExceeded" {
+			status = "degraded"
+		}
+	}
+
+	conditions := make([]map[string]interface{}, 0, len(deploy.Status.Conditions))
+	for _, c := range deploy.Status.Conditions {
+		conditions = append(conditions, map[string]interface{}{
+			"type":    string(c.Type),
+			"status":  string(c.Status),
+			"reason":  c.Reason,
+			"message": c.Message,
+		})
+	}
+
+	return jsonResult(map[string]interface{}{
+		"name":              deploy.Name,
+		"namespace":         deploy.Namespace,
+		"status":            status,
+		"desiredReplicas":   *deploy.Spec.Replicas,
+		"updatedReplicas":   deploy.Status.UpdatedReplicas,
+		"readyReplicas":     deploy.Status.ReadyReplicas,
+		"availableReplicas": deploy.Status.AvailableReplicas,
+		"conditions":        conditions,
+		"replicaSets":       owned,
+	})
+}
+
+func rolloutStatefulSet(ctx context.Context, d *Deps, ns, name string) (*mcp.CallToolResult, error) {
+	sts, err := d.Typed.AppsV1().StatefulSets(ns).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("get statefulset: %v", err)), nil
+	}
+
+	status := "complete"
+	if sts.Status.UpdatedReplicas < *sts.Spec.Replicas {
+		status = "progressing"
+	} else if sts.Status.ReadyReplicas < *sts.Spec.Replicas {
+		status = "progressing"
+	}
+
+	return jsonResult(map[string]interface{}{
+		"name":              sts.Name,
+		"namespace":         sts.Namespace,
+		"status":            status,
+		"desiredReplicas":   *sts.Spec.Replicas,
+		"updatedReplicas":   sts.Status.UpdatedReplicas,
+		"readyReplicas":     sts.Status.ReadyReplicas,
+		"currentRevision":   sts.Status.CurrentRevision,
+		"updateRevision":    sts.Status.UpdateRevision,
+	})
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/zhenyu.jiang/kube-agent-helper && go test ./internal/mcptools/ -run TestRolloutStatus -v`
+Expected: PASS
+
+- [ ] **Step 5: Register the tool**
+
+In `internal/mcptools/register.go`, add at the end of `RegisterExtension()`:
+
+```go
+	registerTool(s, d, mcp.NewTool("kubectl_rollout_status",
+		mcp.WithDescription("Show Deployment or StatefulSet rollout status with ReplicaSet history"),
+		mcp.WithString("kind", mcp.Required(), mcp.Description("Deployment or StatefulSet")),
+		mcp.WithString("name", mcp.Required(), mcp.Description("Resource name")),
+		mcp.WithString("namespace", mcp.Required(), mcp.Description("Namespace")),
+	), []string{"kind", "name", "namespace"}, NewRolloutStatusHandler(d))
+```
+
+- [ ] **Step 6: Run full tool test suite**
+
+Run: `cd /Users/zhenyu.jiang/kube-agent-helper && go test ./internal/mcptools/ -v`
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/mcptools/rollout_status.go internal/mcptools/rollout_status_test.go internal/mcptools/register.go
+git commit -m "feat(mcp): add kubectl_rollout_status tool for deployment/statefulset rollout diagnosis"
+```
+
+---
+
+### Task 2: MCP Tool — `node_status_summary`
+
+**Files:**
+- Create: `internal/mcptools/node_status.go`
+- Create: `internal/mcptools/node_status_test.go`
+- Modify: `internal/mcptools/register.go` (add to RegisterExtension)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/mcptools/node_status_test.go`:
+
+```go
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestNodeStatusSummary_Basic(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+		Spec: corev1.NodeSpec{
+			Taints: []corev1.Taint{{Key: "dedicated", Value: "gpu", Effect: corev1.TaintEffectNoSchedule}},
+		},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+				{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionFalse},
+			},
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4000m"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+				corev1.ResourcePods:   resource.MustParse("110"),
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-1", Namespace: "prod"},
+		Spec: corev1.PodSpec{
+			NodeName: "node-1",
+			Containers: []corev1.Container{{
+				Name: "main",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				},
+			}},
+		},
+	}
+
+	client := k8sfake.NewSimpleClientset(node, pod)
+	d := &Deps{Typed: client}
+	handler := NewNodeStatusSummaryHandler(d)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{"name": "node-1"}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var payload struct {
+		Nodes []struct {
+			Name         string `json:"name"`
+			Ready        bool   `json:"ready"`
+			Unschedulable bool  `json:"unschedulable"`
+			PodCount     int    `json:"podCount"`
+		} `json:"nodes"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &payload))
+	require.Len(t, payload.Nodes, 1)
+	assert.Equal(t, "node-1", payload.Nodes[0].Name)
+	assert.True(t, payload.Nodes[0].Ready)
+	assert.Equal(t, 1, payload.Nodes[0].PodCount)
+}
+
+func TestNodeStatusSummary_NoTypedClient(t *testing.T) {
+	d := &Deps{Typed: nil}
+	handler := NewNodeStatusSummaryHandler(d)
+	result, err := handler(context.Background(), mcp.CallToolRequest{})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/zhenyu.jiang/kube-agent-helper && go test ./internal/mcptools/ -run TestNodeStatusSummary -v`
+Expected: FAIL — `NewNodeStatusSummaryHandler` not defined
+
+- [ ] **Step 3: Write implementation**
+
+Create `internal/mcptools/node_status.go`:
+
+```go
+package mcptools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewNodeStatusSummaryHandler(d *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if d.Typed == nil {
+			return mcp.NewToolResultError("kubernetes typed client not available"), nil
+		}
+		args, _ := req.Params.Arguments.(map[string]interface{})
+		name, _ := args["name"].(string)
+		labelSelector, _ := args["labelSelector"].(string)
+
+		var nodes []corev1.Node
+		if name != "" {
+			node, err := d.Typed.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("get node: %v", err)), nil
+			}
+			nodes = []corev1.Node{*node}
+		} else {
+			list, err := d.Typed.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("list nodes: %v", err)), nil
+			}
+			nodes = list.Items
+			if len(nodes) > 20 {
+				nodes = nodes[:20]
+			}
+		}
+
+		// Gather all pods once (more efficient than per-node queries)
+		podList, err := d.Typed.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("list pods: %v", err)), nil
+		}
+		// Group pods by nodeName
+		podsByNode := make(map[string][]corev1.Pod)
+		for _, p := range podList.Items {
+			if p.Spec.NodeName != "" {
+				podsByNode[p.Spec.NodeName] = append(podsByNode[p.Spec.NodeName], p)
+			}
+		}
+
+		result := make([]map[string]interface{}, 0, len(nodes))
+		for _, node := range nodes {
+			nodePods := podsByNode[node.Name]
+
+			// Sum resource requests
+			var cpuReqMilli, memReqMi int64
+			for _, p := range nodePods {
+				for _, c := range p.Spec.Containers {
+					if q, ok := c.Resources.Requests[corev1.ResourceCPU]; ok {
+						cpuReqMilli += q.MilliValue()
+					}
+					if q, ok := c.Resources.Requests[corev1.ResourceMemory]; ok {
+						memReqMi += q.Value() / (1024 * 1024)
+					}
+				}
+			}
+
+			// Allocatable
+			cpuAlloc := node.Status.Allocatable[corev1.ResourceCPU]
+			memAlloc := node.Status.Allocatable[corev1.ResourceMemory]
+			podAlloc := node.Status.Allocatable[corev1.ResourcePods]
+
+			cpuAllocMilli := cpuAlloc.MilliValue()
+			memAllocMi := memAlloc.Value() / (1024 * 1024)
+
+			var cpuPct, memPct float64
+			if cpuAllocMilli > 0 {
+				cpuPct = float64(cpuReqMilli) / float64(cpuAllocMilli) * 100
+			}
+			if memAllocMi > 0 {
+				memPct = float64(memReqMi) / float64(memAllocMi) * 100
+			}
+
+			// Conditions
+			ready := false
+			conditions := make([]map[string]interface{}, 0)
+			for _, c := range node.Status.Conditions {
+				conditions = append(conditions, map[string]interface{}{
+					"type":    string(c.Type),
+					"status":  string(c.Status),
+					"reason":  c.Reason,
+					"message": c.Message,
+				})
+				if c.Type == corev1.NodeReady && c.Status == corev1.ConditionTrue {
+					ready = true
+				}
+			}
+
+			// Taints
+			taints := make([]map[string]interface{}, 0, len(node.Spec.Taints))
+			for _, t := range node.Spec.Taints {
+				taints = append(taints, map[string]interface{}{
+					"key": t.Key, "value": t.Value, "effect": string(t.Effect),
+				})
+			}
+
+			result = append(result, map[string]interface{}{
+				"name":          node.Name,
+				"ready":         ready,
+				"unschedulable": node.Spec.Unschedulable,
+				"conditions":    conditions,
+				"allocatable": map[string]interface{}{
+					"cpuMilli": cpuAllocMilli,
+					"memoryMi": memAllocMi,
+					"pods":     podAlloc.Value(),
+				},
+				"allocated": map[string]interface{}{
+					"cpuMilli": cpuReqMilli,
+					"memoryMi": memReqMi,
+				},
+				"utilizationPct": map[string]interface{}{
+					"cpu":    int(cpuPct),
+					"memory": int(memPct),
+				},
+				"podCount": len(nodePods),
+				"taints":   taints,
+			})
+		}
+
+		return jsonResult(map[string]interface{}{"nodes": result})
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/zhenyu.jiang/kube-agent-helper && go test ./internal/mcptools/ -run TestNodeStatusSummary -v`
+Expected: PASS
+
+- [ ] **Step 5: Register the tool**
+
+In `internal/mcptools/register.go`, add to `RegisterExtension()`:
+
+```go
+	registerTool(s, d, mcp.NewTool("node_status_summary",
+		mcp.WithDescription("Show node conditions, capacity, allocated resources, and taints"),
+		mcp.WithString("name", mcp.Description("Specific node name (omit for all nodes, max 20)")),
+		mcp.WithString("labelSelector", mcp.Description("Label selector to filter nodes")),
+	), []string{"name", "labelSelector"}, NewNodeStatusSummaryHandler(d))
+```
+
+- [ ] **Step 6: Run full tool test suite**
+
+Run: `cd /Users/zhenyu.jiang/kube-agent-helper && go test ./internal/mcptools/ -v`
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/mcptools/node_status.go internal/mcptools/node_status_test.go internal/mcptools/register.go
+git commit -m "feat(mcp): add node_status_summary tool for node conditions and capacity diagnosis"
+```
+
+---
+
+### Task 3: MCP Tool — `prometheus_alerts`
+
+**Files:**
+- Create: `internal/mcptools/prometheus_alerts.go`
+- Create: `internal/mcptools/prometheus_alerts_test.go`
+- Modify: `internal/mcptools/register.go` (add to RegisterExtension)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/mcptools/prometheus_alerts_test.go`:
+
+```go
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeAlertsAPI struct {
+	promv1.API
+	alerts []promv1.Alert
+}
+
+func (f *fakeAlertsAPI) Alerts(ctx context.Context) (promv1.AlertsResult, error) {
+	return promv1.AlertsResult{Alerts: f.alerts}, nil
+}
+
+func TestPrometheusAlerts_Unavailable(t *testing.T) {
+	d := &Deps{Prometheus: nil}
+	handler := NewPrometheusAlertsHandler(d)
+	result, err := handler(context.Background(), mcp.CallToolRequest{})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &payload))
+	assert.Equal(t, false, payload["available"])
+}
+
+func TestPrometheusAlerts_FilterFiring(t *testing.T) {
+	api := &fakeAlertsAPI{
+		alerts: []promv1.Alert{
+			{
+				Labels:   model.LabelSet{"alertname": "HighCPU", "severity": "critical", "namespace": "prod"},
+				State:    promv1.AlertStateFiring,
+				ActiveAt: mustParseTime("2026-04-17T10:00:00Z"),
+			},
+			{
+				Labels: model.LabelSet{"alertname": "DiskSlow", "severity": "warning"},
+				State:  promv1.AlertStatePending,
+			},
+		},
+	}
+	d := &Deps{Prometheus: api}
+	handler := NewPrometheusAlertsHandler(d)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{"state": "firing"}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var payload struct {
+		Available bool                     `json:"available"`
+		Alerts    []map[string]interface{} `json:"alerts"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &payload))
+	assert.True(t, payload.Available)
+	require.Len(t, payload.Alerts, 1)
+	assert.Equal(t, "HighCPU", payload.Alerts[0]["alertname"])
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/zhenyu.jiang/kube-agent-helper && go test ./internal/mcptools/ -run TestPrometheusAlerts -v`
+Expected: FAIL — `NewPrometheusAlertsHandler` not defined
+
+- [ ] **Step 3: Write implementation**
+
+Create `internal/mcptools/prometheus_alerts.go`:
+
+```go
+package mcptools
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+)
+
+// AlertsAPI is the subset of promv1.API we need. Aids testing.
+type AlertsAPI interface {
+	Alerts(ctx context.Context) (promv1.AlertsResult, error)
+}
+
+func NewPrometheusAlertsHandler(d *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if d.Prometheus == nil {
+			return jsonResult(map[string]interface{}{
+				"available": false,
+				"error":     "prometheus not configured (use --prometheus-url)",
+			})
+		}
+
+		args, _ := req.Params.Arguments.(map[string]interface{})
+		state, _ := args["state"].(string)
+		if state == "" {
+			state = "firing"
+		}
+		labelFilter, _ := args["labelFilter"].(string)
+
+		// Parse label filter: "namespace=prod,severity=critical"
+		filterMap := make(map[string]string)
+		if labelFilter != "" {
+			for _, pair := range strings.Split(labelFilter, ",") {
+				kv := strings.SplitN(strings.TrimSpace(pair), "=", 2)
+				if len(kv) == 2 {
+					filterMap[kv[0]] = kv[1]
+				}
+			}
+		}
+
+		// d.Prometheus implements promv1.API which has Alerts()
+		alerter, ok := d.Prometheus.(AlertsAPI)
+		if !ok {
+			return jsonResult(map[string]interface{}{
+				"available": false,
+				"error":     "prometheus client does not support alerts API",
+			})
+		}
+
+		result, err := alerter.Alerts(ctx)
+		if err != nil {
+			return jsonResult(map[string]interface{}{
+				"available": false,
+				"error":     err.Error(),
+			})
+		}
+
+		sevOrder := map[string]int{"critical": 0, "warning": 1, "info": 2}
+
+		var filtered []map[string]interface{}
+		for _, a := range result.Alerts {
+			// Filter by state
+			if state != "all" {
+				if state == "firing" && a.State != promv1.AlertStateFiring {
+					continue
+				}
+				if state == "pending" && a.State != promv1.AlertStatePending {
+					continue
+				}
+			}
+			// Filter by labels
+			match := true
+			for k, v := range filterMap {
+				if string(a.Labels[model.LabelName(k)]) != v {
+					match = false
+					break
+				}
+			}
+			if !match {
+				continue
+			}
+
+			labels := make(map[string]string, len(a.Labels))
+			for k, v := range a.Labels {
+				labels[string(k)] = string(v)
+			}
+			annotations := make(map[string]string, len(a.Annotations))
+			for k, v := range a.Annotations {
+				annotations[string(k)] = string(v)
+			}
+
+			entry := map[string]interface{}{
+				"alertname":   string(a.Labels["alertname"]),
+				"state":       string(a.State),
+				"severity":    string(a.Labels["severity"]),
+				"labels":      labels,
+				"annotations": annotations,
+			}
+			if !a.ActiveAt.IsZero() {
+				entry["activeAt"] = a.ActiveAt.UTC().Format(time.RFC3339)
+			}
+			if a.Value != "" {
+				entry["value"] = string(a.Value)
+			}
+
+			filtered = append(filtered, entry)
+		}
+
+		// Sort: critical > warning > info, then by activeAt descending
+		sort.SliceStable(filtered, func(i, j int) bool {
+			si := sevOrder[filtered[i]["severity"].(string)]
+			sj := sevOrder[filtered[j]["severity"].(string)]
+			if si != sj {
+				return si < sj
+			}
+			ai, _ := filtered[i]["activeAt"].(string)
+			aj, _ := filtered[j]["activeAt"].(string)
+			return ai > aj
+		})
+
+		return jsonResult(map[string]interface{}{
+			"available": true,
+			"count":     len(filtered),
+			"alerts":    filtered,
+		})
+	}
+}
+```
+
+Note: need to add the `model` import. The import line is: `"github.com/prometheus/common/model"`. Add it to the imports.
+
+- [ ] **Step 4: Add `mustParseTime` helper to the test file**
+
+Add at the bottom of `prometheus_alerts_test.go`:
+
+```go
+func mustParseTime(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+```
+
+And add `"time"` to the test imports.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /Users/zhenyu.jiang/kube-agent-helper && go test ./internal/mcptools/ -run TestPrometheusAlerts -v`
+Expected: PASS
+
+- [ ] **Step 6: Register the tool**
+
+In `internal/mcptools/register.go`, add to `RegisterExtension()`:
+
+```go
+	registerTool(s, d, mcp.NewTool("prometheus_alerts",
+		mcp.WithDescription("List active Prometheus alerts, sorted by severity"),
+		mcp.WithString("state", mcp.Description("Filter: firing, pending, or all (default firing)")),
+		mcp.WithString("labelFilter", mcp.Description("Filter by labels, e.g. namespace=prod,severity=critical")),
+	), []string{"state", "labelFilter"}, NewPrometheusAlertsHandler(d))
+```
+
+- [ ] **Step 7: Run full test suite and commit**
+
+Run: `cd /Users/zhenyu.jiang/kube-agent-helper && go test ./internal/mcptools/ -v`
+Expected: All PASS
+
+```bash
+git add internal/mcptools/prometheus_alerts.go internal/mcptools/prometheus_alerts_test.go internal/mcptools/register.go
+git commit -m "feat(mcp): add prometheus_alerts tool for active alert diagnosis"
+```
+
+---
+
+### Task 4: MCP Tool — `pvc_status`
+
+**Files:**
+- Create: `internal/mcptools/pvc_status.go`
+- Create: `internal/mcptools/pvc_status_test.go`
+- Modify: `internal/mcptools/register.go` (add to RegisterExtension)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/mcptools/pvc_status_test.go`:
+
+```go
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestPVCStatus_BoundPVC(t *testing.T) {
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "data-vol", Namespace: "prod"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("10Gi"),
+				},
+			},
+			StorageClassName: strPtr("standard"),
+			VolumeName:       "pv-123",
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: corev1.ClaimBound,
+			Capacity: corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("10Gi"),
+			},
+		},
+	}
+
+	client := k8sfake.NewSimpleClientset(pvc)
+	d := &Deps{Typed: client}
+	handler := NewPVCStatusHandler(d)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{"namespace": "prod"}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var payload struct {
+		Items []struct {
+			Name         string `json:"name"`
+			Phase        string `json:"phase"`
+			VolumeName   string `json:"volumeName"`
+			StorageClass string `json:"storageClass"`
+		} `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &payload))
+	require.Len(t, payload.Items, 1)
+	assert.Equal(t, "data-vol", payload.Items[0].Name)
+	assert.Equal(t, "Bound", payload.Items[0].Phase)
+	assert.Equal(t, "pv-123", payload.Items[0].VolumeName)
+}
+
+func TestPVCStatus_MissingNamespace(t *testing.T) {
+	client := k8sfake.NewSimpleClientset()
+	d := &Deps{Typed: client}
+	handler := NewPVCStatusHandler(d)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+func strPtr(s string) *string { return &s }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/zhenyu.jiang/kube-agent-helper && go test ./internal/mcptools/ -run TestPVCStatus -v`
+Expected: FAIL — `NewPVCStatusHandler` not defined
+
+- [ ] **Step 3: Write implementation**
+
+Create `internal/mcptools/pvc_status.go`:
+
+```go
+package mcptools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewPVCStatusHandler(d *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if d.Typed == nil {
+			return mcp.NewToolResultError("kubernetes typed client not available"), nil
+		}
+		args, _ := req.Params.Arguments.(map[string]interface{})
+		namespace, _ := args["namespace"].(string)
+		if namespace == "" {
+			return mcp.NewToolResultError("namespace is required"), nil
+		}
+		name, _ := args["name"].(string)
+		labelSelector, _ := args["labelSelector"].(string)
+
+		var pvcs []corev1.PersistentVolumeClaim
+		if name != "" {
+			pvc, err := d.Typed.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("get pvc: %v", err)), nil
+			}
+			pvcs = []corev1.PersistentVolumeClaim{*pvc}
+		} else {
+			list, err := d.Typed.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("list pvcs: %v", err)), nil
+			}
+			pvcs = list.Items
+		}
+
+		items := make([]map[string]interface{}, 0, len(pvcs))
+		for _, pvc := range pvcs {
+			storageClass := ""
+			if pvc.Spec.StorageClassName != nil {
+				storageClass = *pvc.Spec.StorageClassName
+			}
+			requestedStorage := ""
+			if q, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]; ok {
+				requestedStorage = q.String()
+			}
+			actualCapacity := ""
+			if q, ok := pvc.Status.Capacity[corev1.ResourceStorage]; ok {
+				actualCapacity = q.String()
+			}
+			accessModes := make([]string, len(pvc.Spec.AccessModes))
+			for i, m := range pvc.Spec.AccessModes {
+				accessModes[i] = string(m)
+			}
+
+			entry := map[string]interface{}{
+				"name":             pvc.Name,
+				"namespace":        pvc.Namespace,
+				"phase":            string(pvc.Status.Phase),
+				"storageClass":     storageClass,
+				"requestedStorage": requestedStorage,
+				"actualCapacity":   actualCapacity,
+				"volumeName":       pvc.Spec.VolumeName,
+				"accessModes":      accessModes,
+			}
+
+			// For Pending PVCs, fetch related events
+			if pvc.Status.Phase == corev1.ClaimPending {
+				events, _ := d.Typed.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{
+					FieldSelector: fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=PersistentVolumeClaim", pvc.Name),
+				})
+				if events != nil && len(events.Items) > 0 {
+					evList := make([]map[string]interface{}, 0)
+					for _, ev := range events.Items {
+						evList = append(evList, map[string]interface{}{
+							"type":    ev.Type,
+							"reason":  ev.Reason,
+							"message": ev.Message,
+						})
+					}
+					entry["events"] = evList
+				}
+			}
+
+			items = append(items, entry)
+		}
+
+		return jsonResult(map[string]interface{}{"items": items})
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/zhenyu.jiang/kube-agent-helper && go test ./internal/mcptools/ -run TestPVCStatus -v`
+Expected: PASS
+
+- [ ] **Step 5: Register the tool**
+
+In `internal/mcptools/register.go`, add to `RegisterExtension()`:
+
+```go
+	registerTool(s, d, mcp.NewTool("pvc_status",
+		mcp.WithDescription("List PersistentVolumeClaim status, capacity, and binding info"),
+		mcp.WithString("namespace", mcp.Required(), mcp.Description("Namespace")),
+		mcp.WithString("name", mcp.Description("Specific PVC name (omit to list all)")),
+		mcp.WithString("labelSelector", mcp.Description("Label selector to filter PVCs")),
+	), []string{"namespace", "name", "labelSelector"}, NewPVCStatusHandler(d))
+```
+
+- [ ] **Step 6: Run full test suite and commit**
+
+Run: `cd /Users/zhenyu.jiang/kube-agent-helper && go test ./internal/mcptools/ -v`
+Expected: All PASS
+
+```bash
+git add internal/mcptools/pvc_status.go internal/mcptools/pvc_status_test.go internal/mcptools/register.go
+git commit -m "feat(mcp): add pvc_status tool for storage diagnosis"
+```
+
+---
+
+### Task 5: MCP Tool — `network_policy_check`
+
+**Files:**
+- Create: `internal/mcptools/network_policy.go`
+- Create: `internal/mcptools/network_policy_test.go`
+- Modify: `internal/mcptools/register.go` (add to RegisterExtension)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/mcptools/network_policy_test.go`:
+
+```go
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestNetworkPolicyCheck_MissingArgs(t *testing.T) {
+	client := k8sfake.NewSimpleClientset()
+	d := &Deps{Typed: client}
+	handler := NewNetworkPolicyCheckHandler(d)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestNetworkPolicyCheck_MatchingPolicy(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "web-1", Namespace: "prod",
+			Labels: map[string]string{"app": "web", "tier": "frontend"},
+		},
+	}
+	port80 := intstr.FromInt(80)
+	policy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "allow-frontend", Namespace: "prod"},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "web"},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{{
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "api"},
+					},
+				}},
+				Ports: []networkingv1.NetworkPolicyPort{{
+					Port: &port80,
+				}},
+			}},
+		},
+	}
+
+	client := k8sfake.NewSimpleClientset(pod, policy)
+	d := &Deps{Typed: client}
+	handler := NewNetworkPolicyCheckHandler(d)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{
+		"namespace": "prod", "podName": "web-1",
+	}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var payload struct {
+		PodLabels        map[string]string        `json:"podLabels"`
+		MatchingPolicies []map[string]interface{} `json:"matchingPolicies"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &payload))
+	assert.Equal(t, "web", payload.PodLabels["app"])
+	require.Len(t, payload.MatchingPolicies, 1)
+	assert.Equal(t, "allow-frontend", payload.MatchingPolicies[0]["name"])
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/zhenyu.jiang/kube-agent-helper && go test ./internal/mcptools/ -run TestNetworkPolicyCheck -v`
+Expected: FAIL — `NewNetworkPolicyCheckHandler` not defined
+
+- [ ] **Step 3: Write implementation**
+
+Create `internal/mcptools/network_policy.go`:
+
+```go
+package mcptools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func NewNetworkPolicyCheckHandler(d *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if d.Typed == nil {
+			return mcp.NewToolResultError("kubernetes typed client not available"), nil
+		}
+		args, _ := req.Params.Arguments.(map[string]interface{})
+		namespace, _ := args["namespace"].(string)
+		podName, _ := args["podName"].(string)
+		if namespace == "" || podName == "" {
+			return mcp.NewToolResultError("namespace and podName are required"), nil
+		}
+
+		pod, err := d.Typed.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("get pod: %v", err)), nil
+		}
+
+		npList, err := d.Typed.NetworkingV1().NetworkPolicies(namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("list network policies: %v", err)), nil
+		}
+
+		var matching []map[string]interface{}
+		defaultDeny := false
+
+		for _, np := range npList.Items {
+			sel, err := metav1.LabelSelectorAsSelector(&np.Spec.PodSelector)
+			if err != nil {
+				continue
+			}
+			if !sel.Matches(labels.Set(pod.Labels)) {
+				continue
+			}
+
+			// Check if this is a default-deny (empty selector + no rules)
+			if sel.Empty() && len(np.Spec.Ingress) == 0 && len(np.Spec.Egress) == 0 {
+				defaultDeny = true
+			}
+
+			policyTypes := make([]string, len(np.Spec.PolicyTypes))
+			for i, pt := range np.Spec.PolicyTypes {
+				policyTypes[i] = string(pt)
+			}
+
+			// Summarize ingress rules
+			ingressRules := make([]map[string]interface{}, 0)
+			for _, rule := range np.Spec.Ingress {
+				from := make([]string, 0)
+				for _, peer := range rule.From {
+					if peer.PodSelector != nil {
+						from = append(from, fmt.Sprintf("pods(%v)", peer.PodSelector.MatchLabels))
+					}
+					if peer.NamespaceSelector != nil {
+						from = append(from, fmt.Sprintf("namespaces(%v)", peer.NamespaceSelector.MatchLabels))
+					}
+					if peer.IPBlock != nil {
+						cidr := peer.IPBlock.CIDR
+						from = append(from, fmt.Sprintf("cidr(%s)", cidr))
+					}
+				}
+				ports := make([]string, 0)
+				for _, p := range rule.Ports {
+					proto := "TCP"
+					if p.Protocol != nil {
+						proto = string(*p.Protocol)
+					}
+					if p.Port != nil {
+						ports = append(ports, fmt.Sprintf("%s/%s", proto, p.Port.String()))
+					}
+				}
+				ingressRules = append(ingressRules, map[string]interface{}{
+					"from": from, "ports": ports,
+				})
+			}
+
+			// Summarize egress rules
+			egressRules := make([]map[string]interface{}, 0)
+			for _, rule := range np.Spec.Egress {
+				to := make([]string, 0)
+				for _, peer := range rule.To {
+					if peer.PodSelector != nil {
+						to = append(to, fmt.Sprintf("pods(%v)", peer.PodSelector.MatchLabels))
+					}
+					if peer.NamespaceSelector != nil {
+						to = append(to, fmt.Sprintf("namespaces(%v)", peer.NamespaceSelector.MatchLabels))
+					}
+					if peer.IPBlock != nil {
+						to = append(to, fmt.Sprintf("cidr(%s)", peer.IPBlock.CIDR))
+					}
+				}
+				ports := make([]string, 0)
+				for _, p := range rule.Ports {
+					proto := "TCP"
+					if p.Protocol != nil {
+						proto = string(*p.Protocol)
+					}
+					if p.Port != nil {
+						ports = append(ports, fmt.Sprintf("%s/%s", proto, p.Port.String()))
+					}
+				}
+				egressRules = append(egressRules, map[string]interface{}{
+					"to": to, "ports": ports,
+				})
+			}
+
+			matching = append(matching, map[string]interface{}{
+				"name":         np.Name,
+				"policyTypes":  policyTypes,
+				"ingressRules": ingressRules,
+				"egressRules":  egressRules,
+			})
+		}
+
+		// Build summary text
+		summary := fmt.Sprintf("%d NetworkPolicy(ies) match this pod.", len(matching))
+		if len(matching) == 0 {
+			summary = "No NetworkPolicies match this pod. All traffic is allowed by default."
+		}
+		if defaultDeny {
+			summary += " A default-deny policy is in effect."
+		}
+
+		return jsonResult(map[string]interface{}{
+			"podLabels":        pod.Labels,
+			"matchingPolicies": matching,
+			"defaultDeny":      defaultDeny,
+			"summary":          summary,
+		})
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/zhenyu.jiang/kube-agent-helper && go test ./internal/mcptools/ -run TestNetworkPolicyCheck -v`
+Expected: PASS
+
+- [ ] **Step 5: Register the tool**
+
+In `internal/mcptools/register.go`, add to `RegisterExtension()`:
+
+```go
+	registerTool(s, d, mcp.NewTool("network_policy_check",
+		mcp.WithDescription("Analyze NetworkPolicies affecting a specific Pod"),
+		mcp.WithString("namespace", mcp.Required(), mcp.Description("Namespace of the target Pod")),
+		mcp.WithString("podName", mcp.Required(), mcp.Description("Name of the Pod to analyze")),
+	), []string{"namespace", "podName"}, NewNetworkPolicyCheckHandler(d))
+```
+
+- [ ] **Step 6: Run full test suite and commit**
+
+Run: `cd /Users/zhenyu.jiang/kube-agent-helper && go test ./internal/mcptools/ -v`
+Expected: All PASS
+
+```bash
+git add internal/mcptools/network_policy.go internal/mcptools/network_policy_test.go internal/mcptools/register.go
+git commit -m "feat(mcp): add network_policy_check tool for network diagnosis"
+```
+
+---
+
+### Task 6: Update Builtin Skill Prompts
+
+**Files:**
+- Modify: `skills/pod-health-analyst.md`
+- Modify: `skills/pod-cost-analyst.md`
+- Modify: `skills/reliability-analyst.md`
+- Modify: `skills/config-drift-analyst.md`
+
+- [ ] **Step 1: Update pod-health-analyst.md**
+
+Change the tools line and add instructions for new tools:
+
+```markdown
+---
+name: pod-health-analyst
+dimension: health
+tools: ["kubectl_get","kubectl_describe","kubectl_logs","events_list","kubectl_rollout_status","prometheus_alerts"]
+requires_data: ["pods","events"]
+---
+
+You are a Kubernetes pod health specialist. Analyze all pods in the target namespaces.
+
+## Instructions
+
+1. List all pods using `kubectl_get` with kind=Pod for each target namespace.
+2. For each pod that is NOT in Running or Succeeded state:
+   - Use `kubectl_describe` to get details.
+   - Use `events_list` to get related events.
+   - If CrashLoopBackOff or OOMKilled, use `kubectl_logs` (previous=true) to get last crash logs.
+3. Check for pods with high restart counts (>5 restarts).
+4. If pods belong to a Deployment or StatefulSet, use `kubectl_rollout_status` to check if a rollout is stuck or recently changed.
+5. Use `prometheus_alerts` to check for any firing alerts related to the target namespaces.
+6. For each issue found, output one finding JSON per line:
+   {"dimension":"health","severity":"<critical|high|medium|low>","title":"<short title>","description":"<what you observed>","resource_kind":"Pod","resource_namespace":"<ns>","resource_name":"<pod-name>","suggestion":"<actionable fix>"}
+
+## Severity Guide
+- critical: Pod won't start or is OOMKilled repeatedly
+- high: CrashLoopBackOff or probe failures preventing traffic
+- medium: High restart count but currently running
+- low: Completed/evicted pods leaving stale entries
+```
+
+- [ ] **Step 2: Update pod-cost-analyst.md**
+
+Change tools line:
+
+```markdown
+---
+name: pod-cost-analyst
+dimension: cost
+tools: ["kubectl_get","top_pods","top_nodes","prometheus_query","node_status_summary"]
+requires_data: ["pods","nodes","metrics"]
+---
+```
+
+Add after step 6 (identify underutilized nodes):
+
+```markdown
+6. Use `node_status_summary` to check node capacity vs allocated resources. Identify nodes with very low utilization (<20% allocated) that could be candidates for consolidation.
+```
+
+- [ ] **Step 3: Update reliability-analyst.md**
+
+Change tools line:
+
+```markdown
+---
+name: reliability-analyst
+dimension: reliability
+tools: ["kubectl_get","kubectl_describe","events_list","kubectl_rollout_status","pvc_status","node_status_summary"]
+requires_data: ["pods","events","deployments"]
+---
+```
+
+Add new instructions after step 6:
+
+```markdown
+7. Use `kubectl_rollout_status` for Deployments with recent events or pods in non-Ready state to check if a rollout is stuck.
+8. Use `pvc_status` to check for PVCs in Pending or Lost state that may block pod scheduling.
+9. Use `node_status_summary` to check if any nodes have MemoryPressure, DiskPressure, or are NotReady.
+```
+
+- [ ] **Step 4: Update config-drift-analyst.md**
+
+Change tools line:
+
+```markdown
+---
+name: config-drift-analyst
+dimension: reliability
+tools: ["kubectl_get","kubectl_describe","network_policy_check"]
+requires_data: ["pods","deployments","services","configmaps"]
+---
+```
+
+Add after step 4:
+
+```markdown
+5. For Services with 0 endpoints, use `network_policy_check` on one of the intended backend pods to check if a NetworkPolicy might be blocking traffic.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/pod-health-analyst.md skills/pod-cost-analyst.md skills/reliability-analyst.md skills/config-drift-analyst.md
+git commit -m "feat(skills): update builtin skills to use new M7 tools"
+```
+
+---
+
+### Task 7: Backend API — `/api/k8s/resources`
+
+**Files:**
+- Modify: `internal/controller/httpserver/server.go` (add handler + route)
+- Modify: `internal/controller/httpserver/server_test.go` (add tests)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/controller/httpserver/server_test.go`:
+
+```go
+func TestK8sResources_ListNamespaces(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = v1alpha1.AddToScheme(scheme)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "production"}}
+	nsSys := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}}
+	k8s := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns, nsSys).Build()
+	srv := httpserver.New(&fakeStore{}, k8s, nil)
+
+	req := httptest.NewRequest("GET", "/api/k8s/resources?kind=Namespace", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var items []map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
+	// Should filter out kube-system
+	names := make([]string, len(items))
+	for i, item := range items {
+		names[i] = item["name"]
+	}
+	assert.Contains(t, names, "production")
+	assert.NotContains(t, names, "kube-system")
+}
+
+func TestK8sResources_ListDeployments(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = appsv1.AddToScheme(scheme)
+	_ = v1alpha1.AddToScheme(scheme)
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "web", Namespace: "prod",
+			Labels: map[string]string{"app": "web"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+		},
+	}
+	k8s := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy).Build()
+	srv := httpserver.New(&fakeStore{}, k8s, nil)
+
+	req := httptest.NewRequest("GET", "/api/k8s/resources?kind=Deployment&namespace=prod", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var items []map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
+	require.Len(t, items, 1)
+	assert.Equal(t, "web", items[0]["name"])
+}
+
+func TestK8sResources_GetSingleDeployment(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = appsv1.AddToScheme(scheme)
+	_ = v1alpha1.AddToScheme(scheme)
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "web", Namespace: "prod",
+			Labels: map[string]string{"app": "web"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+		},
+	}
+	k8s := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy).Build()
+	srv := httpserver.New(&fakeStore{}, k8s, nil)
+
+	req := httptest.NewRequest("GET", "/api/k8s/resources?kind=Deployment&namespace=prod&name=web", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	meta := result["metadata"].(map[string]interface{})
+	assert.Equal(t, "web", meta["name"])
+	spec := result["spec"].(map[string]interface{})
+	selector := spec["selector"].(map[string]interface{})
+	matchLabels := selector["matchLabels"].(map[string]interface{})
+	assert.Equal(t, "web", matchLabels["app"])
+}
+```
+
+Add these imports to the test file's import block:
+
+```go
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/zhenyu.jiang/kube-agent-helper && go test ./internal/controller/httpserver/ -run TestK8sResources -v`
+Expected: FAIL — route not registered, 404
+
+- [ ] **Step 3: Write implementation**
+
+Add route registration in `server.go` `New()` function, after the existing HandleFunc lines:
+
+```go
+	srv.mux.HandleFunc("/api/k8s/resources", srv.handleAPIK8sResources)
+```
+
+Add the handler method to `server.go`:
+
+```go
+// GET /api/k8s/resources?kind=X&namespace=Y&name=Z
+func (s *Server) handleAPIK8sResources(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	kind := r.URL.Query().Get("kind")
+	namespace := r.URL.Query().Get("namespace")
+	name := r.URL.Query().Get("name")
+
+	if kind == "" {
+		http.Error(w, "kind query parameter is required", http.StatusBadRequest)
+		return
+	}
+
+	ctx := r.Context()
+
+	switch kind {
+	case "Namespace":
+		s.handleListNamespaces(ctx, w)
+	case "Deployment":
+		s.handleK8sResource(ctx, w, namespace, name, &appsv1.DeploymentList{}, &appsv1.Deployment{})
+	case "Pod":
+		s.handleK8sResource(ctx, w, namespace, name, &corev1.PodList{}, &corev1.Pod{})
+	case "StatefulSet":
+		s.handleK8sResource(ctx, w, namespace, name, &appsv1.StatefulSetList{}, &appsv1.StatefulSet{})
+	case "DaemonSet":
+		s.handleK8sResource(ctx, w, namespace, name, &appsv1.DaemonSetList{}, &appsv1.DaemonSet{})
+	default:
+		http.Error(w, "unsupported kind: "+kind, http.StatusBadRequest)
+	}
+}
+
+func (s *Server) handleListNamespaces(ctx context.Context, w http.ResponseWriter) {
+	var list corev1.NamespaceList
+	if err := s.k8sClient.List(ctx, &list); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	systemNS := map[string]bool{
+		"kube-system": true, "kube-public": true, "kube-node-lease": true,
+	}
+	items := make([]map[string]string, 0)
+	for _, ns := range list.Items {
+		if systemNS[ns.Name] {
+			continue
+		}
+		items = append(items, map[string]string{"name": ns.Name})
+	}
+	writeJSON(w, items)
+}
+
+func (s *Server) handleK8sResource(ctx context.Context, w http.ResponseWriter, namespace, name string, listObj client.ObjectList, singleObj client.Object) {
+	if namespace == "" {
+		http.Error(w, "namespace is required for this kind", http.StatusBadRequest)
+		return
+	}
+
+	if name != "" {
+		// Get single resource with full metadata (for label resolution)
+		key := client.ObjectKey{Namespace: namespace, Name: name}
+		if err := s.k8sClient.Get(ctx, key, singleObj); err != nil {
+			if errors.IsNotFound(err) {
+				http.NotFound(w, nil)
+				return
+			}
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, singleObj)
+		return
+	}
+
+	// List mode — return compact name/namespace pairs
+	if err := s.k8sClient.List(ctx, listObj, client.InNamespace(namespace)); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	// Use reflection-free approach: marshal then extract names
+	raw, _ := json.Marshal(listObj)
+	var parsed struct {
+		Items []struct {
+			Metadata struct {
+				Name      string `json:"name"`
+				Namespace string `json:"namespace"`
+			} `json:"metadata"`
+		} `json:"items"`
+	}
+	_ = json.Unmarshal(raw, &parsed)
+	items := make([]map[string]string, 0, len(parsed.Items))
+	for _, item := range parsed.Items {
+		items = append(items, map[string]string{
+			"name":      item.Metadata.Name,
+			"namespace": item.Metadata.Namespace,
+		})
+	}
+	writeJSON(w, items)
+}
+```
+
+Add the needed imports to `server.go`:
+
+```go
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+```
+
+Note: `errors` import for `errors.IsNotFound` is already present as `"k8s.io/apimachinery/pkg/api/errors"`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/zhenyu.jiang/kube-agent-helper && go test ./internal/controller/httpserver/ -run TestK8sResources -v`
+Expected: PASS
+
+- [ ] **Step 5: Run full httpserver test suite**
+
+Run: `cd /Users/zhenyu.jiang/kube-agent-helper && go test ./internal/controller/httpserver/ -v`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/controller/httpserver/server.go internal/controller/httpserver/server_test.go
+git commit -m "feat(api): add /api/k8s/resources endpoint for resource autocomplete"
+```
+
+---
+
+### Task 8: Dashboard — Symptom Config + API Helpers
+
+**Files:**
+- Create: `dashboard/src/lib/symptoms.ts`
+- Modify: `dashboard/src/lib/api.ts` (add k8s resource query helpers)
+- Modify: `dashboard/src/lib/types.ts` (add DiagnoseForm type)
+
+- [ ] **Step 1: Create symptoms.ts**
+
+Create `dashboard/src/lib/symptoms.ts`:
+
+```typescript
+export interface SymptomPreset {
+  id: string;
+  label_zh: string;
+  label_en: string;
+  skills: string[];
+}
+
+export const SYMPTOM_PRESETS: SymptomPreset[] = [
+  {
+    id: "cpu-high",
+    label_zh: "CPU 利用率高",
+    label_en: "High CPU usage",
+    skills: ["pod-health-analyst", "pod-cost-analyst"],
+  },
+  {
+    id: "memory-high",
+    label_zh: "内存使用率高 / OOMKill",
+    label_en: "High memory / OOMKill",
+    skills: ["pod-health-analyst", "pod-cost-analyst"],
+  },
+  {
+    id: "request-slow",
+    label_zh: "请求延迟高 / 服务不通",
+    label_en: "Slow requests / service unreachable",
+    skills: ["pod-health-analyst", "config-drift-analyst"],
+  },
+  {
+    id: "pod-restart",
+    label_zh: "Pod 频繁重启",
+    label_en: "Pod frequent restarts",
+    skills: ["pod-health-analyst", "reliability-analyst"],
+  },
+  {
+    id: "pod-not-start",
+    label_zh: "Pod 启动失败",
+    label_en: "Pod failed to start",
+    skills: ["pod-health-analyst", "config-drift-analyst", "reliability-analyst"],
+  },
+  {
+    id: "scaling-issue",
+    label_zh: "扩缩容异常",
+    label_en: "Scaling issues (HPA)",
+    skills: ["pod-cost-analyst", "reliability-analyst"],
+  },
+  {
+    id: "rollout-stuck",
+    label_zh: "滚动更新卡住",
+    label_en: "Rollout stuck",
+    skills: ["pod-health-analyst", "reliability-analyst"],
+  },
+  {
+    id: "full-check",
+    label_zh: "全面体检",
+    label_en: "Full health check",
+    skills: [],
+  },
+];
+
+export function symptomsToSkills(symptomIds: string[]): string[] | undefined {
+  if (symptomIds.includes("full-check")) return undefined;
+  const skills = new Set<string>();
+  for (const id of symptomIds) {
+    const preset = SYMPTOM_PRESETS.find((p) => p.id === id);
+    if (preset) {
+      for (const s of preset.skills) skills.add(s);
+    }
+  }
+  return skills.size > 0 ? Array.from(skills) : undefined;
+}
+```
+
+- [ ] **Step 2: Add types to types.ts**
+
+Append to `dashboard/src/lib/types.ts`:
+
+```typescript
+export interface K8sResourceItem {
+  name: string;
+  namespace?: string;
+}
+```
+
+- [ ] **Step 3: Add API helpers to api.ts**
+
+Append to `dashboard/src/lib/api.ts`:
+
+```typescript
+import type { K8sResourceItem } from "./types";
+
+export function useK8sNamespaces() {
+  return useSWR<K8sResourceItem[]>("/api/k8s/resources?kind=Namespace", fetcher);
+}
+
+export function useK8sResources(kind: string, namespace: string) {
+  const url = namespace
+    ? `/api/k8s/resources?kind=${kind}&namespace=${namespace}`
+    : null;
+  return useSWR<K8sResourceItem[]>(url, fetcher);
+}
+
+export async function getK8sResourceDetail(
+  kind: string,
+  namespace: string,
+  name: string
+): Promise<Record<string, unknown>> {
+  const res = await fetch(
+    `/api/k8s/resources?kind=${kind}&namespace=${namespace}&name=${name}`
+  );
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add dashboard/src/lib/symptoms.ts dashboard/src/lib/api.ts dashboard/src/lib/types.ts
+git commit -m "feat(dashboard): add symptom config and k8s resource API helpers"
+```
+
+---
+
+### Task 9: Dashboard — `/diagnose` Page
+
+**Files:**
+- Create: `dashboard/src/app/diagnose/page.tsx`
+- Modify: `dashboard/src/i18n/zh.json` (add diagnose keys)
+- Modify: `dashboard/src/i18n/en.json` (add diagnose keys)
+- Modify: `dashboard/src/app/layout.tsx` (add nav item)
+
+- [ ] **Step 1: Add i18n keys**
+
+Add to `zh.json` top-level:
+
+```json
+  "diagnose": {
+    "title": "快速诊断",
+    "namespace": "命名空间",
+    "namespacePlaceholder": "选择命名空间",
+    "resourceType": "资源类型",
+    "resourceName": "资源名称",
+    "resourceNamePlaceholder": "选择资源",
+    "symptoms": "你观察到的症状",
+    "symptomsHint": "可多选，平台自动选择合适的诊断策略",
+    "outputLanguage": "输出语言",
+    "submit": "开始诊断",
+    "submitting": "创建中...",
+    "error": "创建诊断失败",
+    "recent": "最近的诊断",
+    "recentEmpty": "暂无诊断记录",
+    "findings_count": "个问题"
+  }
+```
+
+Add corresponding English keys to `en.json`:
+
+```json
+  "diagnose": {
+    "title": "Quick Diagnose",
+    "namespace": "Namespace",
+    "namespacePlaceholder": "Select namespace",
+    "resourceType": "Resource Type",
+    "resourceName": "Resource Name",
+    "resourceNamePlaceholder": "Select resource",
+    "symptoms": "Observed Symptoms",
+    "symptomsHint": "Select one or more, platform auto-selects diagnostic skills",
+    "outputLanguage": "Output Language",
+    "submit": "Start Diagnosis",
+    "submitting": "Creating...",
+    "error": "Failed to create diagnosis",
+    "recent": "Recent Diagnoses",
+    "recentEmpty": "No diagnoses yet",
+    "findings_count": "findings"
+  }
+```
+
+Also add to nav sections:
+
+```json
+  "nav": {
+    ...
+    "diagnose": "诊断"
+  }
+```
+
+(English: `"diagnose": "Diagnose"`)
+
+- [ ] **Step 2: Add nav item to layout.tsx**
+
+In `dashboard/src/app/layout.tsx`, add the Diagnose link as the first item in the nav:
+
+```tsx
+        <div className="flex flex-1 gap-6 text-sm">
+          <Link href="/diagnose" className="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100">{t("nav.diagnose")}</Link>
+          <Link href="/" className="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100">{t("nav.runs")}</Link>
+```
+
+- [ ] **Step 3: Create /diagnose/page.tsx**
+
+Create `dashboard/src/app/diagnose/page.tsx`:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useI18n } from "@/i18n/context";
+import { useK8sNamespaces, useK8sResources, getK8sResourceDetail, createRun, useRuns } from "@/lib/api";
+import { SYMPTOM_PRESETS, symptomsToSkills } from "@/lib/symptoms";
+import { PhaseBadge } from "@/components/phase-badge";
+import Link from "next/link";
+
+const RESOURCE_TYPES = ["Deployment", "Pod", "StatefulSet", "DaemonSet"];
+
+export default function DiagnosePage() {
+  const { t, lang } = useI18n();
+  const router = useRouter();
+
+  const [namespace, setNamespace] = useState("");
+  const [resourceType, setResourceType] = useState("Deployment");
+  const [resourceName, setResourceName] = useState("");
+  const [symptoms, setSymptoms] = useState<string[]>([]);
+  const [outputLang, setOutputLang] = useState<"zh" | "en">("zh");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  const { data: namespaces } = useK8sNamespaces();
+  const { data: resources } = useK8sResources(resourceType, namespace);
+  const { data: runs } = useRuns();
+
+  const toggleSymptom = (id: string) => {
+    if (id === "full-check") {
+      setSymptoms(["full-check"]);
+      return;
+    }
+    setSymptoms((prev) => {
+      const without = prev.filter((s) => s !== "full-check");
+      return without.includes(id) ? without.filter((s) => s !== id) : [...without, id];
+    });
+  };
+
+  const handleSubmit = async () => {
+    if (!namespace || symptoms.length === 0) return;
+    setSubmitting(true);
+    setError("");
+
+    try {
+      // Resolve labels from the selected resource
+      let labelSelector: Record<string, string> | undefined;
+      if (resourceName) {
+        const detail = await getK8sResourceDetail(resourceType, namespace, resourceName);
+        const spec = (detail as Record<string, unknown>).spec as Record<string, unknown> | undefined;
+        const selector = spec?.selector as Record<string, unknown> | undefined;
+        const matchLabels = selector?.matchLabels as Record<string, string> | undefined;
+
+        if (matchLabels && (resourceType === "Deployment" || resourceType === "StatefulSet")) {
+          labelSelector = matchLabels;
+        } else {
+          const meta = (detail as Record<string, unknown>).metadata as Record<string, unknown>;
+          const labels = meta?.labels as Record<string, string> | undefined;
+          if (labels) {
+            const appLabel = labels["app"] || labels["app.kubernetes.io/name"];
+            if (appLabel) {
+              labelSelector = { app: appLabel };
+            }
+          }
+        }
+      }
+
+      const symptomSuffix = symptoms.slice(0, 2).join("-");
+      const runName = resourceName
+        ? `diagnose-${resourceName}-${symptomSuffix}-${Math.random().toString(36).slice(2, 6)}`
+        : `diagnose-${namespace}-${symptomSuffix}-${Math.random().toString(36).slice(2, 6)}`;
+
+      await createRun({
+        name: runName,
+        namespace: "kube-agent-helper",
+        target: {
+          scope: "namespace",
+          namespaces: [namespace],
+          labelSelector,
+        },
+        skills: symptomsToSkills(symptoms),
+        modelConfigRef: "anthropic-credentials",
+        outputLanguage: outputLang,
+      });
+
+      // Navigate to diagnose result page
+      // We use the run name to find it — redirect to the diagnose results view
+      router.push(`/diagnose/${encodeURIComponent(runName)}`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // Recent diagnoses: filter runs whose name starts with "diagnose-"
+  const recentDiagnoses = (runs || [])
+    .filter((r) => r.ID && (r.TargetJSON || "").includes("namespace"))
+    .slice(0, 5);
+
+  return (
+    <div className="space-y-8">
+      <h1 className="text-2xl font-bold">{t("diagnose.title")}</h1>
+
+      <div className="rounded-lg border bg-white p-6 shadow-sm dark:bg-gray-900 dark:border-gray-800 space-y-6">
+        {/* Namespace */}
+        <div>
+          <label className="block text-sm font-medium mb-1">{t("diagnose.namespace")}</label>
+          <select
+            value={namespace}
+            onChange={(e) => { setNamespace(e.target.value); setResourceName(""); }}
+            className="w-full rounded border px-3 py-2 text-sm dark:bg-gray-800 dark:border-gray-700"
+          >
+            <option value="">{t("diagnose.namespacePlaceholder")}</option>
+            {(namespaces || []).map((ns) => (
+              <option key={ns.name} value={ns.name}>{ns.name}</option>
+            ))}
+          </select>
+        </div>
+
+        {/* Resource Type */}
+        <div>
+          <label className="block text-sm font-medium mb-1">{t("diagnose.resourceType")}</label>
+          <div className="flex gap-3">
+            {RESOURCE_TYPES.map((rt) => (
+              <label key={rt} className="flex items-center gap-1.5 text-sm cursor-pointer">
+                <input
+                  type="radio" name="resourceType" value={rt}
+                  checked={resourceType === rt}
+                  onChange={() => { setResourceType(rt); setResourceName(""); }}
+                />
+                {rt}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        {/* Resource Name */}
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            {t("diagnose.resourceName")}
+            <span className="text-gray-400 ml-1 font-normal">({t("common.none")} = {lang === "zh" ? "全部" : "all"})</span>
+          </label>
+          <select
+            value={resourceName}
+            onChange={(e) => setResourceName(e.target.value)}
+            disabled={!namespace}
+            className="w-full rounded border px-3 py-2 text-sm dark:bg-gray-800 dark:border-gray-700 disabled:opacity-50"
+          >
+            <option value="">{t("diagnose.resourceNamePlaceholder")}</option>
+            {(resources || []).map((r) => (
+              <option key={r.name} value={r.name}>{r.name}</option>
+            ))}
+          </select>
+        </div>
+
+        {/* Symptoms */}
+        <div>
+          <label className="block text-sm font-medium mb-1">{t("diagnose.symptoms")}</label>
+          <p className="text-xs text-gray-500 mb-2">{t("diagnose.symptomsHint")}</p>
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+            {SYMPTOM_PRESETS.map((s) => (
+              <label
+                key={s.id}
+                className={`flex items-center gap-2 rounded border px-3 py-2 text-sm cursor-pointer transition-colors ${
+                  symptoms.includes(s.id)
+                    ? "border-blue-500 bg-blue-50 dark:bg-blue-900/30 dark:border-blue-400"
+                    : "border-gray-200 dark:border-gray-700 hover:border-gray-400"
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  checked={symptoms.includes(s.id)}
+                  onChange={() => toggleSymptom(s.id)}
+                  className="sr-only"
+                />
+                {lang === "zh" ? s.label_zh : s.label_en}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        {/* Output Language */}
+        <div>
+          <label className="block text-sm font-medium mb-1">{t("diagnose.outputLanguage")}</label>
+          <div className="flex gap-4">
+            <label className="flex items-center gap-1.5 text-sm cursor-pointer">
+              <input type="radio" name="outputLang" value="zh" checked={outputLang === "zh"} onChange={() => setOutputLang("zh")} />
+              中文
+            </label>
+            <label className="flex items-center gap-1.5 text-sm cursor-pointer">
+              <input type="radio" name="outputLang" value="en" checked={outputLang === "en"} onChange={() => setOutputLang("en")} />
+              English
+            </label>
+          </div>
+        </div>
+
+        {/* Submit */}
+        {error && <p className="text-sm text-red-600">{t("diagnose.error")}: {error}</p>}
+        <button
+          onClick={handleSubmit}
+          disabled={submitting || !namespace || symptoms.length === 0}
+          className="rounded bg-blue-600 px-6 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {submitting ? t("diagnose.submitting") : t("diagnose.submit")}
+        </button>
+      </div>
+
+      {/* Recent Diagnoses */}
+      <div>
+        <h2 className="text-lg font-semibold mb-3">{t("diagnose.recent")}</h2>
+        {recentDiagnoses.length === 0 ? (
+          <p className="text-sm text-gray-500">{t("diagnose.recentEmpty")}</p>
+        ) : (
+          <div className="space-y-2">
+            {recentDiagnoses.map((run) => (
+              <Link
+                key={run.ID}
+                href={`/diagnose/${encodeURIComponent(run.ID)}`}
+                className="flex items-center justify-between rounded border px-4 py-3 hover:bg-gray-50 dark:border-gray-800 dark:hover:bg-gray-800/50"
+              >
+                <div className="flex items-center gap-3">
+                  <PhaseBadge phase={run.Status} />
+                  <span className="text-sm font-medium">{run.ID}</span>
+                </div>
+                <span className="text-xs text-gray-500">
+                  {new Date(run.CreatedAt).toLocaleString()}
+                </span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Verify the page renders**
+
+Run: `cd /Users/zhenyu.jiang/kube-agent-helper/dashboard && npm run build`
+Expected: Build succeeds without errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/src/app/diagnose/page.tsx dashboard/src/app/layout.tsx dashboard/src/i18n/zh.json dashboard/src/i18n/en.json
+git commit -m "feat(dashboard): add /diagnose page with symptom-driven diagnostic entry"
+```
+
+---
+
+### Task 10: Dashboard — `/diagnose/[id]` Result Page
+
+**Files:**
+- Create: `dashboard/src/app/diagnose/[id]/page.tsx`
+
+- [ ] **Step 1: Create the result page**
+
+Create `dashboard/src/app/diagnose/[id]/page.tsx`:
+
+```tsx
+"use client";
+
+import { use } from "react";
+import Link from "next/link";
+import { useI18n } from "@/i18n/context";
+import { useRun, useFindings, generateFix } from "@/lib/api";
+import { SeverityBadge } from "@/components/severity-badge";
+import { PhaseBadge } from "@/components/phase-badge";
+import type { Finding } from "@/lib/types";
+import { useState } from "react";
+
+const SEVERITY_ORDER: Record<string, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+  info: 4,
+};
+
+const SEVERITY_STYLES: Record<string, { border: string; bg: string; icon: string }> = {
+  critical: { border: "border-red-300 dark:border-red-700", bg: "bg-red-50 dark:bg-red-900/20", icon: "🔴" },
+  high: { border: "border-orange-300 dark:border-orange-700", bg: "bg-orange-50 dark:bg-orange-900/20", icon: "🟠" },
+  medium: { border: "border-yellow-300 dark:border-yellow-700", bg: "bg-yellow-50 dark:bg-yellow-900/20", icon: "🟡" },
+  low: { border: "border-blue-300 dark:border-blue-700", bg: "bg-blue-50 dark:bg-blue-900/20", icon: "🔵" },
+  info: { border: "border-gray-200 dark:border-gray-700", bg: "bg-gray-50 dark:bg-gray-900/20", icon: "⚪" },
+};
+
+function sortFindings(findings: Finding[]): Finding[] {
+  return [...findings].sort(
+    (a, b) => (SEVERITY_ORDER[a.Severity] ?? 99) - (SEVERITY_ORDER[b.Severity] ?? 99)
+  );
+}
+
+function groupBySeverity(findings: Finding[]): [string, Finding[]][] {
+  const sorted = sortFindings(findings);
+  const groups = new Map<string, Finding[]>();
+  for (const f of sorted) {
+    const g = groups.get(f.Severity) || [];
+    g.push(f);
+    groups.set(f.Severity, g);
+  }
+  return Array.from(groups.entries());
+}
+
+export default function DiagnoseResultPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const { t, lang } = useI18n();
+  const { data: run, error: runError } = useRun(id);
+  const { data: findings } = useFindings(id);
+  const [generatingIds, setGeneratingIds] = useState<Set<string>>(new Set());
+
+  if (runError) return <p className="text-red-600">{t("common.loadFailed")}</p>;
+  if (!run) return <p>{t("common.loading")}</p>;
+
+  const grouped = findings ? groupBySeverity(findings) : [];
+  const totalFindings = findings?.length ?? 0;
+
+  // Parse run name for display
+  const displayName = run.ID.startsWith("diagnose-")
+    ? run.ID.replace(/^diagnose-/, "").replace(/-[a-z0-9]{4}$/, "").replace(/-/g, " ")
+    : run.ID;
+
+  const handleGenerateFix = async (findingId: string) => {
+    setGeneratingIds((prev) => new Set(prev).add(findingId));
+    try {
+      await generateFix(findingId);
+    } catch {
+      // ignore — will show via fix link on next poll
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Link href="/diagnose" className="text-sm text-blue-600 hover:underline">
+          ← {t("diagnose.title")}
+        </Link>
+      </div>
+
+      <div className="rounded-lg border bg-white p-6 shadow-sm dark:bg-gray-900 dark:border-gray-800">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-xl font-bold">{displayName}</h1>
+            <p className="text-sm text-gray-500 mt-1">
+              {run.ID}
+            </p>
+          </div>
+          <PhaseBadge phase={run.Status} />
+        </div>
+
+        <div className="mt-4 grid grid-cols-3 gap-4 text-sm">
+          <div>
+            <span className="text-gray-500">{t("runs.detail.created")}</span>
+            <p>{new Date(run.CreatedAt).toLocaleString()}</p>
+          </div>
+          <div>
+            <span className="text-gray-500">{t("runs.detail.completed")}</span>
+            <p>{run.CompletedAt ? new Date(run.CompletedAt).toLocaleString() : "-"}</p>
+          </div>
+          <div>
+            <span className="text-gray-500">{t("runs.detail.findings")}</span>
+            <p className="font-semibold">{totalFindings}</p>
+          </div>
+        </div>
+
+        {run.Status === "Running" && (
+          <div className="mt-4 flex items-center gap-2 text-sm text-blue-600">
+            <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+            {lang === "zh" ? "诊断中..." : "Diagnosing..."}
+          </div>
+        )}
+
+        {run.Status === "Failed" && run.Message && (
+          <div className="mt-4 rounded bg-red-50 p-3 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400">
+            {run.Message}
+          </div>
+        )}
+      </div>
+
+      {/* Findings grouped by severity */}
+      {totalFindings === 0 && run.Status === "Succeeded" && (
+        <p className="text-sm text-gray-500">{t("runs.findings.empty")}</p>
+      )}
+
+      {grouped.map(([severity, items]) => {
+        const style = SEVERITY_STYLES[severity] || SEVERITY_STYLES.info;
+        return (
+          <div key={severity} className="space-y-3">
+            <h2 className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-400">
+              {style.icon} {t(`severity.${severity}` as never) || severity} ({items.length})
+            </h2>
+            {items.map((f) => (
+              <div key={f.ID} className={`rounded-lg border ${style.border} ${style.bg} p-4 space-y-2`}>
+                <div className="flex items-start justify-between gap-2">
+                  <h3 className="font-medium">{f.Title}</h3>
+                  <SeverityBadge severity={f.Severity} />
+                </div>
+                {f.ResourceKind && (
+                  <p className="text-xs text-gray-500">
+                    {f.ResourceKind}: {f.ResourceNamespace}/{f.ResourceName}
+                  </p>
+                )}
+                <p className="text-sm">{f.Description}</p>
+                {f.Suggestion && (
+                  <div className="rounded bg-blue-50 p-3 text-sm text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
+                    💡 {f.Suggestion}
+                  </div>
+                )}
+                <div className="flex justify-end">
+                  {f.FixID ? (
+                    <Link
+                      href={`/fixes/${f.FixID}`}
+                      className="text-sm text-blue-600 hover:underline"
+                    >
+                      {t("runs.findings.viewFix")} →
+                    </Link>
+                  ) : (
+                    <button
+                      onClick={() => handleGenerateFix(f.ID)}
+                      disabled={generatingIds.has(f.ID)}
+                      className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+                    >
+                      {generatingIds.has(f.ID) ? t("runs.findings.generating") : t("runs.findings.generateFix")}
+                    </button>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify the build succeeds**
+
+Run: `cd /Users/zhenyu.jiang/kube-agent-helper/dashboard && npm run build`
+Expected: Build succeeds
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dashboard/src/app/diagnose/[id]/page.tsx
+git commit -m "feat(dashboard): add /diagnose/[id] result page with severity-sorted findings"
+```
+
+---
+
+### Task 11: Update About Page Tool List
+
+**Files:**
+- Modify: `dashboard/src/i18n/zh.json`
+- Modify: `dashboard/src/i18n/en.json`
+
+- [ ] **Step 1: Update tool count and list in i18n**
+
+In `zh.json`, update the about section:
+
+```json
+    "tools.desc": "Agent Pod 内嵌 k8s-mcp-server（Go），提供 14 个只读工具：",
+    "tools.list": "kubectl_get · kubectl_describe · kubectl_logs · kubectl_explain · events_list · top_pods · top_nodes · list_api_resources · prometheus_query · kubectl_rollout_status · node_status_summary · prometheus_alerts · pvc_status · network_policy_check"
+```
+
+Make the same update in `en.json`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add dashboard/src/i18n/zh.json dashboard/src/i18n/en.json
+git commit -m "docs(dashboard): update About page tool list to include 5 new M7 tools"
+```
+
+---
+
+### Task 12: Full Integration Verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run all Go tests**
+
+Run: `cd /Users/zhenyu.jiang/kube-agent-helper && go test ./... -v`
+Expected: All PASS
+
+- [ ] **Step 2: Run dashboard build**
+
+Run: `cd /Users/zhenyu.jiang/kube-agent-helper/dashboard && npm run build`
+Expected: Build succeeds
+
+- [ ] **Step 3: Verify tool count**
+
+Run: `cd /Users/zhenyu.jiang/kube-agent-helper && grep -c 'registerTool' internal/mcptools/register.go`
+Expected: 14 (9 existing + 5 new)
+
+- [ ] **Step 4: Verify new route exists**
+
+Run: `grep -r 'diagnose' dashboard/src/app/ --include='*.tsx' -l`
+Expected: `dashboard/src/app/diagnose/page.tsx` and `dashboard/src/app/diagnose/[id]/page.tsx`

--- a/docs/superpowers/specs/2026-04-17-diagnose-page-and-new-tools-design.md
+++ b/docs/superpowers/specs/2026-04-17-diagnose-page-and-new-tools-design.md
@@ -1,0 +1,539 @@
+# Diagnose Page + New MCP Tools Design
+
+> Date: 2026-04-17
+> Status: Draft
+
+## Background
+
+Users come to the platform because they observed a symptom in monitoring/alerting (CPU high, memory high, slow requests, pod crash) on a specific resource (Pod/Deployment). The current dashboard is admin-oriented (Runs/Skills/Fixes management). We need a user-facing diagnostic page that lets users express "what's wrong with this thing" and get structured results.
+
+## Goals
+
+1. Add a `/diagnose` page — symptom-driven diagnostic entry for end users
+2. Add a `/diagnose/[id]` result page — user-friendly findings view sorted by severity
+3. Add 5 new MCP tools to close diagnostic gaps across 6 major symptom categories
+4. Add 1 lightweight backend API for resource autocomplete
+5. Keep existing admin pages and backend architecture unchanged
+
+## Non-Goals
+
+- User authentication / RBAC (future)
+- Custom MCP tool plugin mechanism (deferred — not a real need yet)
+- Changing DiagnosticRun CRD schema
+- Modifying existing admin pages
+
+---
+
+## Part 1: New MCP Tools
+
+### Current Tool Coverage
+
+| Tool | Purpose |
+|------|---------|
+| `kubectl_get` | Get/list any K8s resource |
+| `kubectl_describe` | Describe a resource + events |
+| `kubectl_logs` | Pod container logs |
+| `events_list` | List/filter K8s events |
+| `top_pods` | Pod CPU/memory usage |
+| `top_nodes` | Node CPU/memory usage |
+| `list_api_resources` | List available API types |
+| `prometheus_query` | Execute PromQL |
+| `kubectl_explain` | OpenAPI schema |
+
+### Gap Analysis by Symptom
+
+| Symptom | Current Coverage | Missing |
+|---------|-----------------|---------|
+| CPU high | top_pods, describe, logs | HPA status, rollout history |
+| Memory high / OOMKill | top_pods, describe, events | Node conditions/capacity |
+| Requests slow / service down | kubectl_get (Endpoints) | NetworkPolicy analysis, active alerts |
+| Pod won't start | describe, events, logs | PVC status, node scheduling capacity |
+| Rollout stuck | events | Rollout status, ReplicaSet history |
+| Node NotReady | top_nodes, events | Node conditions/capacity summary |
+| Scaling issues | - | HPA status |
+
+### New Tools (5)
+
+#### 1. `kubectl_rollout_status`
+
+**Purpose:** Show Deployment/StatefulSet rollout status including ReplicaSet history.
+
+**Parameters:**
+- `kind` (required): Deployment or StatefulSet
+- `name` (required): Resource name
+- `namespace` (required): Namespace
+
+**Returns:** JSON with:
+- Current rollout status (progressing / complete / degraded)
+- Desired vs updated vs ready vs available replicas
+- ReplicaSet list (name, replicas, image, creation time) — newest first
+- Rollout conditions from the Deployment status
+
+**Implementation:** Use typed client to get the Deployment, then list ReplicaSets with owner reference matching the Deployment. Sort by creation timestamp descending.
+
+**Covers:** Rollout stuck, CPU high (new version regression), pod won't start after deploy.
+
+#### 2. `node_status_summary`
+
+**Purpose:** Show node conditions, capacity, allocated resources, and taints in one call.
+
+**Parameters:**
+- `name` (optional): Specific node name. If omitted, return summary for all nodes (limited to 20).
+- `labelSelector` (optional): Filter nodes by label.
+
+**Returns:** JSON array with per-node:
+- `conditions`: Array of {type, status, reason, message} — highlight non-True Ready, True MemoryPressure/DiskPressure/PIDPressure
+- `capacity`: CPU, memory, pods (allocatable)
+- `allocated`: Sum of requests from all pods on this node (CPU, memory, pod count)
+- `utilization_pct`: allocated / allocatable as percentage
+- `taints`: Array of {key, value, effect}
+- `unschedulable`: boolean
+
+**Implementation:**
+1. List Nodes (typed client)
+2. For each node, list Pods with `fieldSelector=spec.nodeName=<node>`
+3. Sum pod resource requests
+4. Return aggregated view
+
+**Covers:** Node NotReady, OOMKill (node memory pressure), pod scheduling failures, capacity planning.
+
+#### 3. `prometheus_alerts`
+
+**Purpose:** List active alerts from Prometheus/AlertManager.
+
+**Parameters:**
+- `state` (optional): Filter by state — "firing", "pending", or "all" (default "firing")
+- `labelFilter` (optional): Filter alerts by label match, e.g. "namespace=production,severity=critical"
+
+**Returns:** JSON array of alerts:
+- `alertname`, `state`, `severity`
+- `labels`: full label set
+- `annotations`: summary, description, runbook_url
+- `activeAt`: when the alert started firing
+- `value`: current metric value (if available)
+
+**Implementation:** Call Prometheus API `/api/v1/alerts` (already have Prometheus client in Deps). Filter by state and labels. Sort by severity (critical > warning > info) then activeAt descending.
+
+**Covers:** All symptom scenarios — the user came from an alert, the LLM should also see what alerts are firing to correlate.
+
+#### 4. `pvc_status`
+
+**Purpose:** List PersistentVolumeClaims with their binding status, capacity, and associated PV/StorageClass.
+
+**Parameters:**
+- `namespace` (required): Namespace to check
+- `name` (optional): Specific PVC name
+- `labelSelector` (optional): Filter by label
+
+**Returns:** JSON array with per-PVC:
+- `name`, `namespace`, `phase` (Bound / Pending / Lost)
+- `capacity`: requested vs actual
+- `storageClass`: name, provisioner
+- `volumeName`: bound PV name (if any)
+- `accessModes`: ReadWriteOnce, etc.
+- `events`: recent events for Pending PVCs (auto-fetched)
+
+**Implementation:** List PVCs via typed client. For any PVC in Pending state, also fetch events filtered by involvedObject. Include StorageClass info via discovery.
+
+**Covers:** Pod won't start (volume mount failure), storage issues.
+
+#### 5. `network_policy_check`
+
+**Purpose:** Analyze NetworkPolicies affecting a specific Pod and show which ingress/egress traffic is allowed or blocked.
+
+**Parameters:**
+- `namespace` (required): Namespace of the target Pod
+- `podName` (required): Name of the Pod to analyze
+
+**Returns:** JSON with:
+- `pod_labels`: the Pod's labels
+- `matching_policies`: array of NetworkPolicies whose podSelector matches this Pod
+  - `name`: policy name
+  - `policy_types`: ["Ingress"] / ["Egress"] / ["Ingress", "Egress"]
+  - `ingress_rules`: array of {from, ports} — human-readable
+  - `egress_rules`: array of {to, ports} — human-readable
+- `default_deny`: whether there's a default-deny policy in this namespace
+- `summary`: text description of effective access (e.g. "Only allows ingress from pods with label app=frontend on port 8080. All egress allowed.")
+
+**Implementation:**
+1. Get the Pod's labels
+2. List all NetworkPolicies in the namespace
+3. For each policy, evaluate if its podSelector matches the Pod labels
+4. Compile matching rules into a readable summary
+
+**Covers:** Requests slow / service unreachable, network debugging.
+
+### Tool Registration
+
+All 5 tools registered in `RegisterExtension()` in `internal/mcptools/register.go`. This keeps the Core (M5) / Extension (M6) pattern. These become **M7 tools**.
+
+### Skill Prompt Updates
+
+After adding tools, update the builtin skills to reference them:
+
+| Skill | Add Tools |
+|-------|-----------|
+| `pod-health-analyst` | `kubectl_rollout_status`, `prometheus_alerts` |
+| `pod-cost-analyst` | `node_status_summary` |
+| `reliability-analyst` | `kubectl_rollout_status`, `pvc_status`, `node_status_summary` |
+| `config-drift-analyst` | `network_policy_check` |
+
+---
+
+## Part 2: Diagnose Page (`/diagnose`)
+
+### User Flow
+
+```
+User observes "payment-svc CPU high" in Grafana
+     │
+     ▼
+/diagnose page
+     │
+     ├─ Select namespace: [production ▼]     (autocomplete)
+     ├─ Select resource type: ○ Deployment ○ Pod ○ StatefulSet ...
+     ├─ Select resource name: [payment-svc ▼]  (autocomplete from API)
+     ├─ Select symptoms: ☑ CPU高  ☐ 内存高  ☐ 请求慢 ...
+     ├─ Output language: ○ 中文  ○ English
+     │
+     └─ [开始诊断]
+            │
+            ├─ Frontend resolves resource labels via API
+            ├─ Frontend maps symptoms → skills
+            ├─ Frontend calls POST /api/runs with computed params
+            │
+            ▼
+       /diagnose/[runId] — user-friendly result page
+```
+
+### Symptom → Skill Mapping (Frontend-only)
+
+```typescript
+const SYMPTOM_PRESETS: Record<string, {
+  label_zh: string;
+  label_en: string;
+  skills: string[];
+}> = {
+  'cpu-high': {
+    label_zh: 'CPU 利用率高',
+    label_en: 'High CPU usage',
+    skills: ['pod-health-analyst', 'pod-cost-analyst'],
+  },
+  'memory-high': {
+    label_zh: '内存使用率高 / OOMKill',
+    label_en: 'High memory / OOMKill',
+    skills: ['pod-health-analyst', 'pod-cost-analyst'],
+  },
+  'request-slow': {
+    label_zh: '请求延迟高 / 服务不通',
+    label_en: 'Slow requests / service unreachable',
+    skills: ['pod-health-analyst', 'config-drift-analyst'],
+  },
+  'pod-restart': {
+    label_zh: 'Pod 频繁重启',
+    label_en: 'Pod frequent restarts',
+    skills: ['pod-health-analyst', 'reliability-analyst'],
+  },
+  'pod-not-start': {
+    label_zh: 'Pod 启动失败',
+    label_en: 'Pod failed to start',
+    skills: ['pod-health-analyst', 'config-drift-analyst', 'reliability-analyst'],
+  },
+  'scaling-issue': {
+    label_zh: '扩缩容异常',
+    label_en: 'Scaling issues (HPA)',
+    skills: ['pod-cost-analyst', 'reliability-analyst'],
+  },
+  'rollout-stuck': {
+    label_zh: '滚动更新卡住',
+    label_en: 'Rollout stuck',
+    skills: ['pod-health-analyst', 'reliability-analyst'],
+  },
+  'full-check': {
+    label_zh: '全面体检',
+    label_en: 'Full health check',
+    skills: [],  // empty = all enabled skills
+  },
+};
+```
+
+### Resource Autocomplete Flow
+
+1. User selects namespace → frontend calls `GET /api/k8s/namespaces` to populate namespace dropdown
+2. User selects resource type → frontend calls `GET /api/k8s/resources?namespace=X&kind=Deployment` to get resource list
+3. User selects resource name → frontend calls `GET /api/k8s/resources?namespace=X&kind=Deployment&name=Y` to get the resource's labels
+4. On submit, frontend uses those labels as `labelSelector` in the `CreateRunRequest`
+
+### Label Resolution Logic
+
+```typescript
+async function resolveLabels(ns: string, kind: string, name: string): Promise<Record<string, string>> {
+  const res = await fetch(`/api/k8s/resources?namespace=${ns}&kind=${kind}&name=${name}`);
+  const data = await res.json();
+
+  // Strategy: prefer well-known labels, fall back to matchLabels
+  const labels = data.metadata?.labels || {};
+  const matchLabels = data.spec?.selector?.matchLabels || {};
+
+  // For Deployment/StatefulSet: use spec.selector.matchLabels (most precise)
+  if (kind === 'Deployment' || kind === 'StatefulSet') {
+    return matchLabels;
+  }
+  // For Pod: use pod labels directly, prefer app/app.kubernetes.io/name
+  const appLabel = labels['app'] || labels['app.kubernetes.io/name'];
+  if (appLabel) {
+    return { app: appLabel };
+  }
+  return labels;
+}
+```
+
+### CreateRunRequest Construction
+
+```typescript
+function buildDiagnoseRequest(form: DiagnoseForm): CreateRunRequest {
+  const allSkills = [...new Set(
+    form.symptoms.flatMap(s => SYMPTOM_PRESETS[s].skills)
+  )];
+
+  return {
+    namespace: 'kube-agent-helper',      // Run CR lives in controller ns
+    target: {
+      scope: 'namespace',
+      namespaces: [form.namespace],
+      labelSelector: form.resolvedLabels, // from resolveLabels()
+    },
+    skills: allSkills.length > 0 ? allSkills : undefined,
+    modelConfigRef: 'anthropic-credentials',
+    outputLanguage: form.language,
+  };
+}
+```
+
+### Recent Diagnoses Section
+
+Below the form, show the user's recent diagnoses. This reuses `GET /api/runs` and renders the latest 5 runs in a compact card format:
+
+```
+payment-svc (CPU高, 内存高)     3分钟前    ✅ 发现 3 个问题
+order-svc (请求慢)              1小时前    ✅ 发现 1 个问题
+全面体检 / production           昨天       ✅ 发现 7 个问题
+```
+
+Implementation: filter runs list, parse TargetJSON to extract resource info. The symptom info is not stored in the backend — use a naming convention for the Run name: `diagnose-{resource}-{symptoms}-{random}` (e.g. `diagnose-payment-svc-cpu-high-ab3d`). The diagnose page parses this prefix to display symptom labels. Runs created from the admin "Create Run" page won't have this prefix and won't appear in the recent diagnoses section (filter by `name.startsWith('diagnose-')`).
+
+---
+
+## Part 3: Diagnose Result Page (`/diagnose/[id]`)
+
+### Design Principles
+
+- **Severity-first ordering** — critical → high → medium → low
+- **Hide internal concepts** — no "dimension" label visible to user
+- **Highlight actionable findings** — suggestion and fix button prominent
+- **Compact cards** — each finding is a card, not a section
+
+### Page Layout
+
+```
+┌─ 诊断报告 ─────────────────────────────────────────────┐
+│                                                         │
+│  📋 payment-svc 诊断报告              状态: ● 诊断完成   │
+│  症状: CPU 利用率高, 内存使用率高                         │
+│  耗时: 45s  |  发现: 5 个问题                            │
+│                                                         │
+│  ── 发现 ──────────────────────────────────────────     │
+│                                                         │
+│  🔴 Critical ──────────────────────────────────────     │
+│  ┌────────────────────────────────────────────────┐    │
+│  │ HPA maxReplicas=2 已达上限，无法扩容             │    │
+│  │ Pod: production/payment-svc-7d8f                │    │
+│  │                                                 │    │
+│  │ 当前副本 2/2，HPA 期望 5 个副本但受 maxReplicas  │    │
+│  │ 限制无法扩容，导致现有 Pod CPU 持续 >90%。       │    │
+│  │                                                 │    │
+│  │ 💡 建议: 调高 HPA maxReplicas 至 10，同时检查   │    │
+│  │    是否存在代码层面的 CPU 热点。                  │    │
+│  │                                     [生成修复]   │    │
+│  └────────────────────────────────────────────────┘    │
+│                                                         │
+│  🟡 Medium ────────────────────────────────────────     │
+│  ┌────────────────────────────────────────────────┐    │
+│  │ Pod payment-svc-7d8f 重启 12 次                 │    │
+│  │ ...                                             │    │
+│  └────────────────────────────────────────────────┘    │
+│                                                         │
+│  ┌────────────────────────────────────────────────┐    │
+│  │ 未配置 PodDisruptionBudget                      │    │
+│  │ ...                                             │    │
+│  └────────────────────────────────────────────────┘    │
+│                                                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Severity Grouping & Sorting
+
+```typescript
+const SEVERITY_ORDER = { critical: 0, high: 1, medium: 2, low: 3, info: 4 };
+
+function sortFindings(findings: Finding[]): Finding[] {
+  return [...findings].sort((a, b) =>
+    (SEVERITY_ORDER[a.Severity] ?? 99) - (SEVERITY_ORDER[b.Severity] ?? 99)
+  );
+}
+
+// Group consecutive findings by severity for section headers
+function groupBySeverity(findings: Finding[]): Map<string, Finding[]> {
+  const sorted = sortFindings(findings);
+  const groups = new Map<string, Finding[]>();
+  for (const f of sorted) {
+    const group = groups.get(f.Severity) || [];
+    group.push(f);
+    groups.set(f.Severity, group);
+  }
+  return groups;
+}
+```
+
+### Severity Visual Treatment
+
+| Severity | Color | Icon | Badge Style |
+|----------|-------|------|-------------|
+| critical | red-600 | 🔴 | bg-red-100 text-red-800 border-red-300 |
+| high | orange-500 | 🟠 | bg-orange-100 text-orange-800 border-orange-300 |
+| medium | yellow-500 | 🟡 | bg-yellow-100 text-yellow-800 border-yellow-300 |
+| low | blue-500 | 🔵 | bg-blue-100 text-blue-800 border-blue-300 |
+| info | gray-400 | ⚪ | bg-gray-100 text-gray-600 border-gray-200 |
+
+### Finding Card Components
+
+Each finding card contains:
+1. **Title** — bold, with severity badge
+2. **Resource** — `Kind: Namespace/Name` in muted text
+3. **Description** — the LLM's analysis
+4. **Suggestion box** — light background, highlighted with 💡 icon
+5. **Action button** — "Generate Fix" or "View Fix →" (reuse existing logic from `/runs/[id]`)
+
+### Status Header
+
+Shows diagnostic progress in real-time (poll every 5s like existing pages):
+- `Pending` → "等待调度..."
+- `Running` → "诊断中..." with spinner
+- `Succeeded` → "诊断完成" with finding count
+- `Failed` → "诊断失败" with error message
+
+### i18n
+
+Reuse existing i18n pattern from the project. All labels have zh/en variants.
+
+---
+
+## Part 4: Backend Addition
+
+### New API Endpoint: `GET /api/k8s/resources`
+
+A lightweight read-only proxy to support resource autocomplete on the diagnose page.
+
+**Query Parameters:**
+- `kind` (required): "Namespace", "Deployment", "Pod", "StatefulSet", "DaemonSet"
+- `namespace` (optional): Required for non-Namespace kinds
+- `name` (optional): If provided, return single resource with full metadata (for label resolution)
+
+**Response:**
+
+When `name` is omitted (list mode):
+```json
+[
+  { "name": "payment-svc", "namespace": "production" },
+  { "name": "order-svc", "namespace": "production" }
+]
+```
+
+When `name` is provided (detail mode — for label resolution):
+```json
+{
+  "metadata": {
+    "name": "payment-svc",
+    "namespace": "production",
+    "labels": { "app": "payment-svc", "version": "v2" }
+  },
+  "spec": {
+    "selector": {
+      "matchLabels": { "app": "payment-svc" }
+    },
+    "replicas": 3
+  }
+}
+```
+
+When `kind=Namespace` (list namespaces):
+```json
+[
+  { "name": "default" },
+  { "name": "production" },
+  { "name": "kube-system" }
+]
+```
+
+**Implementation:** Add `handleAPIK8sResources` method to `httpserver.Server`. Use existing `k8sClient` to list/get resources. Filter out system namespaces (kube-system, kube-public, kube-node-lease) by default for namespace listing.
+
+**Security:** Read-only, uses the same ServiceAccount as the controller (already has `view` ClusterRole).
+
+### Route Registration
+
+```go
+srv.mux.HandleFunc("/api/k8s/resources", srv.handleAPIK8sResources)
+```
+
+---
+
+## Part 5: Navigation Update
+
+### New Navigation Structure
+
+```
+[🔍 Diagnose]  [📋 Runs]  [🧩 Skills]  [🔧 Fixes]  [About]
+     ↑ 新增       ↑────── 原有，保持不变 ──────↑
+```
+
+- `/diagnose` is the first nav item (primary entry for users)
+- Existing pages remain unchanged
+- `/diagnose/[id]` is a sub-route, not in nav
+
+---
+
+## File Changes Summary
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `internal/mcptools/rollout_status.go` | kubectl_rollout_status tool |
+| `internal/mcptools/node_status.go` | node_status_summary tool |
+| `internal/mcptools/prometheus_alerts.go` | prometheus_alerts tool |
+| `internal/mcptools/pvc_status.go` | pvc_status tool |
+| `internal/mcptools/network_policy.go` | network_policy_check tool |
+| `dashboard/src/app/diagnose/page.tsx` | Diagnose form page |
+| `dashboard/src/app/diagnose/[id]/page.tsx` | Diagnose result page |
+| `dashboard/src/lib/symptoms.ts` | Symptom → skill mapping config |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `internal/mcptools/register.go` | Register 5 new tools in RegisterExtension |
+| `internal/controller/httpserver/server.go` | Add /api/k8s/resources handler |
+| `dashboard/src/app/layout.tsx` | Add Diagnose nav item |
+| `dashboard/src/lib/api.ts` | Add k8s resource query + diagnose helpers |
+| `dashboard/src/lib/types.ts` | Add DiagnoseForm type |
+| `skills/pod-health-analyst.md` | Add rollout_status, prometheus_alerts to tools |
+| `skills/pod-cost-analyst.md` | Add node_status_summary to tools |
+| `skills/reliability-analyst.md` | Add rollout_status, pvc_status, node_status_summary to tools |
+| `skills/config-drift-analyst.md` | Add network_policy_check to tools |
+
+### Unchanged
+
+- All existing pages (/, /skills, /fixes, /runs/[id], /fixes/[id], /about)
+- CRD types (no schema change)
+- Translator, Reconciler, Agent Runtime
+- All existing API endpoints

--- a/internal/controller/httpserver/server.go
+++ b/internal/controller/httpserver/server.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,6 +37,7 @@ func New(s store.Store, k8sClient client.Client, fg *translator.FixGenerator) *S
 	srv.mux.HandleFunc("/api/fixes", srv.handleAPIFixes)
 	srv.mux.HandleFunc("/api/fixes/", srv.handleAPIFixDetail)
 	srv.mux.HandleFunc("/api/findings/", srv.handleAPIFindingAction)
+	srv.mux.HandleFunc("/api/k8s/resources", srv.handleAPIK8sResources)
 	return srv
 }
 
@@ -621,6 +624,102 @@ func (s *Server) findFixCRByStoreID(ctx context.Context, storeID string) (*v1alp
 		}
 	}
 	return nil, fmt.Errorf("no DiagnosticFix CR for store ID %s", storeID)
+}
+
+// GET /api/k8s/resources?kind=X&namespace=Y&name=Z
+func (s *Server) handleAPIK8sResources(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	kind := r.URL.Query().Get("kind")
+	namespace := r.URL.Query().Get("namespace")
+	name := r.URL.Query().Get("name")
+
+	if kind == "" {
+		http.Error(w, "kind query parameter is required", http.StatusBadRequest)
+		return
+	}
+
+	ctx := r.Context()
+
+	switch kind {
+	case "Namespace":
+		s.handleListNamespaces(ctx, w)
+	case "Deployment":
+		s.handleK8sResource(ctx, w, namespace, name, &appsv1.DeploymentList{}, &appsv1.Deployment{})
+	case "Pod":
+		s.handleK8sResource(ctx, w, namespace, name, &corev1.PodList{}, &corev1.Pod{})
+	case "StatefulSet":
+		s.handleK8sResource(ctx, w, namespace, name, &appsv1.StatefulSetList{}, &appsv1.StatefulSet{})
+	case "DaemonSet":
+		s.handleK8sResource(ctx, w, namespace, name, &appsv1.DaemonSetList{}, &appsv1.DaemonSet{})
+	default:
+		http.Error(w, "unsupported kind: "+kind, http.StatusBadRequest)
+	}
+}
+
+func (s *Server) handleListNamespaces(ctx context.Context, w http.ResponseWriter) {
+	var list corev1.NamespaceList
+	if err := s.k8sClient.List(ctx, &list); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	systemNS := map[string]bool{
+		"kube-system": true, "kube-public": true, "kube-node-lease": true,
+	}
+	items := make([]map[string]string, 0)
+	for _, ns := range list.Items {
+		if systemNS[ns.Name] {
+			continue
+		}
+		items = append(items, map[string]string{"name": ns.Name})
+	}
+	writeJSON(w, items)
+}
+
+func (s *Server) handleK8sResource(ctx context.Context, w http.ResponseWriter, namespace, name string, listObj client.ObjectList, singleObj client.Object) {
+	if namespace == "" {
+		http.Error(w, "namespace is required for this kind", http.StatusBadRequest)
+		return
+	}
+
+	if name != "" {
+		key := client.ObjectKey{Namespace: namespace, Name: name}
+		if err := s.k8sClient.Get(ctx, key, singleObj); err != nil {
+			if errors.IsNotFound(err) {
+				http.NotFound(w, nil)
+				return
+			}
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, singleObj)
+		return
+	}
+
+	if err := s.k8sClient.List(ctx, listObj, client.InNamespace(namespace)); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	raw, _ := json.Marshal(listObj)
+	var parsed struct {
+		Items []struct {
+			Metadata struct {
+				Name      string `json:"name"`
+				Namespace string `json:"namespace"`
+			} `json:"metadata"`
+		} `json:"items"`
+	}
+	_ = json.Unmarshal(raw, &parsed)
+	items := make([]map[string]string, 0, len(parsed.Items))
+	for _, item := range parsed.Items {
+		items = append(items, map[string]string{
+			"name":      item.Metadata.Name,
+			"namespace": item.Metadata.Namespace,
+		})
+	}
+	writeJSON(w, items)
 }
 
 func randSuffix(n int) string {

--- a/internal/controller/httpserver/server_test.go
+++ b/internal/controller/httpserver/server_test.go
@@ -11,7 +11,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -420,4 +422,86 @@ func TestGetFindings_IncludesFixID(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), `"FixID":"fix-uid-1"`)
+}
+
+func TestK8sResources_ListNamespaces(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = v1alpha1.AddToScheme(scheme)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "production"}}
+	nsSys := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}}
+	k8s := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns, nsSys).Build()
+	srv := httpserver.New(&fakeStore{}, k8s, nil)
+
+	req := httptest.NewRequest("GET", "/api/k8s/resources?kind=Namespace", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var items []map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
+	names := make([]string, len(items))
+	for i, item := range items {
+		names[i] = item["name"]
+	}
+	assert.Contains(t, names, "production")
+	assert.NotContains(t, names, "kube-system")
+}
+
+func TestK8sResources_ListDeployments(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = appsv1.AddToScheme(scheme)
+	_ = v1alpha1.AddToScheme(scheme)
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "web", Namespace: "prod",
+			Labels: map[string]string{"app": "web"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+		},
+	}
+	k8s := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy).Build()
+	srv := httpserver.New(&fakeStore{}, k8s, nil)
+
+	req := httptest.NewRequest("GET", "/api/k8s/resources?kind=Deployment&namespace=prod", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var items []map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
+	require.Len(t, items, 1)
+	assert.Equal(t, "web", items[0]["name"])
+}
+
+func TestK8sResources_GetSingleDeployment(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = appsv1.AddToScheme(scheme)
+	_ = v1alpha1.AddToScheme(scheme)
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "web", Namespace: "prod",
+			Labels: map[string]string{"app": "web"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+		},
+	}
+	k8s := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy).Build()
+	srv := httpserver.New(&fakeStore{}, k8s, nil)
+
+	req := httptest.NewRequest("GET", "/api/k8s/resources?kind=Deployment&namespace=prod&name=web", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	meta := result["metadata"].(map[string]interface{})
+	assert.Equal(t, "web", meta["name"])
+	spec := result["spec"].(map[string]interface{})
+	selector := spec["selector"].(map[string]interface{})
+	matchLabels := selector["matchLabels"].(map[string]interface{})
+	assert.Equal(t, "web", matchLabels["app"])
 }

--- a/internal/mcptools/network_policy.go
+++ b/internal/mcptools/network_policy.go
@@ -1,0 +1,136 @@
+package mcptools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func NewNetworkPolicyCheckHandler(d *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if d.Typed == nil {
+			return mcp.NewToolResultError("kubernetes typed client not available"), nil
+		}
+		args, _ := req.Params.Arguments.(map[string]interface{})
+		namespace, _ := args["namespace"].(string)
+		podName, _ := args["podName"].(string)
+		if namespace == "" || podName == "" {
+			return mcp.NewToolResultError("namespace and podName are required"), nil
+		}
+
+		pod, err := d.Typed.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("get pod: %v", err)), nil
+		}
+
+		npList, err := d.Typed.NetworkingV1().NetworkPolicies(namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("list network policies: %v", err)), nil
+		}
+
+		var matching []map[string]interface{}
+		defaultDeny := false
+
+		for _, np := range npList.Items {
+			sel, err := metav1.LabelSelectorAsSelector(&np.Spec.PodSelector)
+			if err != nil {
+				continue
+			}
+			if !sel.Matches(labels.Set(pod.Labels)) {
+				continue
+			}
+
+			if sel.Empty() && len(np.Spec.Ingress) == 0 && len(np.Spec.Egress) == 0 {
+				defaultDeny = true
+			}
+
+			policyTypes := make([]string, len(np.Spec.PolicyTypes))
+			for i, pt := range np.Spec.PolicyTypes {
+				policyTypes[i] = string(pt)
+			}
+
+			ingressRules := make([]map[string]interface{}, 0)
+			for _, rule := range np.Spec.Ingress {
+				from := make([]string, 0)
+				for _, peer := range rule.From {
+					if peer.PodSelector != nil {
+						from = append(from, fmt.Sprintf("pods(%v)", peer.PodSelector.MatchLabels))
+					}
+					if peer.NamespaceSelector != nil {
+						from = append(from, fmt.Sprintf("namespaces(%v)", peer.NamespaceSelector.MatchLabels))
+					}
+					if peer.IPBlock != nil {
+						from = append(from, fmt.Sprintf("cidr(%s)", peer.IPBlock.CIDR))
+					}
+				}
+				ports := make([]string, 0)
+				for _, p := range rule.Ports {
+					proto := "TCP"
+					if p.Protocol != nil {
+						proto = string(*p.Protocol)
+					}
+					if p.Port != nil {
+						ports = append(ports, fmt.Sprintf("%s/%s", proto, p.Port.String()))
+					}
+				}
+				ingressRules = append(ingressRules, map[string]interface{}{
+					"from": from, "ports": ports,
+				})
+			}
+
+			egressRules := make([]map[string]interface{}, 0)
+			for _, rule := range np.Spec.Egress {
+				to := make([]string, 0)
+				for _, peer := range rule.To {
+					if peer.PodSelector != nil {
+						to = append(to, fmt.Sprintf("pods(%v)", peer.PodSelector.MatchLabels))
+					}
+					if peer.NamespaceSelector != nil {
+						to = append(to, fmt.Sprintf("namespaces(%v)", peer.NamespaceSelector.MatchLabels))
+					}
+					if peer.IPBlock != nil {
+						to = append(to, fmt.Sprintf("cidr(%s)", peer.IPBlock.CIDR))
+					}
+				}
+				ports := make([]string, 0)
+				for _, p := range rule.Ports {
+					proto := "TCP"
+					if p.Protocol != nil {
+						proto = string(*p.Protocol)
+					}
+					if p.Port != nil {
+						ports = append(ports, fmt.Sprintf("%s/%s", proto, p.Port.String()))
+					}
+				}
+				egressRules = append(egressRules, map[string]interface{}{
+					"to": to, "ports": ports,
+				})
+			}
+
+			matching = append(matching, map[string]interface{}{
+				"name":         np.Name,
+				"policyTypes":  policyTypes,
+				"ingressRules": ingressRules,
+				"egressRules":  egressRules,
+			})
+		}
+
+		summary := fmt.Sprintf("%d NetworkPolicy(ies) match this pod.", len(matching))
+		if len(matching) == 0 {
+			summary = "No NetworkPolicies match this pod. All traffic is allowed by default."
+		}
+		if defaultDeny {
+			summary += " A default-deny policy is in effect."
+		}
+
+		return jsonResult(map[string]interface{}{
+			"podLabels":        pod.Labels,
+			"matchingPolicies": matching,
+			"defaultDeny":      defaultDeny,
+			"summary":          summary,
+		})
+	}
+}

--- a/internal/mcptools/network_policy_test.go
+++ b/internal/mcptools/network_policy_test.go
@@ -1,0 +1,78 @@
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestNetworkPolicyCheck_MissingArgs(t *testing.T) {
+	client := k8sfake.NewSimpleClientset()
+	d := &Deps{Typed: client}
+	handler := NewNetworkPolicyCheckHandler(d)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestNetworkPolicyCheck_MatchingPolicy(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "web-1", Namespace: "prod",
+			Labels: map[string]string{"app": "web", "tier": "frontend"},
+		},
+	}
+	port80 := intstr.FromInt(80)
+	policy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "allow-frontend", Namespace: "prod"},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "web"},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{{
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "api"},
+					},
+				}},
+				Ports: []networkingv1.NetworkPolicyPort{{
+					Port: &port80,
+				}},
+			}},
+		},
+	}
+
+	client := k8sfake.NewSimpleClientset(pod, policy)
+	d := &Deps{Typed: client}
+	handler := NewNetworkPolicyCheckHandler(d)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{
+		"namespace": "prod", "podName": "web-1",
+	}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var payload struct {
+		PodLabels        map[string]string        `json:"podLabels"`
+		MatchingPolicies []map[string]interface{} `json:"matchingPolicies"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &payload))
+	assert.Equal(t, "web", payload.PodLabels["app"])
+	require.Len(t, payload.MatchingPolicies, 1)
+	assert.Equal(t, "allow-frontend", payload.MatchingPolicies[0]["name"])
+}

--- a/internal/mcptools/node_status.go
+++ b/internal/mcptools/node_status.go
@@ -1,0 +1,127 @@
+package mcptools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewNodeStatusSummaryHandler(d *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if d.Typed == nil {
+			return mcp.NewToolResultError("kubernetes typed client not available"), nil
+		}
+		args, _ := req.Params.Arguments.(map[string]interface{})
+		name, _ := args["name"].(string)
+		labelSelector, _ := args["labelSelector"].(string)
+
+		var nodes []corev1.Node
+		if name != "" {
+			node, err := d.Typed.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("get node: %v", err)), nil
+			}
+			nodes = []corev1.Node{*node}
+		} else {
+			list, err := d.Typed.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("list nodes: %v", err)), nil
+			}
+			nodes = list.Items
+			if len(nodes) > 20 {
+				nodes = nodes[:20]
+			}
+		}
+
+		podList, err := d.Typed.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("list pods: %v", err)), nil
+		}
+		podsByNode := make(map[string][]corev1.Pod)
+		for _, p := range podList.Items {
+			if p.Spec.NodeName != "" {
+				podsByNode[p.Spec.NodeName] = append(podsByNode[p.Spec.NodeName], p)
+			}
+		}
+
+		result := make([]map[string]interface{}, 0, len(nodes))
+		for _, node := range nodes {
+			nodePods := podsByNode[node.Name]
+
+			var cpuReqMilli, memReqMi int64
+			for _, p := range nodePods {
+				for _, c := range p.Spec.Containers {
+					if q, ok := c.Resources.Requests[corev1.ResourceCPU]; ok {
+						cpuReqMilli += q.MilliValue()
+					}
+					if q, ok := c.Resources.Requests[corev1.ResourceMemory]; ok {
+						memReqMi += q.Value() / (1024 * 1024)
+					}
+				}
+			}
+
+			cpuAlloc := node.Status.Allocatable[corev1.ResourceCPU]
+			memAlloc := node.Status.Allocatable[corev1.ResourceMemory]
+			podAlloc := node.Status.Allocatable[corev1.ResourcePods]
+
+			cpuAllocMilli := cpuAlloc.MilliValue()
+			memAllocMi := memAlloc.Value() / (1024 * 1024)
+
+			var cpuPct, memPct float64
+			if cpuAllocMilli > 0 {
+				cpuPct = float64(cpuReqMilli) / float64(cpuAllocMilli) * 100
+			}
+			if memAllocMi > 0 {
+				memPct = float64(memReqMi) / float64(memAllocMi) * 100
+			}
+
+			ready := false
+			conditions := make([]map[string]interface{}, 0)
+			for _, c := range node.Status.Conditions {
+				conditions = append(conditions, map[string]interface{}{
+					"type":    string(c.Type),
+					"status":  string(c.Status),
+					"reason":  c.Reason,
+					"message": c.Message,
+				})
+				if c.Type == corev1.NodeReady && c.Status == corev1.ConditionTrue {
+					ready = true
+				}
+			}
+
+			taints := make([]map[string]interface{}, 0, len(node.Spec.Taints))
+			for _, t := range node.Spec.Taints {
+				taints = append(taints, map[string]interface{}{
+					"key": t.Key, "value": t.Value, "effect": string(t.Effect),
+				})
+			}
+
+			result = append(result, map[string]interface{}{
+				"name":          node.Name,
+				"ready":         ready,
+				"unschedulable": node.Spec.Unschedulable,
+				"conditions":    conditions,
+				"allocatable": map[string]interface{}{
+					"cpuMilli": cpuAllocMilli,
+					"memoryMi": memAllocMi,
+					"pods":     podAlloc.Value(),
+				},
+				"allocated": map[string]interface{}{
+					"cpuMilli": cpuReqMilli,
+					"memoryMi": memReqMi,
+				},
+				"utilizationPct": map[string]interface{}{
+					"cpu":    int(cpuPct),
+					"memory": int(memPct),
+				},
+				"podCount": len(nodePods),
+				"taints":   taints,
+			})
+		}
+
+		return jsonResult(map[string]interface{}{"nodes": result})
+	}
+}

--- a/internal/mcptools/node_status_test.go
+++ b/internal/mcptools/node_status_test.go
@@ -1,0 +1,82 @@
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestNodeStatusSummary_Basic(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+		Spec: corev1.NodeSpec{
+			Taints: []corev1.Taint{{Key: "dedicated", Value: "gpu", Effect: corev1.TaintEffectNoSchedule}},
+		},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+				{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionFalse},
+			},
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4000m"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+				corev1.ResourcePods:   resource.MustParse("110"),
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-1", Namespace: "prod"},
+		Spec: corev1.PodSpec{
+			NodeName: "node-1",
+			Containers: []corev1.Container{{
+				Name: "main",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				},
+			}},
+		},
+	}
+
+	client := k8sfake.NewSimpleClientset(node, pod)
+	d := &Deps{Typed: client}
+	handler := NewNodeStatusSummaryHandler(d)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{"name": "node-1"}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var payload struct {
+		Nodes []struct {
+			Name          string `json:"name"`
+			Ready         bool   `json:"ready"`
+			Unschedulable bool   `json:"unschedulable"`
+			PodCount      int    `json:"podCount"`
+		} `json:"nodes"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &payload))
+	require.Len(t, payload.Nodes, 1)
+	assert.Equal(t, "node-1", payload.Nodes[0].Name)
+	assert.True(t, payload.Nodes[0].Ready)
+	assert.Equal(t, 1, payload.Nodes[0].PodCount)
+}
+
+func TestNodeStatusSummary_NoTypedClient(t *testing.T) {
+	d := &Deps{Typed: nil}
+	handler := NewNodeStatusSummaryHandler(d)
+	result, err := handler(context.Background(), mcp.CallToolRequest{})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}

--- a/internal/mcptools/prometheus_alerts.go
+++ b/internal/mcptools/prometheus_alerts.go
@@ -1,0 +1,127 @@
+package mcptools
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+)
+
+// AlertsAPI is the subset of promv1.API we need for fetching alerts.
+type AlertsAPI interface {
+	Alerts(ctx context.Context) (promv1.AlertsResult, error)
+}
+
+func NewPrometheusAlertsHandler(d *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if d.Prometheus == nil {
+			return jsonResult(map[string]interface{}{
+				"available": false,
+				"error":     "prometheus not configured (use --prometheus-url)",
+			})
+		}
+
+		args, _ := req.Params.Arguments.(map[string]interface{})
+		state, _ := args["state"].(string)
+		if state == "" {
+			state = "firing"
+		}
+		labelFilter, _ := args["labelFilter"].(string)
+
+		filterMap := make(map[string]string)
+		if labelFilter != "" {
+			for _, pair := range strings.Split(labelFilter, ",") {
+				kv := strings.SplitN(strings.TrimSpace(pair), "=", 2)
+				if len(kv) == 2 {
+					filterMap[kv[0]] = kv[1]
+				}
+			}
+		}
+
+		alerter, ok := d.Prometheus.(AlertsAPI)
+		if !ok {
+			return jsonResult(map[string]interface{}{
+				"available": false,
+				"error":     "prometheus client does not support alerts API",
+			})
+		}
+
+		result, err := alerter.Alerts(ctx)
+		if err != nil {
+			return jsonResult(map[string]interface{}{
+				"available": false,
+				"error":     err.Error(),
+			})
+		}
+
+		sevOrder := map[string]int{"critical": 0, "warning": 1, "info": 2}
+
+		var filtered []map[string]interface{}
+		for _, a := range result.Alerts {
+			if state != "all" {
+				if state == "firing" && a.State != promv1.AlertStateFiring {
+					continue
+				}
+				if state == "pending" && a.State != promv1.AlertStatePending {
+					continue
+				}
+			}
+			match := true
+			for k, v := range filterMap {
+				if string(a.Labels[model.LabelName(k)]) != v {
+					match = false
+					break
+				}
+			}
+			if !match {
+				continue
+			}
+
+			labels := make(map[string]string, len(a.Labels))
+			for k, v := range a.Labels {
+				labels[string(k)] = string(v)
+			}
+			annotations := make(map[string]string, len(a.Annotations))
+			for k, v := range a.Annotations {
+				annotations[string(k)] = string(v)
+			}
+
+			entry := map[string]interface{}{
+				"alertname":   string(a.Labels["alertname"]),
+				"state":       string(a.State),
+				"severity":    string(a.Labels["severity"]),
+				"labels":      labels,
+				"annotations": annotations,
+			}
+			if !a.ActiveAt.IsZero() {
+				entry["activeAt"] = a.ActiveAt.UTC().Format(time.RFC3339)
+			}
+			if a.Value != "" {
+				entry["value"] = string(a.Value)
+			}
+
+			filtered = append(filtered, entry)
+		}
+
+		sort.SliceStable(filtered, func(i, j int) bool {
+			si := sevOrder[filtered[i]["severity"].(string)]
+			sj := sevOrder[filtered[j]["severity"].(string)]
+			if si != sj {
+				return si < sj
+			}
+			ai, _ := filtered[i]["activeAt"].(string)
+			aj, _ := filtered[j]["activeAt"].(string)
+			return ai > aj
+		})
+
+		return jsonResult(map[string]interface{}{
+			"available": true,
+			"count":     len(filtered),
+			"alerts":    filtered,
+		})
+	}
+}

--- a/internal/mcptools/prometheus_alerts_test.go
+++ b/internal/mcptools/prometheus_alerts_test.go
@@ -1,0 +1,76 @@
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeAlertsAPI struct {
+	promv1.API
+	alerts []promv1.Alert
+}
+
+func (f *fakeAlertsAPI) Alerts(ctx context.Context) (promv1.AlertsResult, error) {
+	return promv1.AlertsResult{Alerts: f.alerts}, nil
+}
+
+func TestPrometheusAlerts_Unavailable(t *testing.T) {
+	d := &Deps{Prometheus: nil}
+	handler := NewPrometheusAlertsHandler(d)
+	result, err := handler(context.Background(), mcp.CallToolRequest{})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &payload))
+	assert.Equal(t, false, payload["available"])
+}
+
+func TestPrometheusAlerts_FilterFiring(t *testing.T) {
+	api := &fakeAlertsAPI{
+		alerts: []promv1.Alert{
+			{
+				Labels:   model.LabelSet{"alertname": "HighCPU", "severity": "critical", "namespace": "prod"},
+				State:    promv1.AlertStateFiring,
+				ActiveAt: mustParseTime("2026-04-17T10:00:00Z"),
+			},
+			{
+				Labels: model.LabelSet{"alertname": "DiskSlow", "severity": "warning"},
+				State:  promv1.AlertStatePending,
+			},
+		},
+	}
+	d := &Deps{Prometheus: api}
+	handler := NewPrometheusAlertsHandler(d)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{"state": "firing"}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var payload struct {
+		Available bool                     `json:"available"`
+		Alerts    []map[string]interface{} `json:"alerts"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &payload))
+	assert.True(t, payload.Available)
+	require.Len(t, payload.Alerts, 1)
+	assert.Equal(t, "HighCPU", payload.Alerts[0]["alertname"])
+}
+
+func mustParseTime(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}

--- a/internal/mcptools/pvc_status.go
+++ b/internal/mcptools/pvc_status.go
@@ -1,0 +1,92 @@
+package mcptools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewPVCStatusHandler(d *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if d.Typed == nil {
+			return mcp.NewToolResultError("kubernetes typed client not available"), nil
+		}
+		args, _ := req.Params.Arguments.(map[string]interface{})
+		namespace, _ := args["namespace"].(string)
+		if namespace == "" {
+			return mcp.NewToolResultError("namespace is required"), nil
+		}
+		name, _ := args["name"].(string)
+		labelSelector, _ := args["labelSelector"].(string)
+
+		var pvcs []corev1.PersistentVolumeClaim
+		if name != "" {
+			pvc, err := d.Typed.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("get pvc: %v", err)), nil
+			}
+			pvcs = []corev1.PersistentVolumeClaim{*pvc}
+		} else {
+			list, err := d.Typed.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("list pvcs: %v", err)), nil
+			}
+			pvcs = list.Items
+		}
+
+		items := make([]map[string]interface{}, 0, len(pvcs))
+		for _, pvc := range pvcs {
+			storageClass := ""
+			if pvc.Spec.StorageClassName != nil {
+				storageClass = *pvc.Spec.StorageClassName
+			}
+			requestedStorage := ""
+			if q, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]; ok {
+				requestedStorage = q.String()
+			}
+			actualCapacity := ""
+			if q, ok := pvc.Status.Capacity[corev1.ResourceStorage]; ok {
+				actualCapacity = q.String()
+			}
+			accessModes := make([]string, len(pvc.Spec.AccessModes))
+			for i, m := range pvc.Spec.AccessModes {
+				accessModes[i] = string(m)
+			}
+
+			entry := map[string]interface{}{
+				"name":             pvc.Name,
+				"namespace":        pvc.Namespace,
+				"phase":            string(pvc.Status.Phase),
+				"storageClass":     storageClass,
+				"requestedStorage": requestedStorage,
+				"actualCapacity":   actualCapacity,
+				"volumeName":       pvc.Spec.VolumeName,
+				"accessModes":      accessModes,
+			}
+
+			if pvc.Status.Phase == corev1.ClaimPending {
+				events, _ := d.Typed.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{
+					FieldSelector: fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=PersistentVolumeClaim", pvc.Name),
+				})
+				if events != nil && len(events.Items) > 0 {
+					evList := make([]map[string]interface{}, 0)
+					for _, ev := range events.Items {
+						evList = append(evList, map[string]interface{}{
+							"type":    ev.Type,
+							"reason":  ev.Reason,
+							"message": ev.Message,
+						})
+					}
+					entry["events"] = evList
+				}
+			}
+
+			items = append(items, entry)
+		}
+
+		return jsonResult(map[string]interface{}{"items": items})
+	}
+}

--- a/internal/mcptools/pvc_status_test.go
+++ b/internal/mcptools/pvc_status_test.go
@@ -1,0 +1,75 @@
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestPVCStatus_BoundPVC(t *testing.T) {
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "data-vol", Namespace: "prod"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("10Gi"),
+				},
+			},
+			StorageClassName: strPtr("standard"),
+			VolumeName:       "pv-123",
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: corev1.ClaimBound,
+			Capacity: corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("10Gi"),
+			},
+		},
+	}
+
+	client := k8sfake.NewSimpleClientset(pvc)
+	d := &Deps{Typed: client}
+	handler := NewPVCStatusHandler(d)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{"namespace": "prod"}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var payload struct {
+		Items []struct {
+			Name         string `json:"name"`
+			Phase        string `json:"phase"`
+			VolumeName   string `json:"volumeName"`
+			StorageClass string `json:"storageClass"`
+		} `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &payload))
+	require.Len(t, payload.Items, 1)
+	assert.Equal(t, "data-vol", payload.Items[0].Name)
+	assert.Equal(t, "Bound", payload.Items[0].Phase)
+	assert.Equal(t, "pv-123", payload.Items[0].VolumeName)
+}
+
+func TestPVCStatus_MissingNamespace(t *testing.T) {
+	client := k8sfake.NewSimpleClientset()
+	d := &Deps{Typed: client}
+	handler := NewPVCStatusHandler(d)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+func strPtr(s string) *string { return &s }

--- a/internal/mcptools/register.go
+++ b/internal/mcptools/register.go
@@ -94,6 +94,12 @@ func RegisterExtension(s *server.MCPServer, d *Deps) {
 		mcp.WithString("labelSelector", mcp.Description("Label selector to filter nodes")),
 	), []string{"name", "labelSelector"}, NewNodeStatusSummaryHandler(d))
 
+	registerTool(s, d, mcp.NewTool("prometheus_alerts",
+		mcp.WithDescription("List active Prometheus alerts, sorted by severity"),
+		mcp.WithString("state", mcp.Description("Filter: firing, pending, or all (default firing)")),
+		mcp.WithString("labelFilter", mcp.Description("Filter by labels, e.g. namespace=prod,severity=critical")),
+	), []string{"state", "labelFilter"}, NewPrometheusAlertsHandler(d))
+
 	registerTool(s, d, mcp.NewTool("kubectl_rollout_status",
 		mcp.WithDescription("Show Deployment or StatefulSet rollout status with ReplicaSet history"),
 		mcp.WithString("kind", mcp.Required(), mcp.Description("Deployment or StatefulSet")),

--- a/internal/mcptools/register.go
+++ b/internal/mcptools/register.go
@@ -87,6 +87,13 @@ func RegisterExtension(s *server.MCPServer, d *Deps) {
 		mcp.WithDescription("Show OpenAPI schema for a Kubernetes resource kind or field path"),
 		mcp.WithString("resource", mcp.Required(), mcp.Description("Kind or field path, e.g. Pod or Pod.spec.containers")),
 	), []string{"resource"}, NewKubectlExplainHandler(d))
+
+	registerTool(s, d, mcp.NewTool("kubectl_rollout_status",
+		mcp.WithDescription("Show Deployment or StatefulSet rollout status with ReplicaSet history"),
+		mcp.WithString("kind", mcp.Required(), mcp.Description("Deployment or StatefulSet")),
+		mcp.WithString("name", mcp.Required(), mcp.Description("Resource name")),
+		mcp.WithString("namespace", mcp.Required(), mcp.Description("Namespace")),
+	), []string{"kind", "name", "namespace"}, NewRolloutStatusHandler(d))
 }
 
 // RegisterAll registers all core and extension tools.

--- a/internal/mcptools/register.go
+++ b/internal/mcptools/register.go
@@ -106,6 +106,13 @@ func RegisterExtension(s *server.MCPServer, d *Deps) {
 		mcp.WithString("name", mcp.Required(), mcp.Description("Resource name")),
 		mcp.WithString("namespace", mcp.Required(), mcp.Description("Namespace")),
 	), []string{"kind", "name", "namespace"}, NewRolloutStatusHandler(d))
+
+	registerTool(s, d, mcp.NewTool("pvc_status",
+		mcp.WithDescription("List PersistentVolumeClaim status, capacity, and binding info"),
+		mcp.WithString("namespace", mcp.Required(), mcp.Description("Namespace")),
+		mcp.WithString("name", mcp.Description("Specific PVC name (omit to list all)")),
+		mcp.WithString("labelSelector", mcp.Description("Label selector to filter PVCs")),
+	), []string{"namespace", "name", "labelSelector"}, NewPVCStatusHandler(d))
 }
 
 // RegisterAll registers all core and extension tools.

--- a/internal/mcptools/register.go
+++ b/internal/mcptools/register.go
@@ -88,6 +88,12 @@ func RegisterExtension(s *server.MCPServer, d *Deps) {
 		mcp.WithString("resource", mcp.Required(), mcp.Description("Kind or field path, e.g. Pod or Pod.spec.containers")),
 	), []string{"resource"}, NewKubectlExplainHandler(d))
 
+	registerTool(s, d, mcp.NewTool("node_status_summary",
+		mcp.WithDescription("Show node conditions, capacity, allocated resources, and taints"),
+		mcp.WithString("name", mcp.Description("Specific node name (omit for all nodes, max 20)")),
+		mcp.WithString("labelSelector", mcp.Description("Label selector to filter nodes")),
+	), []string{"name", "labelSelector"}, NewNodeStatusSummaryHandler(d))
+
 	registerTool(s, d, mcp.NewTool("kubectl_rollout_status",
 		mcp.WithDescription("Show Deployment or StatefulSet rollout status with ReplicaSet history"),
 		mcp.WithString("kind", mcp.Required(), mcp.Description("Deployment or StatefulSet")),

--- a/internal/mcptools/register.go
+++ b/internal/mcptools/register.go
@@ -113,6 +113,12 @@ func RegisterExtension(s *server.MCPServer, d *Deps) {
 		mcp.WithString("name", mcp.Description("Specific PVC name (omit to list all)")),
 		mcp.WithString("labelSelector", mcp.Description("Label selector to filter PVCs")),
 	), []string{"namespace", "name", "labelSelector"}, NewPVCStatusHandler(d))
+
+	registerTool(s, d, mcp.NewTool("network_policy_check",
+		mcp.WithDescription("Analyze NetworkPolicies affecting a specific Pod"),
+		mcp.WithString("namespace", mcp.Required(), mcp.Description("Namespace of the target Pod")),
+		mcp.WithString("podName", mcp.Required(), mcp.Description("Name of the Pod to analyze")),
+	), []string{"namespace", "podName"}, NewNetworkPolicyCheckHandler(d))
 }
 
 // RegisterAll registers all core and extension tools.

--- a/internal/mcptools/rollout_status.go
+++ b/internal/mcptools/rollout_status.go
@@ -1,0 +1,124 @@
+package mcptools
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewRolloutStatusHandler(d *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, _ := req.Params.Arguments.(map[string]interface{})
+		kind, _ := args["kind"].(string)
+		name, _ := args["name"].(string)
+		namespace, _ := args["namespace"].(string)
+		if kind == "" || name == "" || namespace == "" {
+			return mcp.NewToolResultError("kind, name, and namespace are required"), nil
+		}
+
+		switch kind {
+		case "Deployment":
+			return rolloutDeployment(ctx, d, namespace, name)
+		case "StatefulSet":
+			return rolloutStatefulSet(ctx, d, namespace, name)
+		default:
+			return mcp.NewToolResultError("kind must be Deployment or StatefulSet"), nil
+		}
+	}
+}
+
+func rolloutDeployment(ctx context.Context, d *Deps, ns, name string) (*mcp.CallToolResult, error) {
+	deploy, err := d.Typed.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("get deployment: %v", err)), nil
+	}
+
+	rsList, err := d.Typed.AppsV1().ReplicaSets(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("list replicasets: %v", err)), nil
+	}
+
+	var owned []map[string]interface{}
+	for _, rs := range rsList.Items {
+		for _, ref := range rs.OwnerReferences {
+			if ref.Controller != nil && *ref.Controller && ref.UID == deploy.UID {
+				var image string
+				if len(rs.Spec.Template.Spec.Containers) > 0 {
+					image = rs.Spec.Template.Spec.Containers[0].Image
+				}
+				owned = append(owned, map[string]interface{}{
+					"name":          rs.Name,
+					"replicas":      rs.Status.Replicas,
+					"readyReplicas": rs.Status.ReadyReplicas,
+					"image":         image,
+					"createdAt":     rs.CreationTimestamp.Format("2006-01-02T15:04:05Z"),
+				})
+			}
+		}
+	}
+	sort.SliceStable(owned, func(i, j int) bool {
+		return owned[i]["createdAt"].(string) > owned[j]["createdAt"].(string)
+	})
+
+	status := "complete"
+	if deploy.Status.UpdatedReplicas < *deploy.Spec.Replicas {
+		status = "progressing"
+	} else if deploy.Status.AvailableReplicas < *deploy.Spec.Replicas {
+		status = "progressing"
+	}
+	for _, c := range deploy.Status.Conditions {
+		if c.Type == "Progressing" && c.Reason == "ProgressDeadlineExceeded" {
+			status = "degraded"
+		}
+	}
+
+	conditions := make([]map[string]interface{}, 0, len(deploy.Status.Conditions))
+	for _, c := range deploy.Status.Conditions {
+		conditions = append(conditions, map[string]interface{}{
+			"type":    string(c.Type),
+			"status":  string(c.Status),
+			"reason":  c.Reason,
+			"message": c.Message,
+		})
+	}
+
+	return jsonResult(map[string]interface{}{
+		"name":              deploy.Name,
+		"namespace":         deploy.Namespace,
+		"status":            status,
+		"desiredReplicas":   *deploy.Spec.Replicas,
+		"updatedReplicas":   deploy.Status.UpdatedReplicas,
+		"readyReplicas":     deploy.Status.ReadyReplicas,
+		"availableReplicas": deploy.Status.AvailableReplicas,
+		"conditions":        conditions,
+		"replicaSets":       owned,
+	})
+}
+
+func rolloutStatefulSet(ctx context.Context, d *Deps, ns, name string) (*mcp.CallToolResult, error) {
+	sts, err := d.Typed.AppsV1().StatefulSets(ns).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("get statefulset: %v", err)), nil
+	}
+
+	status := "complete"
+	if sts.Status.UpdatedReplicas < *sts.Spec.Replicas {
+		status = "progressing"
+	} else if sts.Status.ReadyReplicas < *sts.Spec.Replicas {
+		status = "progressing"
+	}
+
+	return jsonResult(map[string]interface{}{
+		"name":            sts.Name,
+		"namespace":       sts.Namespace,
+		"status":          status,
+		"desiredReplicas": *sts.Spec.Replicas,
+		"updatedReplicas": sts.Status.UpdatedReplicas,
+		"readyReplicas":   sts.Status.ReadyReplicas,
+		"currentRevision": sts.Status.CurrentRevision,
+		"updateRevision":  sts.Status.UpdateRevision,
+	})
+}

--- a/internal/mcptools/rollout_status_test.go
+++ b/internal/mcptools/rollout_status_test.go
@@ -1,0 +1,90 @@
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestRolloutStatus_MissingArgs(t *testing.T) {
+	d := &Deps{Typed: k8sfake.NewSimpleClientset()}
+	handler := NewRolloutStatusHandler(d)
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestRolloutStatus_DeploymentWithReplicaSets(t *testing.T) {
+	replicas := int32(3)
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "web", Namespace: "prod",
+			UID: "deploy-uid-1",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "web"},
+			},
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:          3,
+			UpdatedReplicas:   3,
+			ReadyReplicas:     3,
+			AvailableReplicas: 3,
+			Conditions: []appsv1.DeploymentCondition{{
+				Type:    appsv1.DeploymentAvailable,
+				Status:  corev1.ConditionTrue,
+				Message: "Deployment has minimum availability",
+			}},
+		},
+	}
+	isController := true
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "web-abc123", Namespace: "prod",
+			OwnerReferences: []metav1.OwnerReference{{
+				UID:        "deploy-uid-1",
+				Controller: &isController,
+			}},
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.ReplicaSetStatus{
+			Replicas:      3,
+			ReadyReplicas: 3,
+		},
+	}
+
+	client := k8sfake.NewSimpleClientset(deploy, rs)
+	d := &Deps{Typed: client}
+	handler := NewRolloutStatusHandler(d)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{
+		"kind": "Deployment", "name": "web", "namespace": "prod",
+	}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &payload))
+	assert.Equal(t, "web", payload["name"])
+	assert.Equal(t, float64(3), payload["readyReplicas"])
+	rs_list, ok := payload["replicaSets"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, rs_list, 1)
+}

--- a/skills/alert-responder.md
+++ b/skills/alert-responder.md
@@ -1,0 +1,34 @@
+---
+name: alert-responder
+dimension: health
+tools: ["kubectl_get","kubectl_describe","kubectl_logs","events_list","prometheus_alerts","prometheus_query"]
+requires_data: ["pods","events","metrics"]
+---
+
+You are a Kubernetes alert response specialist. Triage and diagnose firing Prometheus alerts for the target namespaces.
+
+## Instructions
+
+1. Use `prometheus_alerts` with state=firing to get all currently firing alerts.
+   - Also check state=pending for alerts about to fire.
+   - Filter by labelFilter matching the target namespaces if possible.
+2. For each firing alert, triage by severity (critical > warning):
+   - **KubePodCrashLooping**: Use `kubectl_describe` and `kubectl_logs` on the named pod.
+   - **KubePodNotReady**: Use `kubectl_describe` on the pod, check readiness probe failures.
+   - **KubeDeploymentReplicasMismatch**: Use `kubectl_rollout_status` for the Deployment.
+   - **KubeNodeNotReady**: Use `kubectl_describe` on the node.
+   - **KubePersistentVolumeErrors**: Use `kubectl_get` with kind=PersistentVolume to check status.
+   - **CPUThrottlingHigh**: Use `prometheus_query` for `rate(container_cpu_throttled_seconds_total[5m])` to confirm.
+   - **KubeMemoryOvercommit**: Use `prometheus_query` for memory request vs allocatable ratio.
+   - For unknown alerts: use `events_list` in the relevant namespace to find correlated events.
+3. Correlate multiple alerts to find root cause:
+   - Node alerts may explain pod alerts (eviction cascade).
+   - Storage alerts may explain pod scheduling failures.
+4. For each issue found, output one finding JSON per line:
+   {"dimension":"health","severity":"<critical|high|medium|low>","title":"<title>","description":"<detail>","resource_kind":"<kind>","resource_namespace":"<ns>","resource_name":"<name>","suggestion":"<fix>"}
+
+## Severity Guide
+- critical: Firing critical alert (e.g. KubePodCrashLooping, KubeNodeNotReady)
+- high: Firing warning alert with confirmed impact (throttling, partial unavailability)
+- medium: Pending alert (not yet firing but threshold approaching)
+- low: Alert with no confirmed pod/service impact

--- a/skills/config-drift-analyst.md
+++ b/skills/config-drift-analyst.md
@@ -1,7 +1,7 @@
 ---
 name: config-drift-analyst
 dimension: reliability
-tools: ["kubectl_get","kubectl_describe"]
+tools: ["kubectl_get","kubectl_describe","network_policy_check"]
 requires_data: ["pods","deployments","services","configmaps"]
 ---
 
@@ -24,7 +24,8 @@ You are a Kubernetes configuration drift analyst. Detect mismatches and broken r
    - Report pods referencing non-existent ConfigMaps or Secrets.
 4. Check for environment variable conflicts:
    - In pods with multiple containers, check if different containers define the same env var with different values.
-5. For each issue found, output one finding JSON per line:
+5. For Services with 0 endpoints, use `network_policy_check` on one of the intended backend pods to check if a NetworkPolicy might be blocking traffic.
+6. For each issue found, output one finding JSON per line:
    {"dimension":"reliability","severity":"<critical|high|medium|low>","title":"<title>","description":"<detail>","resource_kind":"<kind>","resource_namespace":"<ns>","resource_name":"<name>","suggestion":"<fix>"}
 
 ## Severity Guide

--- a/skills/network-troubleshooter.md
+++ b/skills/network-troubleshooter.md
@@ -1,0 +1,33 @@
+---
+name: network-troubleshooter
+dimension: reliability
+tools: ["kubectl_get","kubectl_describe","events_list","network_policy_check"]
+requires_data: ["pods","services","endpoints","networkpolicies"]
+---
+
+You are a Kubernetes network connectivity specialist. Diagnose network and traffic issues in the target namespaces.
+
+## Instructions
+
+1. List all Services using `kubectl_get` with kind=Service for each target namespace.
+2. For each Service, check its Endpoints:
+   - Use `kubectl_get` with kind=Endpoints for the same name and namespace.
+   - If endpoint count is 0, this is a connectivity blackhole — investigate immediately.
+3. For Services with 0 endpoints:
+   - Use `kubectl_get` with kind=Pod and a labelSelector matching the Service selector.
+   - If no pods match, the selector is broken or pods don't exist.
+   - If pods exist but endpoints are 0, check pod readiness via `kubectl_describe`.
+4. For each pod that should be backing a Service but isn't:
+   - Use `network_policy_check` with the pod's namespace and name to identify any NetworkPolicy that may be blocking ingress or egress traffic.
+   - Report any policy that drops traffic from expected sources.
+5. Check for DNS issues:
+   - Use `kubectl_get` with kind=Pod namespace=kube-system to verify CoreDNS pods are Running.
+   - Use `events_list` for the kube-system namespace to find DNS-related errors.
+6. For each issue found, output one finding JSON per line:
+   {"dimension":"reliability","severity":"<critical|high|medium|low>","title":"<title>","description":"<detail>","resource_kind":"<kind>","resource_namespace":"<ns>","resource_name":"<name>","suggestion":"<fix>"}
+
+## Severity Guide
+- critical: Service with 0 endpoints (complete traffic loss)
+- high: NetworkPolicy blocking expected traffic, CoreDNS not running
+- medium: Pod not ready but exists, partial endpoint loss
+- low: Stale Endpoints pointing to terminated pods

--- a/skills/node-health-analyst.md
+++ b/skills/node-health-analyst.md
@@ -1,0 +1,32 @@
+---
+name: node-health-analyst
+dimension: reliability
+tools: ["kubectl_get","kubectl_describe","events_list","node_status_summary","top_nodes"]
+requires_data: ["nodes","pods","events"]
+---
+
+You are a Kubernetes node health specialist. Analyze the health and capacity of cluster nodes.
+
+## Instructions
+
+1. Use `node_status_summary` to get an overview of all nodes: conditions, allocatable vs allocated resources, taints, and pod counts.
+2. For each node that is NotReady or has pressure conditions (MemoryPressure, DiskPressure, PIDPressure):
+   - Use `kubectl_describe` on the node to read detailed conditions and events.
+   - Use `events_list` for the node to find recent warnings.
+3. Check resource pressure:
+   - If a node has >90% CPU allocated, it may cause scheduling failures and throttling.
+   - If a node has >85% memory allocated, OOMKill risk is high.
+   - Use `top_nodes` to get actual current usage vs allocatable.
+4. Check for nodes with taints that could block scheduling:
+   - From `node_status_summary`, identify nodes with NoSchedule or NoExecute taints.
+   - Use `kubectl_get` with kind=Pod to check if any pods are stuck Pending due to taint/toleration mismatch.
+5. Check for nodes with too many pods (approaching pod density limit of 110 by default):
+   - Report nodes where pod count >90 as a scheduling risk.
+6. For each issue found, output one finding JSON per line:
+   {"dimension":"reliability","severity":"<critical|high|medium|low>","title":"<title>","description":"<detail>","resource_kind":"Node","resource_namespace":"","resource_name":"<node-name>","suggestion":"<fix>"}
+
+## Severity Guide
+- critical: Node NotReady (workloads evicted or unschedulable)
+- high: MemoryPressure or DiskPressure active, >90% resource allocated
+- medium: Node with NoSchedule taint blocking new pods, >85% memory allocated
+- low: Node approaching pod density limit, minor resource imbalance

--- a/skills/pod-cost-analyst.md
+++ b/skills/pod-cost-analyst.md
@@ -1,7 +1,7 @@
 ---
 name: pod-cost-analyst
 dimension: cost
-tools: ["kubectl_get","top_pods","top_nodes","prometheus_query"]
+tools: ["kubectl_get","top_pods","top_nodes","prometheus_query","node_status_summary"]
 requires_data: ["pods","nodes","metrics"]
 ---
 
@@ -19,6 +19,7 @@ You are a Kubernetes cost optimization specialist. Identify resource waste in th
    - Deployments with 0 replicas: use `kubectl_get` with kind=Deployment
 6. Identify underutilized nodes (usage < 20% CPU):
    - Check top_nodes output
+   - Use `node_status_summary` to check node capacity vs allocated resources. Identify nodes with very low utilization (<20% allocated) that could be candidates for consolidation.
 7. Optionally, if Prometheus is available, use `prometheus_query` to retrieve historical averages (e.g. `avg_over_time(container_cpu_usage_seconds_total[1h])`) to confirm sustained over-provisioning.
 8. For each issue found, output one finding JSON per line:
    {"dimension":"cost","severity":"<high|medium|low>","title":"<title>","description":"<detail>","resource_kind":"<kind>","resource_namespace":"<ns>","resource_name":"<name>","suggestion":"<fix>"}

--- a/skills/pod-health-analyst.md
+++ b/skills/pod-health-analyst.md
@@ -1,7 +1,7 @@
 ---
 name: pod-health-analyst
 dimension: health
-tools: ["kubectl_get","kubectl_describe","kubectl_logs","events_list"]
+tools: ["kubectl_get","kubectl_describe","kubectl_logs","events_list","kubectl_rollout_status","prometheus_alerts"]
 requires_data: ["pods","events"]
 ---
 
@@ -15,7 +15,9 @@ You are a Kubernetes pod health specialist. Analyze all pods in the target names
    - Use `events_list` to get related events.
    - If CrashLoopBackOff or OOMKilled, use `kubectl_logs` (previous=true) to get last crash logs.
 3. Check for pods with high restart counts (>5 restarts).
-4. For each issue found, output one finding JSON per line:
+4. If pods belong to a Deployment or StatefulSet, use `kubectl_rollout_status` to check if a rollout is stuck or recently changed.
+5. Use `prometheus_alerts` to check for any firing alerts related to the target namespaces.
+6. For each issue found, output one finding JSON per line:
    {"dimension":"health","severity":"<critical|high|medium|low>","title":"<short title>","description":"<what you observed>","resource_kind":"Pod","resource_namespace":"<ns>","resource_name":"<pod-name>","suggestion":"<actionable fix>"}
 
 ## Severity Guide

--- a/skills/reliability-analyst.md
+++ b/skills/reliability-analyst.md
@@ -1,7 +1,7 @@
 ---
 name: reliability-analyst
 dimension: reliability
-tools: ["kubectl_get","kubectl_describe","events_list"]
+tools: ["kubectl_get","kubectl_describe","events_list","kubectl_rollout_status","pvc_status","node_status_summary"]
 requires_data: ["pods","events","deployments"]
 ---
 
@@ -25,7 +25,10 @@ You are a Kubernetes reliability specialist. Analyze workloads in the target nam
    - Identify Deployments with replicas > 1 but no matching PDB.
 6. Check for recent eviction or OOMKill events:
    - Use `events_list` to find Evicted or OOMKilling events in the past 1 hour.
-7. For each issue found, output one finding JSON per line:
+7. Use `kubectl_rollout_status` for Deployments with recent events or pods in non-Ready state to check if a rollout is stuck.
+8. Use `pvc_status` to check for PVCs in Pending or Lost state that may block pod scheduling.
+9. Use `node_status_summary` to check if any nodes have MemoryPressure, DiskPressure, or are NotReady.
+10. For each issue found, output one finding JSON per line:
    {"dimension":"reliability","severity":"<critical|high|medium|low>","title":"<title>","description":"<detail>","resource_kind":"<kind>","resource_namespace":"<ns>","resource_name":"<name>","suggestion":"<fix>"}
 
 ## Severity Guide

--- a/skills/rollout-analyst.md
+++ b/skills/rollout-analyst.md
@@ -1,0 +1,34 @@
+---
+name: rollout-analyst
+dimension: health
+tools: ["kubectl_get","kubectl_describe","kubectl_logs","events_list","kubectl_rollout_status"]
+requires_data: ["pods","deployments","events"]
+---
+
+You are a Kubernetes rollout specialist. Diagnose stuck or failing deployment rollouts in the target namespaces.
+
+## Instructions
+
+1. List all Deployments and StatefulSets using `kubectl_get` for each target namespace.
+2. For each Deployment or StatefulSet, use `kubectl_rollout_status` to check if a rollout is in progress or stuck.
+   - A stuck rollout (Progressing condition with reason DeadlineExceeded) is critical.
+   - A rollout with unavailable replicas is high severity.
+3. For stuck or failing rollouts:
+   - Use `kubectl_describe` on the Deployment/StatefulSet to read conditions and events.
+   - Identify the new ReplicaSet (highest revision) and the old ReplicaSet.
+   - Use `kubectl_get` with kind=Pod and the new ReplicaSet's selector to find new pods.
+   - For each new pod not in Running state, use `kubectl_describe` and `kubectl_logs` to find the failure reason.
+4. Check for image pull errors:
+   - `ImagePullBackOff` or `ErrImagePull` in pod events indicate the new image is unavailable.
+5. Check for config errors:
+   - `CreateContainerConfigError` indicates missing ConfigMap/Secret referenced by the new spec.
+6. Check rollout history for context:
+   - From `kubectl_rollout_status`, note the revision count and last change time.
+7. For each issue found, output one finding JSON per line:
+   {"dimension":"health","severity":"<critical|high|medium|low>","title":"<title>","description":"<detail>","resource_kind":"<kind>","resource_namespace":"<ns>","resource_name":"<name>","suggestion":"<fix>"}
+
+## Severity Guide
+- critical: Rollout deadline exceeded (ProgressDeadlineExceeded), service partially degraded
+- high: New pods failing to start (ImagePullBackOff, CrashLoopBackOff), old version still serving
+- medium: Rollout in progress but slow, some replicas unavailable
+- low: Rollout succeeded but old ReplicaSets not cleaned up (revision history cluttered)

--- a/skills/storage-analyst.md
+++ b/skills/storage-analyst.md
@@ -1,0 +1,33 @@
+---
+name: storage-analyst
+dimension: reliability
+tools: ["kubectl_get","kubectl_describe","events_list","pvc_status"]
+requires_data: ["pods","pvcs","events"]
+---
+
+You are a Kubernetes storage specialist. Diagnose PersistentVolumeClaim and storage issues in the target namespaces.
+
+## Instructions
+
+1. Use `pvc_status` for each target namespace to list all PVCs and their phases.
+2. For each PVC in Pending state:
+   - Use `kubectl_describe` on the PVC to read the events and identify why binding is stuck.
+   - Common causes: no matching StorageClass, no available PV, quota exceeded.
+3. For each PVC in Lost state:
+   - Use `kubectl_describe` to find the underlying PV reference.
+   - Check if the PV still exists using `kubectl_get` with kind=PersistentVolume.
+   - This is critical as pods using this PVC will fail to mount.
+4. For Pending PVCs, check the StorageClass:
+   - Use `kubectl_get` with kind=StorageClass to verify the referenced class exists and has a provisioner.
+5. Check for pods blocked on volume mounts:
+   - Use `kubectl_get` with kind=Pod for each target namespace.
+   - Use `kubectl_describe` on pods in Pending/ContainerCreating state to find mount errors.
+   - Use `events_list` to find FailedMount or FailedAttachVolume events.
+6. For each issue found, output one finding JSON per line:
+   {"dimension":"reliability","severity":"<critical|high|medium|low>","title":"<title>","description":"<detail>","resource_kind":"<kind>","resource_namespace":"<ns>","resource_name":"<name>","suggestion":"<fix>"}
+
+## Severity Guide
+- critical: PVC in Lost state (pod will never start), or pod stuck ContainerCreating due to mount failure
+- high: PVC Pending for >5 minutes, blocking pod scheduling
+- medium: PVC Pending with known cause (quota, StorageClass mismatch)
+- low: Orphaned PVCs not bound to any pod (wasted storage)


### PR DESCRIPTION
## Summary

- **5 new MCP tools** for production diagnostic gaps: `kubectl_rollout_status`, `node_status_summary`, `prometheus_alerts`, `pvc_status`, `network_policy_check`
- **5 new builtin skills** (10 total): `alert-responder`, `network-troubleshooter`, `node-health-analyst`, `rollout-analyst`, `storage-analyst`
- **`/diagnose` page**: symptom-driven entry point for users arriving from monitoring alerts — select namespace/resource + symptoms → maps to skills → creates DiagnosticRun
- **`/diagnose/[id]` page**: user-friendly result view with findings sorted by severity (critical→low), suggestions highlighted, Generate Fix / View Fix buttons
- **`/api/k8s/resources` endpoint**: lightweight read-only proxy for namespace and workload autocomplete in the frontend form
- **3 bug fixes**: i18n hydration mismatch, proxy query string dropped, run navigation using wrong ID
- **RBAC fix**: add `namespaces` and workload `list/watch` permissions required by new k8s resource API
- **CI improvements**: `skill-lint` job for frontmatter validation, explicit `tsc --noEmit` typecheck step

Extends #6 (builtin skills) and #7 (dashboard visualization).

## Test Plan

- [x] `go test ./...` — all 26 mcptools + 18 httpserver tests pass
- [x] `npm run build` — dashboard builds with all new routes
- [x] `helm lint deploy/helm` — chart lints clean
- [x] Manual: `/diagnose` namespace dropdown populates from cluster
- [x] Manual: symptom selection → submit → redirects to `/diagnose/{uuid}` result page
- [x] Manual: `/skills` page shows 10 builtin skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)