### PR TITLE
ci: add CRD consistency check and Docker build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,50 @@ jobs:
           done
           if [ $ERRORS -gt 0 ]; then exit 1; fi
 
+  crd-check:
+    name: CRD Consistency Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install controller-gen
+        run: go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
+
+      - name: Regenerate CRDs from types.go
+        run: controller-gen crd paths="./internal/controller/api/..." output:crd:dir=deploy/crds
+
+      - name: Check deploy/crds is up to date
+        run: |
+          if ! git diff --exit-code deploy/crds/; then
+            echo "::error::deploy/crds/ is out of date with types.go. Run: controller-gen crd paths=./internal/controller/api/... output:crd:dir=deploy/crds"
+            exit 1
+          fi
+
+      - name: Check Helm CRDs match deploy/crds
+        run: |
+          if ! diff deploy/crds/ deploy/helm/templates/crds/; then
+            echo "::error::deploy/helm/templates/crds/ differs from deploy/crds/. Run: cp deploy/crds/*.yaml deploy/helm/templates/crds/"
+            exit 1
+          fi
+
+  docker-build:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build controller image
+        run: docker build -f Dockerfile -t controller:ci .
+
+      - name: Build agent-runtime image
+        run: docker build -f agent-runtime/Dockerfile -t agent-runtime:ci .
+
   helm-lint:
     name: Helm Lint
     runs-on: ubuntu-latest

--- a/deploy/crds/k8sai.io_diagnosticfixes.yaml
+++ b/deploy/crds/k8sai.io_diagnosticfixes.yaml
@@ -1,6 +1,9 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: diagnosticfixes.k8sai.io
 spec:
   group: k8sai.io
@@ -8,100 +11,144 @@ spec:
     kind: DiagnosticFix
     listKind: DiagnosticFixList
     plural: diagnosticfixes
-    singular: diagnosticfix
     shortNames:
-      - dfix
+    - dfix
+    singular: diagnosticfix
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      subresources:
-        status: {}
-      additionalPrinterColumns:
-        - name: Phase
-          type: string
-          jsonPath: .status.phase
-        - name: Target
-          type: string
-          jsonPath: .spec.target.name
-        - name: Age
-          type: date
-          jsonPath: .metadata.creationTimestamp
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              required: [diagnosticRunRef, findingTitle, target, patch]
-              properties:
-                diagnosticRunRef:
-                  type: string
-                findingTitle:
-                  type: string
-                target:
-                  type: object
-                  required: [kind, namespace, name]
-                  properties:
-                    kind:
-                      type: string
-                    namespace:
-                      type: string
-                    name:
-                      type: string
-                strategy:
-                  type: string
-                  enum: [auto, dry-run, create]
-                  default: auto
-                approvalRequired:
-                  type: boolean
-                  default: true
-                patch:
-                  type: object
-                  required: [content]
-                  properties:
-                    type:
-                      type: string
-                      enum: [strategic-merge, json-patch]
-                      default: strategic-merge
-                    content:
-                      type: string
-                rollback:
-                  type: object
-                  properties:
-                    enabled:
-                      type: boolean
-                      default: true
-                    snapshotBefore:
-                      type: boolean
-                      default: true
-                    autoRollbackOnFailure:
-                      type: boolean
-                      default: true
-                    healthCheckTimeout:
-                      type: integer
-                      default: 300
-                findingID:
-                  type: string
-            status:
-              type: object
-              properties:
-                phase:
-                  type: string
-                  enum: [PendingApproval, Approved, Applying, Succeeded, Failed, RolledBack, DryRunComplete]
-                approvedBy:
-                  type: string
-                approvedAt:
-                  type: string
-                  format: date-time
-                appliedAt:
-                  type: string
-                  format: date-time
-                completedAt:
-                  type: string
-                  format: date-time
-                rollbackSnapshot:
-                  type: string
-                message:
-                  type: string
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.target.name
+      name: Target
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              approvalRequired:
+                default: true
+                type: boolean
+              diagnosticRunRef:
+                type: string
+              findingID:
+                type: string
+              findingTitle:
+                type: string
+              patch:
+                properties:
+                  content:
+                    type: string
+                  type:
+                    default: strategic-merge
+                    enum:
+                    - strategic-merge
+                    - json-patch
+                    type: string
+                required:
+                - content
+                - type
+                type: object
+              rollback:
+                properties:
+                  autoRollbackOnFailure:
+                    default: true
+                    type: boolean
+                  enabled:
+                    default: true
+                    type: boolean
+                  healthCheckTimeout:
+                    default: 300
+                    type: integer
+                  snapshotBefore:
+                    default: true
+                    type: boolean
+                required:
+                - autoRollbackOnFailure
+                - enabled
+                - snapshotBefore
+                type: object
+              strategy:
+                default: auto
+                enum:
+                - auto
+                - dry-run
+                - create
+                type: string
+              target:
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                required:
+                - kind
+                - name
+                - namespace
+                type: object
+            required:
+            - approvalRequired
+            - diagnosticRunRef
+            - findingTitle
+            - patch
+            - strategy
+            - target
+            type: object
+          status:
+            properties:
+              appliedAt:
+                format: date-time
+                type: string
+              approvedAt:
+                format: date-time
+                type: string
+              approvedBy:
+                type: string
+              completedAt:
+                format: date-time
+                type: string
+              message:
+                type: string
+              phase:
+                enum:
+                - PendingApproval
+                - Approved
+                - Applying
+                - Succeeded
+                - Failed
+                - RolledBack
+                - DryRunComplete
+                type: string
+              rollbackSnapshot:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy/crds/k8sai.io_diagnosticruns.yaml
+++ b/deploy/crds/k8sai.io_diagnosticruns.yaml
@@ -18,6 +18,9 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
+    - jsonPath: .status.nextRunAt
+      name: NextRun
+      type: date
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -45,19 +48,22 @@ spec:
           spec:
             properties:
               historyLimit:
-                description: Max number of child runs to retain for scheduled runs
+                default: 10
+                description: HistoryLimit is the maximum number of completed child
+                  runs to retain.
                 format: int32
                 type: integer
               modelConfigRef:
                 type: string
-              schedule:
-                description: Cron expression for scheduled runs (e.g. "0 * * * *")
-                type: string
               outputLanguage:
-                description: Output language for diagnostic reports (zh or en)
                 enum:
                 - zh
                 - en
+                type: string
+              schedule:
+                description: |-
+                  Schedule is a cron expression for periodic runs, e.g. "0 * * * *".
+                  When set, this DiagnosticRun acts as a template; child runs are created automatically.
                 type: string
               skills:
                 items:
@@ -82,14 +88,20 @@ spec:
                 - scope
                 type: object
               timeoutSeconds:
+                format: int32
                 type: integer
-                minimum: 0
             required:
             - modelConfigRef
             - target
             type: object
           status:
             properties:
+              activeRuns:
+                description: ActiveRuns lists the names of child DiagnosticRuns created
+                  by this scheduled run.
+                items:
+                  type: string
+                type: array
               completedAt:
                 format: date-time
                 type: string
@@ -99,6 +111,8 @@ spec:
                 type: object
               findings:
                 items:
+                  description: FindingSummary is a compact representation of a finding
+                    stored in CR status.
                   properties:
                     dimension:
                       type: string
@@ -120,7 +134,16 @@ spec:
                   - title
                   type: object
                 type: array
+              lastRunAt:
+                description: LastRunAt is the time the last child run was created
+                  (only set when schedule is used).
+                format: date-time
+                type: string
               message:
+                type: string
+              nextRunAt:
+                description: NextRunAt is the scheduled time for the next child run.
+                format: date-time
                 type: string
               phase:
                 enum:
@@ -134,19 +157,6 @@ spec:
               startedAt:
                 format: date-time
                 type: string
-              nextRunAt:
-                description: Next scheduled run time (for scheduled DiagnosticRuns)
-                format: date-time
-                type: string
-              lastRunAt:
-                description: Last triggered run time (for scheduled DiagnosticRuns)
-                format: date-time
-                type: string
-              activeRuns:
-                description: Names of child DiagnosticRuns created by this scheduled run
-                items:
-                  type: string
-                type: array
             type: object
         type: object
     served: true

--- a/deploy/crds/k8sai.io_modelconfigs.yaml
+++ b/deploy/crds/k8sai.io_modelconfigs.yaml
@@ -37,9 +37,6 @@ spec:
             type: object
           spec:
             properties:
-              baseURL:
-                description: Override Anthropic API endpoint (e.g. for custom proxies)
-                type: string
               apiKeyRef:
                 properties:
                   key:
@@ -50,6 +47,10 @@ spec:
                 - key
                 - name
                 type: object
+              baseURL:
+                description: BaseURL overrides the Anthropic API endpoint (e.g. for
+                  custom proxies).
+                type: string
               maxTurns:
                 default: 20
                 type: integer

--- a/deploy/helm/templates/crds/k8sai.io_diagnosticfixes.yaml
+++ b/deploy/helm/templates/crds/k8sai.io_diagnosticfixes.yaml
@@ -1,6 +1,9 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: diagnosticfixes.k8sai.io
 spec:
   group: k8sai.io
@@ -8,100 +11,144 @@ spec:
     kind: DiagnosticFix
     listKind: DiagnosticFixList
     plural: diagnosticfixes
-    singular: diagnosticfix
     shortNames:
-      - dfix
+    - dfix
+    singular: diagnosticfix
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      subresources:
-        status: {}
-      additionalPrinterColumns:
-        - name: Phase
-          type: string
-          jsonPath: .status.phase
-        - name: Target
-          type: string
-          jsonPath: .spec.target.name
-        - name: Age
-          type: date
-          jsonPath: .metadata.creationTimestamp
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              required: [diagnosticRunRef, findingTitle, target, patch]
-              properties:
-                diagnosticRunRef:
-                  type: string
-                findingTitle:
-                  type: string
-                target:
-                  type: object
-                  required: [kind, namespace, name]
-                  properties:
-                    kind:
-                      type: string
-                    namespace:
-                      type: string
-                    name:
-                      type: string
-                strategy:
-                  type: string
-                  enum: [auto, dry-run, create]
-                  default: auto
-                approvalRequired:
-                  type: boolean
-                  default: true
-                patch:
-                  type: object
-                  required: [content]
-                  properties:
-                    type:
-                      type: string
-                      enum: [strategic-merge, json-patch]
-                      default: strategic-merge
-                    content:
-                      type: string
-                rollback:
-                  type: object
-                  properties:
-                    enabled:
-                      type: boolean
-                      default: true
-                    snapshotBefore:
-                      type: boolean
-                      default: true
-                    autoRollbackOnFailure:
-                      type: boolean
-                      default: true
-                    healthCheckTimeout:
-                      type: integer
-                      default: 300
-                findingID:
-                  type: string
-            status:
-              type: object
-              properties:
-                phase:
-                  type: string
-                  enum: [PendingApproval, Approved, Applying, Succeeded, Failed, RolledBack, DryRunComplete]
-                approvedBy:
-                  type: string
-                approvedAt:
-                  type: string
-                  format: date-time
-                appliedAt:
-                  type: string
-                  format: date-time
-                completedAt:
-                  type: string
-                  format: date-time
-                rollbackSnapshot:
-                  type: string
-                message:
-                  type: string
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.target.name
+      name: Target
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              approvalRequired:
+                default: true
+                type: boolean
+              diagnosticRunRef:
+                type: string
+              findingID:
+                type: string
+              findingTitle:
+                type: string
+              patch:
+                properties:
+                  content:
+                    type: string
+                  type:
+                    default: strategic-merge
+                    enum:
+                    - strategic-merge
+                    - json-patch
+                    type: string
+                required:
+                - content
+                - type
+                type: object
+              rollback:
+                properties:
+                  autoRollbackOnFailure:
+                    default: true
+                    type: boolean
+                  enabled:
+                    default: true
+                    type: boolean
+                  healthCheckTimeout:
+                    default: 300
+                    type: integer
+                  snapshotBefore:
+                    default: true
+                    type: boolean
+                required:
+                - autoRollbackOnFailure
+                - enabled
+                - snapshotBefore
+                type: object
+              strategy:
+                default: auto
+                enum:
+                - auto
+                - dry-run
+                - create
+                type: string
+              target:
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                required:
+                - kind
+                - name
+                - namespace
+                type: object
+            required:
+            - approvalRequired
+            - diagnosticRunRef
+            - findingTitle
+            - patch
+            - strategy
+            - target
+            type: object
+          status:
+            properties:
+              appliedAt:
+                format: date-time
+                type: string
+              approvedAt:
+                format: date-time
+                type: string
+              approvedBy:
+                type: string
+              completedAt:
+                format: date-time
+                type: string
+              message:
+                type: string
+              phase:
+                enum:
+                - PendingApproval
+                - Approved
+                - Applying
+                - Succeeded
+                - Failed
+                - RolledBack
+                - DryRunComplete
+                type: string
+              rollbackSnapshot:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy/helm/templates/crds/k8sai.io_diagnosticruns.yaml
+++ b/deploy/helm/templates/crds/k8sai.io_diagnosticruns.yaml
@@ -18,6 +18,9 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
+    - jsonPath: .status.nextRunAt
+      name: NextRun
+      type: date
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -45,13 +48,22 @@ spec:
           spec:
             properties:
               historyLimit:
-                description: Max number of child runs to retain for scheduled runs
+                default: 10
+                description: HistoryLimit is the maximum number of completed child
+                  runs to retain.
                 format: int32
                 type: integer
               modelConfigRef:
                 type: string
+              outputLanguage:
+                enum:
+                - zh
+                - en
+                type: string
               schedule:
-                description: Cron expression for scheduled runs (e.g. "0 * * * *")
+                description: |-
+                  Schedule is a cron expression for periodic runs, e.g. "0 * * * *".
+                  When set, this DiagnosticRun acts as a template; child runs are created automatically.
                 type: string
               skills:
                 items:
@@ -76,19 +88,20 @@ spec:
                 - scope
                 type: object
               timeoutSeconds:
+                format: int32
                 type: integer
-                minimum: 0
-              outputLanguage:
-                enum:
-                - zh
-                - en
-                type: string
             required:
             - modelConfigRef
             - target
             type: object
           status:
             properties:
+              activeRuns:
+                description: ActiveRuns lists the names of child DiagnosticRuns created
+                  by this scheduled run.
+                items:
+                  type: string
+                type: array
               completedAt:
                 format: date-time
                 type: string
@@ -98,6 +111,8 @@ spec:
                 type: object
               findings:
                 items:
+                  description: FindingSummary is a compact representation of a finding
+                    stored in CR status.
                   properties:
                     dimension:
                       type: string
@@ -119,7 +134,16 @@ spec:
                   - title
                   type: object
                 type: array
+              lastRunAt:
+                description: LastRunAt is the time the last child run was created
+                  (only set when schedule is used).
+                format: date-time
+                type: string
               message:
+                type: string
+              nextRunAt:
+                description: NextRunAt is the scheduled time for the next child run.
+                format: date-time
                 type: string
               phase:
                 enum:
@@ -133,19 +157,6 @@ spec:
               startedAt:
                 format: date-time
                 type: string
-              nextRunAt:
-                description: Next scheduled run time (for scheduled DiagnosticRuns)
-                format: date-time
-                type: string
-              lastRunAt:
-                description: Last triggered run time (for scheduled DiagnosticRuns)
-                format: date-time
-                type: string
-              activeRuns:
-                description: Names of child DiagnosticRuns created by this scheduled run
-                items:
-                  type: string
-                type: array
             type: object
         type: object
     served: true

--- a/deploy/helm/templates/crds/k8sai.io_modelconfigs.yaml
+++ b/deploy/helm/templates/crds/k8sai.io_modelconfigs.yaml
@@ -47,6 +47,10 @@ spec:
                 - key
                 - name
                 type: object
+              baseURL:
+                description: BaseURL overrides the Anthropic API endpoint (e.g. for
+                  custom proxies).
+                type: string
               maxTurns:
                 default: 20
                 type: integer

--- a/internal/controller/api/v1alpha1/types.go
+++ b/internal/controller/api/v1alpha1/types.go
@@ -153,7 +153,7 @@ type ModelConfigList struct {
 // ── DiagnosticFix ────────────────────────────────────────────────────────
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:resource:scope=Namespaced,shortName=dfix
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Target",type=string,JSONPath=`.spec.target.name`


### PR DESCRIPTION
## Summary

- **CRD consistency check**: New CI job runs `controller-gen` from `types.go`, then `git diff --exit-code` to catch any CRD drift. Also verifies `deploy/helm/templates/crds/` matches `deploy/crds/`.
- **Docker build**: New CI job builds both controller and agent-runtime Docker images to catch Dockerfile issues early.
- **CRD regeneration**: Replace all hand-written CRDs with `controller-gen` output as single source of truth. Fixes missing `NextRun` printer column, field descriptions, and default values that had drifted from `types.go`.
- **DiagnosticFix shortName**: Add `shortName=dfix` kubebuilder marker so `kubectl get dfix` works.

## Test plan

- [x] `controller-gen` output is idempotent (re-run produces no diff)
- [x] `deploy/crds/` matches `deploy/helm/templates/crds/`
- [x] All Go unit tests pass
- [x] `helm lint deploy/helm` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)