### PR TITLE
fix(tracer): fallback to message_delta for input_tokens

### DIFF
--- a/agent-runtime/runtime/orchestrator.py
+++ b/agent-runtime/runtime/orchestrator.py
@@ -249,7 +249,10 @@ def _stream_message(client, tools, messages) -> dict:
                 delta = event.get("delta", {})
                 if delta.get("stop_reason"):
                     stop_reason = delta["stop_reason"]
-                output_tokens = event.get("usage", {}).get("output_tokens", output_tokens)
+                usage = event.get("usage", {})
+                output_tokens = usage.get("output_tokens", output_tokens)
+                if input_tokens == 0:
+                    input_tokens = usage.get("input_tokens", 0)
 
     # Post-process: parse tool_use input JSON, drop thinking blocks
     result_blocks = []


### PR DESCRIPTION
## Summary

- When the LLM proxy omits `input_tokens` in the `message_start` SSE event, fall back to reading it from `message_delta.usage.input_tokens`
- Fixes Langfuse generations showing `input: 0` tokens

## Test plan

- [x] Verified Langfuse UI now shows correct input token counts after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)