### PR TITLE
feat: dashboard batch ops + delete cascade fix + 中文架构注解

### DIFF
--- a/agent-runtime/runtime/fix_main.py
+++ b/agent-runtime/runtime/fix_main.py
@@ -1,8 +1,20 @@
-"""Fix generator entry point — single LLM call to propose a patch for one finding.
+"""修复补丁生成器入口（与 main.py 平级，被 FixGenerator Job 启动）。
 
-Called as: python -m runtime.fix_main
-Reads env var FIX_INPUT_JSON (finding + target), fetches current target YAML
-via MCP, asks the LLM for a patch JSON, POSTs the result to the controller.
+整体流程：
+    1. 从环境变量 FIX_INPUT_JSON 读取待修复的 finding（含 target 资源）
+    2. MCP 调用 kubectl_get 拉取目标资源当前 YAML
+    3. 判断"补丁已有资源" vs "创建新资源"两种场景
+    4. 调 Claude 单次推理（非循环）让其输出 strategic-merge / json-patch
+    5. POST /internal/fixes/{id}/patch 把结果回报给 controller
+
+与 main.py 的区别：
+    - main.py 是诊断（多轮、产出 findings）
+    - fix_main.py 是修复（单轮、产出一个 patch）
+
+被谁调用：
+    - DiagnosticFixReconciler 把 phase 推到 Approved 后
+    - FixGenerator.Compile 翻译出一个临时 Job 跑这个脚本
+    - Job 完成后 reconciler 切到 Applying 阶段把 patch 真正打到目标资源
 """
 import base64
 import json

--- a/agent-runtime/runtime/logger.py
+++ b/agent-runtime/runtime/logger.py
@@ -1,4 +1,19 @@
-"""Structured JSON logger for agent runtime."""
+"""Agent runtime 的结构化 JSON 日志输出。
+
+每行一个 JSON 对象写到 stderr，controller 侧的 collectPodLogs / streamLogsFromPod
+逐行 json.Unmarshal 后写入 SQLite run_logs 表 / SSE 推送到 Dashboard。
+
+字段约定：
+    ts    ISO 8601 时间戳
+    level info / warn / error / debug
+    msg   人类可读消息
+    其它任意 kwargs 平铺到顶层（tool=..., turn=..., error=... 等）
+
+故意避开 Python 标准 logging 模块：
+    - 那个模块输出文本格式，要解析成结构化数据需要正则
+    - 这里直接 print(json.dumps(...)) 简单且无依赖
+    - flush=True 确保 K8s 实时拿到日志（不被 Python stdout buffer 挡住）
+"""
 import json
 import sys
 import time

--- a/agent-runtime/runtime/main.py
+++ b/agent-runtime/runtime/main.py
@@ -1,4 +1,16 @@
-"""Entry point for the Agent Pod."""
+"""Agent Pod 主入口。
+
+整体流程：
+    1. 从环境变量读 RUN_ID / SKILL_NAMES（由 Controller 翻译 CR 时注入）
+    2. skill_loader 解析 /workspace/skills/*.md（ConfigMap 挂载进来）
+    3. orchestrator.run_agent() 跑 LLM + MCP 工具调用循环
+    4. reporter.post_findings() 把 findings 回报给 controller HTTP API
+    5. 全程 logger 用结构化 JSON 写 stderr，controller 端 collectPodLogs 解析
+
+异常处理：
+    - 任何阶段失败都 sys.exit(1)，让 K8s Job 进入 Failed
+    - Reconciler 监到 Job.status.Failed 就把 DiagnosticRun 标 Failed 并发通知
+"""
 import os
 import sys
 

--- a/agent-runtime/runtime/mcp_client.py
+++ b/agent-runtime/runtime/mcp_client.py
@@ -1,7 +1,16 @@
-"""MCP stdio client for the in-cluster k8s-mcp-server.
+"""MCP stdio 客户端，封装与同 Pod 内 k8s-mcp-server 二进制的 JSON-RPC 通信。
 
-Extracted from orchestrator.py so fix_main.py can reuse the same helpers
-without circular imports.
+为什么用 subprocess+stdio 而不是 HTTP/socket：
+    - MCP 协议官方推荐 stdio 传输（mcp-go 的 server.NewStdioServer）
+    - Pod 内进程间通信最简单，无端口、无证书、无超时配置
+    - 每次调用都是"启动 → 三次 JSON-RPC（initialize / initialized / call）→ 退出"
+      短生命周期 + 隔离，进程崩溃不影响其它工具
+
+两个核心函数：
+    - discover_tools()：tools/list，用于 LLM 工具清单（Anthropic schema 格式）
+    - call_mcp_tool(name, args)：tools/call，返回工具的 text 输出
+
+被 orchestrator.py 和 fix_main.py 共用，所以单独抽出来。
 """
 import json
 import os

--- a/agent-runtime/runtime/orchestrator.py
+++ b/agent-runtime/runtime/orchestrator.py
@@ -1,4 +1,27 @@
-"""Builds the orchestrator prompt and runs the agentic loop."""
+"""LLM 多轮编排核心。
+
+run_agent() 的循环：
+
+    [discover_tools] ── MCP 启动子进程，列出 15+ 个诊断工具
+            ↓
+    [build_prompt]   ── 拼出系统 prompt：诊断目标、技能列表、输出格式
+            ↓
+    ┌─ for turn in 0..MAX_TURNS:
+    │     ┌─ Claude 流式 API 推理
+    │     │     ├─ 收到 text 块 → 扫 JSON finding，加入 findings[]
+    │     │     ├─ 收到 tool_use 块 → 转 call_mcp_tool() 拿结果
+    │     │     └─ 把工具结果回喂给 LLM 作为 user 消息
+    │     └─ stop_reason == "end_turn" → break
+    └────────────────────────────────────────────
+            ↓
+    return findings  ── reporter 逐条 POST 给 controller
+
+特殊处理：
+    - 用 _stream_message() 直接走 SSE，绕开 Anthropic SDK 在某些代理上的累加 bug
+    - thinking 块（extended thinking）丢弃不送给下一轮（防 token 浪费）
+    - OUTPUT_LANGUAGE=zh 时 LLM 用中文写 title/desc/suggestion，
+      枚举字段（dimension/severity）保持英文
+"""
 import json
 import os
 from typing import List

--- a/agent-runtime/runtime/reporter.py
+++ b/agent-runtime/runtime/reporter.py
@@ -1,4 +1,17 @@
-"""POSTs findings back to the Controller with exponential backoff retry."""
+"""把 findings 回报给 controller，带指数退避重试。
+
+调用关系：
+    Agent Pod ──POST── /internal/runs/{run_id}/findings ──▶ controller HTTP server
+                                                              └─▶ Store.CreateFinding
+
+为什么逐条 POST 而不是批量：
+    - 一旦其中一条失败也只丢这一条，其它仍可写入
+    - controller 端 finding 写入是幂等的（按 RunID+Title 去重）
+
+CONTROLLER_URL 默认指 cluster-internal Service：
+    http://controller.kube-agent-helper.svc:8080
+跨集群场景下，远端 Pod 通过 NodePort/Ingress/双向 VPC 回到 controller。
+"""
 import os
 import time
 

--- a/agent-runtime/runtime/skill_loader.py
+++ b/agent-runtime/runtime/skill_loader.py
@@ -1,4 +1,19 @@
-"""Loads SKILL.md files from /workspace/skills/"""
+"""加载 /workspace/skills/*.md 技能文件。
+
+Skill 文件格式（与 controller-side parseSkillMD 保持一致）：
+
+    ---
+    name: pod-health
+    dimension: health
+    tools: ["kubectl_get", "kubectl_describe", "events_list"]
+    requires_data: []
+    ---
+
+    <这里是 prompt 主体，会拼接到 system prompt 的 skill 列表中>
+
+来源：Controller Translator 把启用的 Skills 写入 ConfigMap，挂到
+/workspace/skills/<name>.md，所以这里读到的是 controller 选定的子集。
+"""
 import os
 import re
 from dataclasses import dataclass, field

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -1,3 +1,30 @@
+// Command controller — kube-agent-helper 的主进程入口。
+//
+// 启动顺序（按 main 函数）：
+//
+//	[1] 解析 flag（--db / --agent-image / --notify-* …）
+//	[2] 初始化 SQLite Store
+//	[3] 加载 builtin 技能（/skills/*.md → store）
+//	[4] 创建 controller-runtime Manager（监听本地 K8s）
+//	[5] 装配子组件并依赖注入：
+//	       SkillRegistry、ClusterClientRegistry、Translator、FixGenerator、
+//	       Metrics、NotificationManager（DB 优先，flag 兜底）
+//	[6] 注册 6 个 Reconciler：
+//	       DiagnosticRun / Skill / ModelConfig / Fix / ScheduledRun / ClusterConfig
+//	[7] 注册 HTTP Server 与 Collector 为 manager.Runnable，
+//	       与 Reconciler 共享生命周期、退出信号
+//	[8] mgr.Start(ctx) 阻塞直到 SIGTERM/SIGINT
+//
+// 关键 flag：
+//
+//	--db                       SQLite 文件路径
+//	--http-addr                HTTP API 监听地址
+//	--agent-image              注入到 Job 的 Agent Pod 镜像
+//	--controller-url           Agent Pod 回调 controller 的 URL
+//	--prometheus-url           Collector 抓取指标的 Prometheus 地址
+//	--agent-prometheus-url     Agent Pod 内可用的 Prometheus 地址（默认沿用上一个）
+//	--anthropic-base-url/--model  全局 LLM 配置（可被 ModelConfig CR 覆盖）
+//	--notify-{webhook,slack,dingtalk,feishu}-url[/secret]  通知通道（兜底）
 package main
 
 import (

--- a/dashboard/src/app/api/[...proxy]/route.ts
+++ b/dashboard/src/app/api/[...proxy]/route.ts
@@ -1,3 +1,19 @@
+/**
+ * Next.js 全量 API 代理。
+ *
+ * 路由匹配 /api/* 所有路径（[...proxy] 是 catch-all 段），把请求原样转发给
+ * 后端 controller HTTP server（默认 http://localhost:8080，可由 API_URL 覆盖）。
+ *
+ * 关键能力：
+ *   - 普通 JSON：原样透传 status + body
+ *   - SSE 流（Content-Type: text/event-stream）：用 Response.body 直传
+ *     ReadableStream，避免 Next.js 缓冲导致 LogViewer 收不到实时事件
+ *
+ * 为什么需要这层代理：
+ *   1. 浏览器同源 — Dashboard 跑 :3000，controller 跑 :8080，跨域要 CORS
+ *   2. Helm 部署时前端只暴露 :3000，后端可以仅 ClusterIP，安全
+ *   3. 后端地址变化（端口 / 域名）只改 API_URL 环境变量
+ */
 import { NextRequest } from "next/server";
 
 export const dynamic = "force-dynamic";
@@ -37,4 +53,6 @@ async function handler(req: NextRequest) {
 
 export const GET = handler;
 export const POST = handler;
+export const PUT = handler;
 export const PATCH = handler;
+export const DELETE = handler;

--- a/dashboard/src/app/fixes/page.tsx
+++ b/dashboard/src/app/fixes/page.tsx
@@ -53,7 +53,7 @@ const FIX_FILTER_FIELDS: FilterField[] = [
 export default function FixesPage() {
   const { t } = useI18n();
   const { cluster } = useCluster();
-  const table = useTableState({ pageSize: 20 });
+  const table = useTableState({ pageSize: 20 }, { syncURL: true, urlPrefix: "fixes" });
   const { data, error, isLoading, mutate } = useFixesPaginated({
     ...table.params,
     cluster,
@@ -68,8 +68,8 @@ export default function FixesPage() {
       await batchApproveFixes(Array.from(table.selected));
       table.clearSelection();
       mutate();
-    } catch {
-      // ignore
+    } catch (e) {
+      window.alert(`${t("common.actionFailed")}: ${(e as Error).message}`);
     }
   };
 
@@ -79,8 +79,8 @@ export default function FixesPage() {
       await batchRejectFixes(Array.from(table.selected));
       table.clearSelection();
       mutate();
-    } catch {
-      // ignore
+    } catch (e) {
+      window.alert(`${t("common.actionFailed")}: ${(e as Error).message}`);
     }
   };
 

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -1,3 +1,17 @@
+/**
+ * 全站根 layout（Next.js App Router）。
+ *
+ * 提供：
+ *   - <ClientProviders>  ─ 包裹 I18nProvider / ThemeProvider / SWRConfig
+ *   - <ClusterProvider>  ─ 多集群上下文
+ *   - 顶部导航 + ClusterToggle + LanguageToggle + ThemeToggle
+ *   - <ErrorBoundary>    ─ 业务页面崩溃时降级展示
+ *
+ * 路由表见下方 links 数组（运行 / 诊断 / 技能 / 修复 / 事件 / LLM 配置 /
+ * 通知 / 集群 / 关于）。
+ *
+ * preHydrationScript 在 <html> 渲染前注入主题，防止深浅模式闪烁。
+ */
 "use client";
 
 import Link from "next/link";

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import Link from "next/link";
-import { useRunsPaginated } from "@/lib/api";
+import { useRunsPaginated, deleteRunsBatch } from "@/lib/api";
 import { useI18n } from "@/i18n/context";
 import { useCluster } from "@/cluster/context";
 import { PhaseBadge } from "@/components/phase-badge";
 import { CreateRunDialog } from "@/components/create-run-dialog";
 import { Pagination } from "@/components/Pagination";
 import { FilterBar, type FilterField } from "@/components/FilterBar";
+import { BatchToolbar } from "@/components/BatchToolbar";
 import { useTableState } from "@/hooks/useTableState";
 import { Activity, Cpu, Wrench } from "lucide-react";
 import {
@@ -46,7 +47,7 @@ const RUN_FILTER_FIELDS: FilterField[] = [
 export default function RunsPage() {
   const { t } = useI18n();
   const { cluster } = useCluster();
-  const table = useTableState({ pageSize: 20 });
+  const table = useTableState({ pageSize: 20 }, { syncURL: true, urlPrefix: "runs" });
   const { data, error, isLoading, mutate } = useRunsPaginated({
     ...table.params,
     cluster,
@@ -54,6 +55,18 @@ export default function RunsPage() {
 
   const runs = data?.items;
   const total = data?.total ?? 0;
+
+  const handleBatchDelete = async () => {
+    if (table.selected.size === 0) return;
+    if (!window.confirm(t("batch.confirm"))) return;
+    try {
+      await deleteRunsBatch(Array.from(table.selected));
+      table.clearSelection();
+      mutate();
+    } catch (e) {
+      window.alert(`${t("common.deleteFailed")}: ${(e as Error).message}`);
+    }
+  };
 
   const featureCards = [
     { icon: Activity, title: t("overview.card.runs.title"), desc: t("overview.card.runs.desc"), href: "#runs", color: "text-primary" },
@@ -108,6 +121,15 @@ export default function RunsPage() {
             <Table>
               <TableHeader>
                 <TableRow>
+                  <TableHead className="w-10">
+                    <input
+                      type="checkbox"
+                      checked={runs.length > 0 && table.selected.size === runs.length}
+                      onChange={() => table.selectAll(runs.map((r) => r.ID))}
+                      className="rounded border-border"
+                      aria-label="select all"
+                    />
+                  </TableHead>
                   <TableHead>{t("runs.col.id")}</TableHead>
                   <TableHead>{t("runs.col.phase")}</TableHead>
                   <TableHead>{t("runs.col.created")}</TableHead>
@@ -126,7 +148,16 @@ export default function RunsPage() {
                     /* ignore */
                   }
                   return (
-                    <TableRow key={run.ID}>
+                    <TableRow key={run.ID} data-selected={table.selected.has(run.ID) || undefined}>
+                      <TableCell>
+                        <input
+                          type="checkbox"
+                          checked={table.selected.has(run.ID)}
+                          onChange={() => table.toggleSelect(run.ID)}
+                          className="rounded border-border"
+                          aria-label={`select ${run.ID}`}
+                        />
+                      </TableCell>
                       <TableCell>
                         <Link href={`/runs/${run.ID}`} className="font-mono text-sm text-primary hover:underline">
                           {run.Name || run.ID.slice(0, 8)}
@@ -154,6 +185,14 @@ export default function RunsPage() {
           />
         </>
       )}
+
+      <BatchToolbar
+        count={table.selected.size}
+        actions={[
+          { labelKey: "batch.delete", variant: "destructive", onClick: handleBatchDelete },
+        ]}
+        onClear={table.clearSelection}
+      />
     </div>
   );
 }

--- a/dashboard/src/cluster/context.tsx
+++ b/dashboard/src/cluster/context.tsx
@@ -1,3 +1,14 @@
+/**
+ * 全局集群上下文。
+ *
+ * 用途：所有 list 类页面（runs/findings/events/fixes）顶部都有 ClusterToggle
+ * 切换器，选中后通过 useCluster() hook 拿到当前 cluster name，作为参数传给
+ * useRuns({ cluster }) 等 SWR hook，自动加上 ?cluster= 过滤。
+ *
+ * 持久化：localStorage["kah-cluster"]，刷新页面、切换 tab 都保留。
+ *
+ * "local" 是特殊值：表示控制器自身所在集群（不带 ?cluster= 即可）。
+ */
 "use client";
 
 import { createContext, useContext, useState, ReactNode } from "react";

--- a/dashboard/src/components/create-run-dialog.tsx
+++ b/dashboard/src/components/create-run-dialog.tsx
@@ -1,3 +1,19 @@
+/**
+ * 新建诊断任务弹窗。
+ *
+ * 提交流程：
+ *   表单 → POST /api/runs → 后端 HTTP server 创建 DiagnosticRun CR
+ *   → DiagnosticRunReconciler 接管，翻译成 Job 启动 Agent Pod
+ *
+ * 字段：
+ *   - name             K8s CR name（用户输入或自动生成）
+ *   - namespace        CR 所在命名空间
+ *   - scope            namespace（指定 namespaces 列表）/ cluster（全集群）
+ *   - skills           可选；为空则用所有启用的技能
+ *   - clusterRef       目标集群名（来自 ClusterToggle 的当前值）
+ *   - timeoutSeconds   超时（0 = 不超时）
+ *   - outputLanguage   findings 输出语言（zh/en，跟随当前 i18n）
+ */
 "use client";
 
 import { useState } from "react";

--- a/dashboard/src/components/log-viewer.tsx
+++ b/dashboard/src/components/log-viewer.tsx
@@ -1,3 +1,19 @@
+/**
+ * 实时日志查看器（用在 /runs/[id] 详情页）。
+ *
+ * 数据源切换：
+ *   - 运行中：EventSource('/api/runs/{id}/logs?follow=true') ── SSE 流
+ *     后端从 Pod stdout 直读，每行一个 JSON 推送
+ *   - 已完成：fetch('/api/runs/{id}/logs')                  ── 一次性 JSON 数组
+ *     后端从 SQLite run_logs 表读取（reconciler 在 Pod 退出时已采集）
+ *
+ * 切换时机：phase ∈ {Pending, Running} 用 SSE，否则用 fetch。
+ *
+ * UI 行为：
+ *   - 默认自动滚动到底部
+ *   - 鼠标悬停时暂停滚动（避免阅读时跳走）
+ *   - 按 type 着色：step/finding/fix/error/info 用不同颜色
+ */
 "use client";
 
 import { useEffect, useRef, useState } from "react";

--- a/dashboard/src/hooks/useTableState.ts
+++ b/dashboard/src/hooks/useTableState.ts
@@ -1,6 +1,21 @@
+/**
+ * 通用表格状态 hook（分页 / 排序 / 过滤 / 多选 / URL 同步）。
+ *
+ * 所有列表页（runs / fixes / events 等）共享这个 hook，避免重复实现：
+ *
+ *   const t = useTableState({ pageSize: 20 }, { syncURL: true, urlPrefix: "runs" });
+ *   const { data } = useRunsPaginated(t.params);  // 自动包含 page/sort/filter
+ *   <Table ... selected={t.selected} onToggle={t.toggleSelect} />
+ *
+ * 设计要点：
+ *   - selected 用 Set<string>，支持跨页保留（不持久化到 URL，刷新即清）
+ *   - filters 是平铺 string map，传给后端拼成 ?xxx=yyy 查询串
+ *   - syncURL=true 时把 page / pageSize / sortBy / sortOrder / filters 写到 URL，
+ *     用 history.replaceState 不污染浏览器历史；同一 layout 下多张表用 urlPrefix 区分
+ */
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import type { ListParams } from "@/lib/types";
 
 export interface TableState {
@@ -22,17 +37,100 @@ export interface TableState {
   params: ListParams;
 }
 
-export function useTableState(defaults?: Partial<ListParams>): TableState {
-  const [page, setPageRaw] = useState(defaults?.page ?? 1);
-  const [pageSize, setPageSizeRaw] = useState(defaults?.pageSize ?? 20);
-  const [sortBy, setSortBy] = useState(defaults?.sortBy ?? "created_at");
-  const [sortOrder, setSortOrder] = useState<"asc" | "desc">(
-    (defaults?.sortOrder as "asc" | "desc") ?? "desc"
-  );
-  const [filters, setFilters] = useState<Record<string, string>>({});
+export interface UseTableStateOptions {
+  /** 把状态同步到 URL query string，刷新页面后能恢复，链接可分享 */
+  syncURL?: boolean;
+  /** 同一 layout 下多张表共存时用前缀避免 query key 冲突，例如 "runs" → ?runs.page=2 */
+  urlPrefix?: string;
+}
+
+const RESERVED_KEYS = new Set(["page", "pageSize", "sortBy", "sortOrder"]);
+
+function buildKey(prefix: string | undefined, key: string): string {
+  return prefix ? `${prefix}.${key}` : key;
+}
+
+function readInitialFromURL(prefix: string | undefined, defaults: Partial<ListParams>) {
+  if (typeof window === "undefined") {
+    return {
+      page: defaults.page ?? 1,
+      pageSize: defaults.pageSize ?? 20,
+      sortBy: defaults.sortBy ?? "created_at",
+      sortOrder: (defaults.sortOrder as "asc" | "desc") ?? "desc",
+      filters: {} as Record<string, string>,
+    };
+  }
+  const sp = new URLSearchParams(window.location.search);
+  const get = (k: string) => sp.get(buildKey(prefix, k));
+  const filters: Record<string, string> = {};
+  sp.forEach((value, fullKey) => {
+    const key = prefix && fullKey.startsWith(`${prefix}.`)
+      ? fullKey.slice(prefix.length + 1)
+      : !prefix && !fullKey.includes(".")
+        ? fullKey
+        : null;
+    if (!key || RESERVED_KEYS.has(key)) return;
+    filters[key] = value;
+  });
+  return {
+    page: Number(get("page")) || defaults.page || 1,
+    pageSize: Number(get("pageSize")) || defaults.pageSize || 20,
+    sortBy: get("sortBy") || defaults.sortBy || "created_at",
+    sortOrder: ((get("sortOrder") as "asc" | "desc") || (defaults.sortOrder as "asc" | "desc") || "desc"),
+    filters,
+  };
+}
+
+export function useTableState(
+  defaults?: Partial<ListParams>,
+  options?: UseTableStateOptions,
+): TableState {
+  const syncURL = options?.syncURL ?? false;
+  const urlPrefix = options?.urlPrefix;
+
+  // useState lazy initializer runs once on mount — safe to read window.location.
+  const init = () =>
+    syncURL
+      ? readInitialFromURL(urlPrefix, defaults ?? {})
+      : {
+          page: defaults?.page ?? 1,
+          pageSize: defaults?.pageSize ?? 20,
+          sortBy: defaults?.sortBy ?? "created_at",
+          sortOrder: (defaults?.sortOrder as "asc" | "desc") ?? "desc",
+          filters: {} as Record<string, string>,
+        };
+
+  const [page, setPageRaw] = useState(() => init().page);
+  const [pageSize, setPageSizeRaw] = useState(() => init().pageSize);
+  const [sortBy, setSortBy] = useState(() => init().sortBy);
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">(() => init().sortOrder);
+  const [filters, setFilters] = useState<Record<string, string>>(() => init().filters);
   const [selected, setSelected] = useState<Set<string>>(new Set());
 
-  // Reset to page 1 when changing page size or filters
+  // Push state into URL when any tracked field changes.
+  useEffect(() => {
+    if (!syncURL || typeof window === "undefined") return;
+    const sp = new URLSearchParams(window.location.search);
+    // Wipe our keys first so removed filters drop from the URL.
+    Array.from(sp.keys()).forEach((k) => {
+      const stripped = urlPrefix && k.startsWith(`${urlPrefix}.`)
+        ? k.slice(urlPrefix.length + 1)
+        : !urlPrefix && !k.includes(".")
+          ? k
+          : null;
+      if (stripped !== null) sp.delete(k);
+    });
+    sp.set(buildKey(urlPrefix, "page"), String(page));
+    sp.set(buildKey(urlPrefix, "pageSize"), String(pageSize));
+    if (sortBy) sp.set(buildKey(urlPrefix, "sortBy"), sortBy);
+    if (sortOrder) sp.set(buildKey(urlPrefix, "sortOrder"), sortOrder);
+    Object.entries(filters).forEach(([k, v]) => {
+      if (v) sp.set(buildKey(urlPrefix, k), v);
+    });
+    const next = `${window.location.pathname}?${sp.toString()}`;
+    window.history.replaceState(null, "", next);
+  }, [syncURL, urlPrefix, page, pageSize, sortBy, sortOrder, filters]);
+
   const setPage = useCallback((p: number) => setPageRaw(p), []);
   const setPageSize = useCallback((ps: number) => {
     setPageSizeRaw(ps);

--- a/dashboard/src/i18n/context.tsx
+++ b/dashboard/src/i18n/context.tsx
@@ -1,3 +1,16 @@
+/**
+ * 双语 i18n 上下文（中文 / English）。
+ *
+ * 字典文件：zh.json / en.json，结构是嵌套 JSON（runs.form.name 之类的点路径）。
+ * 也支持半扁平 key（runs.stat.total 既可以是 dict.runs.stat.total，也可以
+ * 是 dict.runs["stat.total"]）— 这是为了兼容渐进迁移。
+ *
+ * 用法：
+ *   const { t, lang, setLang } = useI18n();
+ *   t("runs.form.name")     // "Run name" 或 "运行名称"
+ *
+ * 切换语言会写 localStorage["kah-lang"]，并通过 storage 事件跨标签页同步。
+ */
 "use client";
 
 import { createContext, useCallback, useContext, useEffect, useState, ReactNode } from "react";

--- a/dashboard/src/i18n/en.json
+++ b/dashboard/src/i18n/en.json
@@ -87,6 +87,8 @@
     "reject": "Reject",
     "loading": "Loading...",
     "loadFailed": "Failed to load",
+    "deleteFailed": "Delete failed",
+    "actionFailed": "Action failed",
     "notFound": "Not found",
     "back": "Back",
     "yes": "Yes",

--- a/dashboard/src/i18n/zh.json
+++ b/dashboard/src/i18n/zh.json
@@ -87,6 +87,8 @@
     "reject": "拒绝",
     "loading": "加载中...",
     "loadFailed": "加载失败",
+    "deleteFailed": "删除失败",
+    "actionFailed": "操作失败",
     "notFound": "未找到",
     "back": "返回",
     "yes": "是",

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1,3 +1,17 @@
+/**
+ * 后端 API 客户端集合（基于 SWR + fetch）。
+ *
+ * 设计约定：
+ *   - 所有读取用 SWR hook（useXxx），自带 revalidate / 缓存
+ *   - 所有写入用 async function，返回 Promise<T>
+ *   - URL 都走相对路径 /api/...，由 [...proxy] 转发到后端
+ *   - useXxx 接受可选的 { cluster } 参数，附加 ?cluster= 用于多集群过滤
+ *
+ * 刷新频率：
+ *   - useRuns / useRun     5 秒（运行中状态变化频繁）
+ *   - useClusterConfigs    30 秒（集群配置不常变）
+ *   - 列表分页类（useRunsPaginated）跟随表格状态变更触发，不固定轮询
+ */
 import useSWR from "swr";
 import type { DiagnosticRun, Finding, Skill, CreateRunRequest, CreateSkillRequest, Fix, KubeEvent, ModelConfig, PaginatedResult, ListParams } from "./types";
 

--- a/deploy/helm/templates/rbac.yaml
+++ b/deploy/helm/templates/rbac.yaml
@@ -11,7 +11,7 @@ metadata:
 rules:
 - apiGroups: ["k8sai.io"]
   resources: ["diagnosticruns","diagnosticskills","modelconfigs","diagnosticfixes","clusterconfigs"]
-  verbs: ["get","list","watch","create","update","patch"]
+  verbs: ["get","list","watch","create","update","patch","delete"]
 - apiGroups: ["k8sai.io"]
   resources: ["diagnosticruns/status","diagnosticfixes/status","clusterconfigs/status"]
   verbs: ["update","patch"]

--- a/internal/audit/middleware.go
+++ b/internal/audit/middleware.go
@@ -1,3 +1,17 @@
+// Package audit 给 MCP 工具调用包一层"审计中间件"。
+//
+// 包装方式：
+//
+//	audit.Wrap(toolSpec, originalHandler) → newHandler
+//
+// 每次调用时：
+//   1. 生成 ULID 作为 invocation ID
+//   2. 用 argmask 把 Secret 名/值等敏感参数 redact 掉
+//   3. 记录开始日志（tool, args, ulid, ts）
+//   4. 执行原始 handler，捕获结果或错误
+//   5. 记录结束日志（ulid, status, duration_ms）
+//
+// 输出：结构化 JSON 行 → controller stderr → 接入 ELK / Loki 即可查询。
 package audit
 
 import (

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -1,3 +1,14 @@
+// Package collector 控制器侧的后台数据采集器。
+//
+// 三个 goroutine（由 Start 启动）：
+//  1. EventCollector  ─ Watch K8s Warning 事件，批量写入 Store.events 表
+//  2. MetricCollector ─ 周期性 PromQL 查询，写入 Store.metric_snapshots 表
+//  3. PurgeLoop       ─ 每小时清理超过 RetentionDays（默认 7 天）的旧记录
+//
+// 设计要点：
+//   - 实现 controller-runtime 的 manager.Runnable 接口，与 Reconciler 共享生命周期
+//   - NeedLeaderElection() = true，HA 部署时只有 leader pod 在采集，避免重复
+//   - 与 Reconciler 解耦：只通过 Store 接口写数据，不感知 CR / Job
 package collector
 
 import (

--- a/internal/controller/api/v1alpha1/types.go
+++ b/internal/controller/api/v1alpha1/types.go
@@ -1,3 +1,26 @@
+// Package v1alpha1 定义系统全部 CRD 类型。
+//
+// 资源关系：
+//
+//	ClusterConfig（远程集群配置） ◀──┐
+//	                                │ spec.clusterRef
+//	                                │
+//	DiagnosticSkill ◀── DiagnosticRun ──▶ ModelConfig
+//	  (诊断能力)         (一次诊断任务)      (LLM 配置)
+//	                       │
+//	                       │ 产出
+//	                       ▼
+//	                    Findings ──▶ DiagnosticFix
+//	                                 (修复建议，可批准/应用)
+//
+//	ScheduledRun（cron 模板，由 spec.schedule 启用）
+//	   └─▶ 周期性创建子 DiagnosticRun
+//
+// 这些类型的 Reconciler 在 internal/controller/reconciler 包，每种 CRD 一个。
+// 其中 DiagnosticRunReconciler 是核心 — 它负责把 CR 翻译成 K8s Job 并跟踪生命周期。
+//
+// kubebuilder marker（// +kubebuilder:...）用于 controller-gen 生成 deepcopy
+// 函数和 CRD YAML（输出到 deploy/helm/templates/crds/）。
 package v1alpha1
 
 import (

--- a/internal/controller/httpserver/logs_handler.go
+++ b/internal/controller/httpserver/logs_handler.go
@@ -1,3 +1,24 @@
+// logs_handler.go ─ /api/runs/{id}/logs[?follow=true] 端点实现。
+//
+// 数据源选择策略：
+//
+//	┌──────────────┐  非终态 + clientset 可用   ┌───────────────────┐
+//	│ Run 状态判定 │ ───────────────────────▶  │ 直读 Pod 日志      │
+//	└──────┬───────┘                            │ (clientset Stream) │
+//	       │                                    └─────────┬──────────┘
+//	       │ 终态 / pod 找不到                            │ 找不到 pod
+//	       ▼                                              │
+//	┌──────────────┐                                      │
+//	│ 读 SQLite    │ ◀───────────────────────────────────┘ fallback
+//	│ run_logs 表   │
+//	└──────────────┘
+//
+// 两种响应格式：
+//   - follow=false → JSON 数组（一次性返回当前所有日志）
+//   - follow=true  → SSE 流（"data: {...}\n\n" 推送，结束发 "event: done"）
+//
+// findAgentPod 必须用 typed clientset 而非 controller-runtime cache，
+// 因为后者只缓存通过 For()/Owns() 注册的资源，Pod 不在其中。
 package httpserver
 
 import (

--- a/internal/controller/httpserver/server.go
+++ b/internal/controller/httpserver/server.go
@@ -1,3 +1,26 @@
+// Package httpserver 实现控制器对外的 REST API（默认监听 :8080）。
+//
+// 端点分组：
+//
+//	/api/runs          诊断任务的 CRUD（POST 创建会同时创建 DiagnosticRun CR）
+//	/api/runs/{id}/logs       SSE 实时日志流（运行中读 Pod，完成读 DB）
+//	/api/runs/{id}/findings   单次诊断的 Findings 列表
+//	/api/findings      跨任务查询 Findings
+//	/api/skills        技能管理（builtin + DiagnosticSkill CR）
+//	/api/fixes         修复任务（POST 批准/拒绝）
+//	/api/clusters      多集群配置（联动 ClusterConfig CR）
+//	/api/modelconfigs  LLM 配置
+//	/api/notifications 通知配置（changes 自动 reload Manager）
+//	/api/events        K8s 事件查询
+//	/internal/runs/{id}/findings  Agent 回调，写入 finding（仅集群内访问）
+//	/metrics           Prometheus 指标
+//
+// 关键设计：
+//   - Server 通过 functional Option（WithMetrics / WithNotifier / WithClientset…）
+//     可选注入依赖，便于测试。
+//   - SSE 端点直接调用 clientset.GetLogs Stream() 透传 Pod 日志，
+//     完成后切换到 SQLite run_logs 表。详见 logs_handler.go。
+//   - 所有 list 端点支持 ?cluster= 过滤，配合多集群 UI。
 package httpserver
 
 import (
@@ -1550,6 +1573,14 @@ func parsePaginatedOpts(r *http.Request) store.ListOpts {
 }
 
 // DELETE /api/runs/batch
+//
+// 完整删除链路：
+//  1. 找到每个 ID 对应的 DiagnosticRun CR（按 .metadata.uid 匹配 store ID）
+//  2. 删 CR — Kubernetes GC 会顺带回收 OwnerReferences 指向它的 Job/Pod
+//  3. 删 SQLite 行 — 否则 reconciler 不会再看到这条记录而漏清
+//
+// 关键：必须先删 CR 再删 store。否则 Pending/Running 阶段的 reconciler 会把
+// store 行重新写回（CreateRun 调用），看起来"删不掉"。
 func (s *Server) handleAPIRunsBatch(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodDelete {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -1566,6 +1597,27 @@ func (s *Server) handleAPIRunsBatch(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "ids required", http.StatusBadRequest)
 		return
 	}
+
+	// Try to delete the K8s CR for each ID. Look up by UID across all namespaces.
+	idSet := make(map[string]bool, len(body.IDs))
+	for _, id := range body.IDs {
+		idSet[id] = true
+	}
+	if s.k8sClient != nil {
+		var crList v1alpha1.DiagnosticRunList
+		if err := s.k8sClient.List(r.Context(), &crList); err == nil {
+			for i := range crList.Items {
+				cr := &crList.Items[i]
+				if idSet[string(cr.UID)] {
+					if err := s.k8sClient.Delete(r.Context(), cr); err != nil && !errors.IsNotFound(err) {
+						http.Error(w, fmt.Sprintf("delete CR %s: %s", cr.Name, err), http.StatusInternalServerError)
+						return
+					}
+				}
+			}
+		}
+	}
+
 	if err := s.store.DeleteRuns(r.Context(), body.IDs); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/internal/controller/reconciler/clusterconfig_reconciler.go
+++ b/internal/controller/reconciler/clusterconfig_reconciler.go
@@ -15,6 +15,16 @@ import (
 	"github.com/kube-agent-helper/kube-agent-helper/internal/controller/registry"
 )
 
+// ClusterConfigReconciler 把 ClusterConfig CR 转换为可用的远程集群 client。
+//
+// 流程：
+//   1. 监听 ClusterConfig CR 变更
+//   2. 读取 spec.kubeConfigRef 引用的 Secret，取出 kubeconfig
+//   3. 用 clientcmd 解析 → rest.Config → 构建 controller-runtime client
+//   4. 调用 Registry.Set(name, client)，DiagnosticRunReconciler 通过 Get(name) 使用
+//   5. CR 删除时 Registry.Delete(name)，回收资源
+//
+// 是多集群方案的"外部世界 → 内存 client 表"的桥梁。
 type ClusterConfigReconciler struct {
 	client.Client
 	Registry *registry.ClusterClientRegistry

--- a/internal/controller/reconciler/fix_reconciler.go
+++ b/internal/controller/reconciler/fix_reconciler.go
@@ -22,6 +22,23 @@ import (
 	"github.com/kube-agent-helper/kube-agent-helper/internal/store"
 )
 
+// DiagnosticFixReconciler 处理一次修复任务的完整生命周期。
+//
+// 状态机：
+//
+//	""  ──┬─[strategy=dry-run]─▶ DryRunComplete
+//	      ├─[approvalRequired]─▶ PendingApproval ──批准──▶ Approved
+//	      └─[autoApprove]──────▶ Approved
+//	   Approved ──snapshot──▶ Applying ──健康检查──▶ Succeeded
+//	                                  │
+//	                                  └─失败/超时──▶ Failed
+//	                                                  │
+//	                                                  └─autoRollback──▶ RolledBack
+//
+// 设计要点：
+//   - 应用前先抓快照（spec.rollback.snapshotBefore）存到 status，便于回滚
+//   - 健康检查用 Deployment.status.availableReplicas 等内建字段
+//   - 失败时按 spec.rollback.autoRollbackOnFailure 决定是否自动回滚
 type DiagnosticFixReconciler struct {
 	client.Client
 	Store    store.Store

--- a/internal/controller/reconciler/modelconfig_reconciler.go
+++ b/internal/controller/reconciler/modelconfig_reconciler.go
@@ -12,7 +12,14 @@ import (
 	k8saiV1 "github.com/kube-agent-helper/kube-agent-helper/internal/controller/api/v1alpha1"
 )
 
-// ModelConfigReconciler validates ModelConfig resources and their Secret refs.
+// ModelConfigReconciler 仅做 ModelConfig 的合法性校验（Secret 是否存在等）。
+//
+// 设计上这是一个"只观察、不副作用"的 Reconciler：
+//   - 不写 Store
+//   - 不改其它 CR
+//   - 只在 status 上记 Ready/Error 信息供 UI 展示
+//
+// 真正消费 ModelConfig 的是 Translator.resolveModelConfig（运行时按 ref 取）。
 type ModelConfigReconciler struct {
 	client.Client
 }

--- a/internal/controller/reconciler/run_reconciler.go
+++ b/internal/controller/reconciler/run_reconciler.go
@@ -1,3 +1,22 @@
+// Package reconciler 包含所有 CRD 的 controller-runtime Reconciler。
+//
+// 一个文件 = 一种 CRD：
+//
+//	run_reconciler.go            DiagnosticRun（核心，本文件）
+//	skill_reconciler.go          DiagnosticSkill ─ 同步 CR → store.Skill
+//	fix_reconciler.go            DiagnosticFix   ─ 应用补丁 + 健康检查 + 回滚
+//	modelconfig_reconciler.go    ModelConfig     ─ 仅校验，无副作用
+//	scheduled_run_reconciler.go  cron 模板 Run    ─ 周期性创建子 Run
+//	clusterconfig_reconciler.go  ClusterConfig   ─ 写入 ClusterClientRegistry
+//
+// DiagnosticRun 状态机：
+//
+//	  ""/Pending ──translate──▶ Running ──Job 完成──▶ Succeeded
+//	                              │                       │
+//	                              ├──Job 失败/超时──▶ Failed
+//	                              └──pod 异常──▶ 写 status.message（仍 Running）
+//
+// 每次进入终态时：写 findings 到 CR.Status / 收集 pod 日志 / 发通知 / 记 metric。
 package reconciler
 
 import (

--- a/internal/controller/reconciler/scheduled_run_reconciler.go
+++ b/internal/controller/reconciler/scheduled_run_reconciler.go
@@ -23,6 +23,16 @@ const (
 
 var cronParser = cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
 
+// ScheduledRunReconciler 处理"诊断模板"（spec.schedule 不为空的 DiagnosticRun）。
+//
+// 工作方式：
+//   - 模板自身永不变成 Running，只用 cron 表达式调度子 Run
+//   - 每次到点：克隆模板 spec（除 schedule 字段），创建一个新的 DiagnosticRun
+//     子任务（带 scheduledByLabel 标签指向模板）
+//   - HistoryLimit（默认 10）控制保留多少条历史子任务，超出按时间排序删除
+//   - status.nextRunAt 写下次触发时间，供 UI 展示
+//
+// 普通 Run（无 schedule）走 DiagnosticRunReconciler；模板 Run 走这里。
 type ScheduledRunReconciler struct {
 	client.Client
 }

--- a/internal/controller/reconciler/skill_reconciler.go
+++ b/internal/controller/reconciler/skill_reconciler.go
@@ -14,6 +14,14 @@ import (
 	"github.com/kube-agent-helper/kube-agent-helper/internal/store"
 )
 
+// DiagnosticSkillReconciler 把 DiagnosticSkill CR 同步到 Store。
+//
+// 双源 Skill 模型：
+//   - source="builtin"  启动时 main.go 从 /skills/*.md 加载（可被同名 CR 覆盖）
+//   - source="cr"       这里写入，用户通过 kubectl apply 管理
+//
+// CR 删除时只清理 source="cr" 的记录，避免误删 builtin。
+// Translator 调用 SkillRegistry.ListEnabled 时会按 priority 合并两类来源。
 type DiagnosticSkillReconciler struct {
 	client.Client
 	Store store.Store

--- a/internal/controller/registry/cluster_registry.go
+++ b/internal/controller/registry/cluster_registry.go
@@ -6,6 +6,18 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// ClusterClientRegistry 多集群客户端注册表。
+//
+// 用途：在"一份控制器管理多个目标集群"的场景下，按集群名缓存
+// 已经从远程 kubeconfig 构建好的 controller-runtime client。
+//
+// 写入路径：ClusterConfigReconciler 监听 ClusterConfig CR，读取
+// 引用的 Secret（kubeconfig），构建 client，调用 Set(name, c) 注册。
+//
+// 读取路径：DiagnosticRunReconciler 看到 run.Spec.ClusterRef 不为空时，
+// 调用 Get(name) 拿到目标集群 client，Job/ConfigMap/SA 都创建到那个集群。
+//
+// 当 ClusterRef 为空（默认）时，使用本地 mgr.GetClient()，不走该注册表。
 type ClusterClientRegistry struct {
 	mu      sync.RWMutex
 	clients map[string]client.Client

--- a/internal/controller/registry/registry.go
+++ b/internal/controller/registry/registry.go
@@ -1,3 +1,13 @@
+// Package registry 提供两种"按名查找"的注册表：
+//
+//   - SkillRegistry         技能注册表（这个文件）— 从 Store 拉取启用的 Skill
+//   - ClusterClientRegistry 多集群客户端注册表（cluster_registry.go）
+//
+// SkillRegistry 实现了 translator.SkillProvider 接口（鸭子类型），
+// 让 Translator 不直接依赖 store 包，便于测试时注入假数据。
+//
+// 注意：ListEnabled 每次都查 Store，未做缓存 — 这是有意为之，
+// 让 DiagnosticSkill CR 修改后下一次诊断立刻生效（热重载）。
 package registry
 
 import (
@@ -6,7 +16,7 @@ import (
 	"github.com/kube-agent-helper/kube-agent-helper/internal/store"
 )
 
-// SkillRegistry provides the current merged set of skills.
+// SkillRegistry 返回当前所有启用的技能集合。
 type SkillRegistry interface {
 	// ListEnabled returns all enabled skills, ordered by priority ASC.
 	ListEnabled(ctx context.Context) ([]*store.Skill, error)

--- a/internal/controller/translator/translator.go
+++ b/internal/controller/translator/translator.go
@@ -1,3 +1,23 @@
+// Package translator 把 DiagnosticRun CR 翻译成 K8s 原生资源。
+//
+// 核心方法 Compile() 一次产出 4 个对象（按顺序 apply）：
+//
+//	┌──────────────────┐
+//	│ ServiceAccount    │ ─ Agent Pod 的身份
+//	│ ClusterRoleBind   │ ─ 绑定到内置 "view" ClusterRole（最小只读）
+//	│ ConfigMap         │ ─ 把选中的 Skill .md 文件挂到 /workspace/skills/
+//	│ Job               │ ─ 启动 Agent Pod，注入环境变量、挂卷
+//	└──────────────────┘
+//
+// 设计要点：
+//   - SkillProvider 接口（duck-typed）— 不直接依赖 registry 包；
+//     测试时可注入静态 skills 列表
+//   - ModelConfig 解析顺序：run.Spec.ModelConfigRef → ModelConfig CR →
+//     全局 flag fallback；任意一级缺失都能正确降级
+//   - 多集群：Compile 只生成对象、不 Create；调用方（Reconciler）自己
+//     选 client（本地或 ClusterClientRegistry.Get）做 Apply
+//
+// 配套：FixGenerator（fix_generator.go）专门为 DiagnosticFix 翻译 Job。
 package translator
 
 import (

--- a/internal/k8sclient/clients.go
+++ b/internal/k8sclient/clients.go
@@ -1,3 +1,14 @@
+// Package k8sclient 集中构造给 MCP 工具用的所有客户端。
+//
+// 一个 Clients 结构封装：
+//   - kubernetes.Interface (typed)  ─ 标准 Pod/Deployment 等
+//   - dynamic.Interface              ─ 任意 GVR (CRD 也能用)
+//   - metricsv.Interface             ─ metrics.k8s.io（top_pods/top_nodes 用）
+//   - prometheus.API                 ─ 历史指标（PromQL 查询）
+//   - Mapper（mapper.go）             ─ Kind ↔ GVR 解析
+//
+// 工厂在 cmd/kah 和 cmd/...mcp-server 启动时调用一次，
+// 注入到所有 ToolHandler。Metrics / Prometheus 为 nil 安全 — 工具内做能力降级。
 package k8sclient
 
 import (

--- a/internal/mcptools/register.go
+++ b/internal/mcptools/register.go
@@ -1,3 +1,27 @@
+// Package mcptools 实现 K8s MCP Server 暴露给 Agent 的全部诊断工具。
+//
+// 调用链：
+//
+//	Agent (Python orchestrator)
+//	   │ stdio JSON-RPC（mcp-go 协议）
+//	   ▼
+//	k8s-mcp-server 二进制（cmd/...）
+//	   │
+//	   ▼
+//	mcptools.RegisterCore + RegisterExtension
+//	   │（每个工具一个 Handler，封装 kubectl / Prometheus / 内建逻辑）
+//	   ▼
+//	K8s API Server / Prometheus
+//
+// 工具分类：
+//   - 核心（Core，4 个）：kubectl_get / describe / logs + events_list
+//   - 扩展（Extension，11 个）：top_pods / top_nodes / prometheus_query /
+//     prometheus_alerts / network_policy_check / node_status / pvc_status /
+//     rollout_status / list_api_resources / kubectl_explain /
+//     events_history / metric_history
+//
+// 安全：所有工具的入参经 internal/audit 包做参数脱敏后才记录日志，
+// 防止 Secret 内容泄露。
 package mcptools
 
 import (

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,3 +1,26 @@
+// Package metrics 定义并暴露控制器自身的 Prometheus 指标。
+//
+// 指标清单（命名前缀 kah_）：
+//
+//	┌────────────────────────────────────┬──────────┬─────────────────────────┐
+//	│ 名称                                │ 类型      │ 含义                     │
+//	├────────────────────────────────────┼──────────┼─────────────────────────┤
+//	│ kah_diagnostic_runs_total          │ Counter  │ 诊断任务计数（按 phase）  │
+//	│ kah_diagnostic_run_duration_seconds│ Histogram│ 诊断耗时                 │
+//	│ kah_findings_total                 │ Counter  │ 发现条数（按 severity）   │
+//	│ kah_fixes_total                    │ Counter  │ 修复任务（按 phase）      │
+//	│ kah_llm_requests_total             │ Counter  │ LLM 调用数                │
+//	│ kah_llm_request_duration_seconds   │ Histogram│ LLM 单次耗时              │
+//	│ kah_llm_tokens_total               │ Counter  │ Token 用量                │
+//	│ kah_event_collector_events_total   │ Counter  │ 采集到的 K8s 事件         │
+//	│ kah_active_runs                    │ Gauge    │ 当前运行中的任务数         │
+//	└────────────────────────────────────┴──────────┴─────────────────────────┘
+//
+// 暴露方式：HTTP server 在 /metrics 注册 promhttp.HandlerFor(m.Registry())。
+// Helm chart 提供可选的 ServiceMonitor 让 Prometheus Operator 自动发现。
+//
+// 实例化注意：使用独立的 prometheus.Registry（非 default），避免和 controller-runtime
+// 自带 metrics 混在一起，便于隔离测试。
 package metrics
 
 import (

--- a/internal/notification/manager.go
+++ b/internal/notification/manager.go
@@ -1,3 +1,19 @@
+// Package notification 实现事件通知扇出与多通道集成。
+//
+// 架构角色：
+//   - Manager 维护一组 Notifier（Webhook / Slack / DingTalk / Feishu），
+//     接收来自 Reconciler 的 Event 后并行投递到所有匹配的通道。
+//   - 通过 NotifyDispatcher 接口（在 reconciler 包定义）反向暴露给 Reconciler，
+//     避免 reconciler ↔ notification 包形成循环依赖。
+//
+// 关键能力：
+//   - 去重：按 (Type, Resource) 组合做 dedup，默认 5 分钟窗口。
+//   - 事件过滤：每个通道可配置只接收某些 EventType，未配置 = 全收。
+//   - 热重载：ReloadFromConfigs 可被 HTTP API 调用，DB 配置变更后立即生效。
+//
+// 配置来源（启动时按优先级）：
+//  1. SQLite notification_configs 表（HTTP API 增删改）— 推荐
+//  2. controller 启动 flag（--notify-slack-url 等）— 备选
 package notification
 
 import (

--- a/internal/sanitize/sanitize.go
+++ b/internal/sanitize/sanitize.go
@@ -1,3 +1,16 @@
+// Package sanitize 在 K8s 资源对象返回给 LLM 前做敏感字段脱敏。
+//
+// 用途：MCP 工具（kubectl_get / describe）返回 Pod / Secret / ConfigMap 时，
+// 用 Clean(obj, opts) 去掉以下内容防止泄漏给 LLM 或日志：
+//   - Secret.data 全部置空
+//   - ConfigMap.data 中匹配 ConfigMapKeyMask 的 key 置空
+//   - Pod env / volumeMounts / serviceAccountToken 中的密文字段
+//   - managedFields / lastAppliedConfiguration 等噪声字段
+//
+// 设计要点：
+//   - 输入对象不修改（DeepCopy 后操作）
+//   - 幂等：Clean(Clean(x)) == Clean(x)
+//   - 配合 trimmer 一起用，先 trim 再 sanitize
 package sanitize
 
 import (

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -883,6 +883,11 @@ func (s *SQLiteStore) DeleteNotificationConfig(ctx context.Context, id string) e
 
 // ── Batch operations ──────────────────────────────────────────────────────────
 
+// DeleteRuns 级联删除一批 run。
+//
+// 子表（findings / run_logs / fixes）通过 run_id FK 引用 diagnostic_runs，
+// 直接删主表会触发 FOREIGN KEY constraint failed。这里在事务内先清子表再删主表，
+// 保证幂等：任何 ID 不存在都不报错。
 func (s *SQLiteStore) DeleteRuns(ctx context.Context, ids []string) error {
 	if len(ids) == 0 {
 		return nil
@@ -893,10 +898,25 @@ func (s *SQLiteStore) DeleteRuns(ctx context.Context, ids []string) error {
 		placeholders[i] = "?"
 		args[i] = id
 	}
-	query := fmt.Sprintf("DELETE FROM diagnostic_runs WHERE id IN (%s)",
-		strings.Join(placeholders, ","))
-	_, err := s.db.ExecContext(ctx, query, args...)
-	return err
+	in := strings.Join(placeholders, ",")
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	for _, table := range []string{"findings", "run_logs", "fixes"} {
+		q := fmt.Sprintf("DELETE FROM %s WHERE run_id IN (%s)", table, in)
+		if _, err := tx.ExecContext(ctx, q, args...); err != nil {
+			return fmt.Errorf("delete %s: %w", table, err)
+		}
+	}
+	q := fmt.Sprintf("DELETE FROM diagnostic_runs WHERE id IN (%s)", in)
+	if _, err := tx.ExecContext(ctx, q, args...); err != nil {
+		return fmt.Errorf("delete diagnostic_runs: %w", err)
+	}
+	return tx.Commit()
 }
 
 func (s *SQLiteStore) BatchUpdateFixPhase(ctx context.Context, ids []string, phase store.FixPhase, msg string) error {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,3 +1,22 @@
+// Package store 定义系统的持久化抽象层。
+//
+// 架构角色：
+//   - 整个系统的"数据库门面"。Reconciler / HTTP Server / Collector 全部
+//     通过 Store 接口读写数据，不直接依赖 SQL。
+//   - 内置的 sqlite 子包是默认实现，未来可扩展 Postgres 而上层无感知。
+//
+// 数据模型：
+//   - DiagnosticRun  一次诊断任务（与 K8s CR 一一对应，UID 作为 ID）
+//   - Finding        诊断产出（一次 Run 多条 Finding）
+//   - Skill          诊断能力（来自 builtin .md 或 DiagnosticSkill CR）
+//   - Fix            修复建议（findings 衍生，可批准/应用）
+//   - Event          K8s Warning 事件（7 天保留）
+//   - MetricSnapshot Prometheus 指标采样
+//   - RunLog         Agent Pod 结构化日志
+//   - NotificationConfig 通知通道配置
+//
+// 多集群：所有列表查询都支持 ClusterName 过滤，配合 ClusterClientRegistry
+// 实现"一份控制器、多个目标集群"的视图。
 package store
 
 import (

--- a/internal/trimmer/trimmer.go
+++ b/internal/trimmer/trimmer.go
@@ -1,3 +1,16 @@
+// Package trimmer 把 K8s 资源对象投影成"列表精简版"，节省 LLM token。
+//
+// 工作场景：MCP 工具 kubectl_get 在 list 模式返回大量资源时，
+// 完整对象一项动辄几十 KB，会很快撑爆 LLM 上下文。
+// 这里按 Kind（Pod/Deployment/Service/Node/Event）只保留诊断必需字段：
+//
+//   Pod      → name + status.phase + containerStatuses(reason/restartCount)
+//   Deploy   → name + replicas + available/updated + condition reasons
+//   Service  → name + type + clusterIP + ports
+//   Node     → name + addresses + conditions(Ready/Memory/Disk Pressure)
+//   Event    → reason + message + count + lastTimestamp
+//
+// 不在清单中的 Kind 走通用投影（保留 metadata + status 顶层字段）。
 package trimmer
 
 import (


### PR DESCRIPTION
## Summary
- Implement dashboard batch operations for runs (closes #32 acceptance criteria for batch select / URL state) — checkbox column, BatchToolbar with delete, URL-synced page/sort/filter via `useTableState({ syncURL: true })`
- Fix run deletion bug chain discovered during self-test:
  - DELETE /api/runs/batch now deletes the K8s DiagnosticRun CR before the SQLite row (otherwise the reconciler re-creates the row from the CR for Pending/Running runs)
  - `store.DeleteRuns` cascades through child tables (findings / run_logs / fixes) inside a tx — fixes `FOREIGN KEY constraint failed`
  - Next.js `[...proxy]` now exports DELETE and PUT (previously only GET/POST/PATCH, so DELETE returned 405)
  - ClusterRole gains `delete` on `k8sai.io` resources
  - Batch handlers surface errors via `window.alert()` instead of swallowing them
- Add Chinese file-header architecture notes across the codebase (Go controller, Python agent runtime, dashboard) to make onboarding easier — no behavior change

## Test plan
- [x] `go build ./...`, `npx tsc --noEmit`, `npx vitest run` all pass
- [x] Manual: deploy to minikube, create runs with various phases, batch-delete from dashboard
  - Pending / Running / Succeeded / Failed runs all delete cleanly
  - URL reflects `?runs.page=2&runs.phase=Failed`, refresh restores state
  - Failed delete shows alert with backend message
  - Live log streaming still works for in-flight runs
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)