### PR TITLE
fix: batch fixes for issues #41 #42 #43 #44

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,11 +256,42 @@ jobs:
 
       - name: Install dependencies
         working-directory: agent-runtime
-        run: pip install -r requirements.txt pytest httpx
+        run: pip install -r requirements.txt pytest pytest-cov httpx
 
-      - name: Run tests
+      - name: Run tests with coverage
         working-directory: agent-runtime
-        run: PYTHONPATH=. python -m pytest tests/ -v
+        run: |
+          PYTHONPATH=. python -m pytest tests/ -v \
+            --cov=runtime \
+            --cov-report=term-missing \
+            --cov-report=xml:coverage.xml \
+            --cov-report=html:htmlcov
+
+      - name: Agent runtime coverage summary
+        if: always()
+        working-directory: agent-runtime
+        run: |
+          echo '## Agent Runtime Test Coverage' >> $GITHUB_STEP_SUMMARY
+          if [ -f coverage.xml ]; then
+            python3 -c "
+          import xml.etree.ElementTree as ET
+          root = ET.parse('coverage.xml').getroot()
+          line_rate = float(root.get('line-rate', 0)) * 100
+          branch_rate = float(root.get('branch-rate', 0)) * 100
+          print('| Metric | Coverage |')
+          print('|--------|----------|')
+          print(f'| Lines | {line_rate:.1f}% |')
+          print(f'| Branches | {branch_rate:.1f}% |')
+          " >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-runtime-coverage
+          path: agent-runtime/htmlcov/
+          retention-days: 7
 
   skill-lint:
     name: Skill File Validation

--- a/agent-runtime/runtime/model_chain.py
+++ b/agent-runtime/runtime/model_chain.py
@@ -86,7 +86,7 @@ def _stream_one(endpoint: ModelEndpoint, tools, messages) -> dict:
 
     payload: dict[str, Any] = {
         "model": endpoint.model,
-        "max_tokens": int(os.environ.get("MAX_TOKENS", "4096")),
+        "max_tokens": int(os.environ.get("MAX_TOKENS", "8192")),
         "messages": messages,
         "stream": True,
     }

--- a/agent-runtime/runtime/orchestrator.py
+++ b/agent-runtime/runtime/orchestrator.py
@@ -35,6 +35,60 @@ from .skill_loader import Skill
 
 TARGET_NAMESPACES = os.environ.get("TARGET_NAMESPACES", "default")
 
+# Findings extraction (issue #44): the LLM emits one finding per line as
+# "FINDING_JSON: <single-line json>". Validation runs in extract_findings;
+# malformed entries are returned as parse errors so callers can log + emit
+# observability events.
+_FINDING_PREFIX = "FINDING_JSON: "
+_FINDING_REQUIRED_FIELDS = frozenset({
+    "dimension",
+    "severity",
+    "title",
+    "description",
+    "resource_kind",
+    "resource_namespace",
+    "resource_name",
+    "suggestion",
+})
+_DIMENSION_ENUM = frozenset({"health", "security", "cost", "reliability"})
+_SEVERITY_ENUM = frozenset({"critical", "high", "medium", "low", "info"})
+
+
+def extract_findings(text: str) -> tuple[list[dict], list[str]]:
+    """Parse FINDING_JSON: prefixed lines from LLM text output.
+
+    Returns (valid_findings, parse_errors). Each parse_error is a short
+    human-readable description suitable for logging or trace events.
+    The caller is responsible for emitting logs / metrics / events.
+    """
+    findings: list[dict] = []
+    errors: list[str] = []
+    for raw in text.split("\n"):
+        line = raw.strip()
+        if not line.startswith(_FINDING_PREFIX):
+            continue
+        payload = line[len(_FINDING_PREFIX):].strip()
+        try:
+            obj = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            errors.append(f"json parse failed: {exc.msg}")
+            continue
+        if not isinstance(obj, dict):
+            errors.append("finding payload is not a JSON object")
+            continue
+        missing = _FINDING_REQUIRED_FIELDS - obj.keys()
+        if missing:
+            errors.append(f"missing required field(s): {sorted(missing)}")
+            continue
+        if obj["dimension"] not in _DIMENSION_ENUM:
+            errors.append(f"invalid dimension: {obj['dimension']!r}")
+            continue
+        if obj["severity"] not in _SEVERITY_ENUM:
+            errors.append(f"invalid severity: {obj['severity']!r}")
+            continue
+        findings.append(obj)
+    return findings, errors
+
 
 def build_prompt(skills: List[Skill]) -> str:
     skill_list = "\n".join(

--- a/agent-runtime/runtime/orchestrator.py
+++ b/agent-runtime/runtime/orchestrator.py
@@ -27,6 +27,7 @@ import os
 from typing import List
 
 from . import logger
+from . import reporter
 from . import tracer as _tracer_mod
 from .mcp_client import discover_tools, call_mcp_tool
 from .model_chain import ModelChain
@@ -120,8 +121,9 @@ Available diagnostic skills:
 Instructions:
 1. For each skill, analyze the cluster in the target namespaces.
 2. Use the available MCP tools to gather data.
-3. For each issue found, output a finding JSON object on its own line:
-   {{"dimension":"<dim>","severity":"<critical|high|medium|low|info>","title":"<title>","description":"<desc>","resource_kind":"<kind>","resource_namespace":"<ns>","resource_name":"<name>","suggestion":"<suggestion>"}}
+3. For each issue found, emit ONE line in this exact format (literal `FINDING_JSON: ` prefix, single-line JSON, no markdown fence, no trailing commentary on the same line):
+   FINDING_JSON: {{"dimension":"<health|security|cost|reliability>","severity":"<critical|high|medium|low|info>","title":"<title>","description":"<desc>","resource_kind":"<kind>","resource_namespace":"<ns>","resource_name":"<name>","suggestion":"<suggestion>"}}
+   All eight fields are REQUIRED. `dimension` and `severity` MUST be one of the listed enum values.
 4. After all skills complete, output: FINDINGS_COMPLETE
 """
 
@@ -181,15 +183,19 @@ def run_agent(skills: List[Skill], tracer=None) -> List[dict]:
             if block["type"] == "text" and block.get("text"):
                 assistant_content.append({"type": "text", "text": block["text"]})
                 logger.debug("text block", chars=len(block['text']), preview=block['text'][:200])
-                # Extract findings from text
-                for line in block["text"].split("\n"):
-                    line = line.strip()
-                    if line.startswith("{") and "dimension" in line:
-                        try:
-                            f = json.loads(line)
-                            findings.append(f)
-                        except json.JSONDecodeError:
-                            pass
+                block_findings, parse_errors = extract_findings(block["text"])
+                findings.extend(block_findings)
+                for err in parse_errors:
+                    logger.warn("finding parse failed", error=err, turn=turn + 1)
+                    tracer.event(
+                        name="finding_parse_error",
+                        level="WARNING",
+                        metadata={"turn": turn + 1, "error": err},
+                    )
+                    reporter.record_llm_event(
+                        "finding_parse_error",
+                        {"turn": str(turn + 1), "error": err},
+                    )
             elif block["type"] == "tool_use":
                 assistant_content.append(block)
                 logger.debug("tool_use", tool=block['name'], input=block.get('input', {}))

--- a/agent-runtime/runtime/orchestrator.py
+++ b/agent-runtime/runtime/orchestrator.py
@@ -8,7 +8,7 @@ run_agent() 的循环：
             ↓
     ┌─ for turn in 0..MAX_TURNS:
     │     ┌─ Claude 流式 API 推理
-    │     │     ├─ 收到 text 块 → 扫 JSON finding，加入 findings[]
+    │     │     ├─ 收到 text 块 → extract_findings() 校验 schema → findings[]
     │     │     ├─ 收到 tool_use 块 → 转 call_mcp_tool() 拿结果
     │     │     └─ 把工具结果回喂给 LLM 作为 user 消息
     │     └─ stop_reason == "end_turn" → break

--- a/agent-runtime/runtime/orchestrator.py
+++ b/agent-runtime/runtime/orchestrator.py
@@ -90,6 +90,9 @@ def run_agent(skills: List[Skill], tracer=None) -> List[dict]:
 
     findings = []
     max_turns = int(os.environ.get("MAX_TURNS", "10"))
+    max_tokens_continue_limit = int(os.environ.get("MAX_TOKENS_CONTINUE_LIMIT", "3"))
+    max_tokens_behavior = os.environ.get("MAX_TOKENS_BEHAVIOR", "continue")
+    consecutive_max_tokens = 0
 
     for turn in range(max_turns):
         logger.info("turn", turn=turn + 1, max_turns=max_turns)
@@ -141,6 +144,7 @@ def run_agent(skills: List[Skill], tracer=None) -> List[dict]:
             break
 
         if response["stop_reason"] == "tool_use":
+            consecutive_max_tokens = 0
             tool_results = []
             for block in response["content"]:
                 if block["type"] == "tool_use":
@@ -152,6 +156,34 @@ def run_agent(skills: List[Skill], tracer=None) -> List[dict]:
                         "content": result,
                     })
             messages.append({"role": "user", "content": tool_results})
+        elif response["stop_reason"] == "max_tokens":
+            logger.warn(
+                "hit max_tokens",
+                turn=turn + 1,
+                behavior=max_tokens_behavior,
+                consecutive=consecutive_max_tokens + 1,
+                limit=max_tokens_continue_limit,
+            )
+            tracer.event(
+                name="max_tokens_hit",
+                level="WARNING",
+                metadata={
+                    "turn": turn + 1,
+                    "behavior": max_tokens_behavior,
+                    "consecutive": consecutive_max_tokens + 1,
+                },
+            )
+            if max_tokens_behavior == "fail":
+                break
+            consecutive_max_tokens += 1
+            if consecutive_max_tokens >= max_tokens_continue_limit:
+                logger.warn(
+                    "max_tokens continue limit reached, stopping",
+                    limit=max_tokens_continue_limit,
+                )
+                break
+            # behavior == "continue": loop iterates again with the now-extended
+            # messages history; assistant_content has already been appended above.
         else:
             logger.warn("unexpected stop_reason, stopping", stop_reason=response['stop_reason'])
             break

--- a/agent-runtime/runtime/orchestrator.py
+++ b/agent-runtime/runtime/orchestrator.py
@@ -92,6 +92,12 @@ def run_agent(skills: List[Skill], tracer=None) -> List[dict]:
     max_turns = int(os.environ.get("MAX_TURNS", "10"))
     max_tokens_continue_limit = int(os.environ.get("MAX_TOKENS_CONTINUE_LIMIT", "3"))
     max_tokens_behavior = os.environ.get("MAX_TOKENS_BEHAVIOR", "continue")
+    if max_tokens_behavior not in ("continue", "fail"):
+        logger.warn(
+            "unknown MAX_TOKENS_BEHAVIOR value, defaulting to continue",
+            value=max_tokens_behavior,
+        )
+        max_tokens_behavior = "continue"
     consecutive_max_tokens = 0
 
     for turn in range(max_turns):
@@ -179,6 +185,8 @@ def run_agent(skills: List[Skill], tracer=None) -> List[dict]:
             if consecutive_max_tokens >= max_tokens_continue_limit:
                 logger.warn(
                     "max_tokens continue limit reached, stopping",
+                    turn=turn + 1,
+                    consecutive=consecutive_max_tokens,
                     limit=max_tokens_continue_limit,
                 )
                 break

--- a/agent-runtime/runtime/reporter.py
+++ b/agent-runtime/runtime/reporter.py
@@ -33,7 +33,9 @@ _LLM_BUFFER: list[dict] = []
 def record_llm_event(event_type: str, labels: dict) -> None:
     """Buffer an LLM event for later batch upload to /internal/llm-metrics.
 
-    event_type: one of "retry" / "fallback" / "exhausted".
+    event_type: any short string identifying the event class. Current
+        producers: "retry", "fallback", "exhausted" (model_chain.py),
+        "finding_parse_error" (orchestrator.py).
     labels: free-form k/v sent as Prometheus labels server-side.
     """
     _LLM_BUFFER.append({"type": event_type, "labels": labels})

--- a/agent-runtime/tests/test_model_chain.py
+++ b/agent-runtime/tests/test_model_chain.py
@@ -258,6 +258,33 @@ class TestStreamOne:
         assert result["content"][0]["type"] == "text"
         assert result["content"][0]["text"] == "answer"
 
+    def test_default_max_tokens_is_8192(self, monkeypatch):
+        """When MAX_TOKENS env is unset, _stream_one must request 8192."""
+        monkeypatch.delenv("MAX_TOKENS", raising=False)
+        events = ['{"type":"message_stop"}']
+        ep = ModelEndpoint(base_url="", model="m", api_key="k", retries=0)
+
+        with patch("runtime.model_chain.httpx.stream") as mock_stream:
+            mock_stream.return_value = _fake_stream(_make_sse_lines(events))
+            _stream_one(ep, tools=[], messages=[])
+
+        _, kwargs = mock_stream.call_args
+        assert kwargs["json"]["max_tokens"] == 8192
+
+    def test_max_tokens_env_override(self, monkeypatch):
+        """MAX_TOKENS env overrides the default."""
+        monkeypatch.setenv("MAX_TOKENS", "16384")
+        events = ['{"type":"message_stop"}']
+        ep = ModelEndpoint(base_url="", model="m", api_key="k", retries=0)
+
+        with patch("runtime.model_chain.httpx.stream") as mock_stream:
+            mock_stream.return_value = _fake_stream(_make_sse_lines(events))
+            _stream_one(ep, tools=[], messages=[])
+
+        _, kwargs = mock_stream.call_args
+        assert kwargs["json"]["max_tokens"] == 16384
+
+
 class TestInvoke:
     def test_succeeds_first_try(self):
         chain = ModelChain([ModelEndpoint(base_url="", model="m", api_key="k", retries=0)])

--- a/agent-runtime/tests/test_orchestrator.py
+++ b/agent-runtime/tests/test_orchestrator.py
@@ -13,6 +13,96 @@ from runtime.orchestrator import build_prompt, run_agent
 from runtime.skill_loader import Skill
 
 
+class TestExtractFindings:
+    """Tests for the FINDING_JSON: prefix extractor."""
+
+    def test_single_valid_finding(self):
+        text = (
+            "Some preamble.\n"
+            'FINDING_JSON: {"dimension":"health","severity":"critical","title":"Pod CrashLoopBackOff","description":"d","resource_kind":"Pod","resource_namespace":"default","resource_name":"nginx","suggestion":"Restart"}\n'
+            "FINDINGS_COMPLETE"
+        )
+        from runtime.orchestrator import extract_findings
+
+        findings, errors = extract_findings(text)
+        assert errors == []
+        assert len(findings) == 1
+        assert findings[0]["title"] == "Pod CrashLoopBackOff"
+
+    def test_multiple_findings_one_invalid_enum(self):
+        text = (
+            'FINDING_JSON: {"dimension":"health","severity":"critical","title":"A","description":"d","resource_kind":"Pod","resource_namespace":"ns","resource_name":"a","suggestion":"s"}\n'
+            'FINDING_JSON: {"dimension":"BOGUS","severity":"critical","title":"B","description":"d","resource_kind":"Pod","resource_namespace":"ns","resource_name":"b","suggestion":"s"}\n'
+            'FINDING_JSON: {"dimension":"security","severity":"medium","title":"C","description":"d","resource_kind":"Pod","resource_namespace":"ns","resource_name":"c","suggestion":"s"}\n'
+        )
+        from runtime.orchestrator import extract_findings
+
+        findings, errors = extract_findings(text)
+        assert len(findings) == 2  # A and C accepted, B rejected
+        assert {f["title"] for f in findings} == {"A", "C"}
+        assert len(errors) == 1
+        assert "dimension" in errors[0]
+
+    def test_missing_required_field_rejected(self):
+        # No `suggestion` key
+        text = 'FINDING_JSON: {"dimension":"health","severity":"low","title":"X","description":"d","resource_kind":"Pod","resource_namespace":"n","resource_name":"x"}\n'
+        from runtime.orchestrator import extract_findings
+
+        findings, errors = extract_findings(text)
+        assert findings == []
+        assert len(errors) == 1
+        assert "suggestion" in errors[0]
+
+    def test_invalid_severity_enum_rejected(self):
+        text = 'FINDING_JSON: {"dimension":"health","severity":"PANIC","title":"X","description":"d","resource_kind":"Pod","resource_namespace":"n","resource_name":"x","suggestion":"s"}\n'
+        from runtime.orchestrator import extract_findings
+
+        findings, errors = extract_findings(text)
+        assert findings == []
+        assert len(errors) == 1
+        assert "severity" in errors[0]
+
+    def test_markdown_code_fence_json_not_extracted(self):
+        """Old startswith heuristic falsely captured JSON inside ``` blocks. New parser must not."""
+        text = (
+            "Here is an example finding format:\n"
+            "```json\n"
+            '{"dimension":"health","severity":"critical","title":"EXAMPLE","description":"d","resource_kind":"Pod","resource_namespace":"n","resource_name":"e","suggestion":"s"}\n'
+            "```\n"
+            "Now the real one:\n"
+            'FINDING_JSON: {"dimension":"health","severity":"low","title":"REAL","description":"d","resource_kind":"Pod","resource_namespace":"n","resource_name":"r","suggestion":"s"}\n'
+        )
+        from runtime.orchestrator import extract_findings
+
+        findings, errors = extract_findings(text)
+        assert len(findings) == 1
+        assert findings[0]["title"] == "REAL"
+        assert errors == []
+
+    def test_pretty_printed_multiline_json_not_extracted(self):
+        """Multi-line JSON without prefix on first line is rejected — keeps the contract single-line."""
+        text = (
+            "FINDING_JSON: {\n"
+            '  "dimension": "health",\n'
+            '  "severity": "critical"\n'
+            "}\n"
+        )
+        from runtime.orchestrator import extract_findings
+
+        findings, errors = extract_findings(text)
+        # Either parsed nothing (only the prefix line is invalid JSON), or
+        # captured an error — both are acceptable, but findings must be empty.
+        assert findings == []
+
+    def test_garbage_after_prefix_logged(self):
+        text = "FINDING_JSON: not-json-at-all\n"
+        from runtime.orchestrator import extract_findings
+
+        findings, errors = extract_findings(text)
+        assert findings == []
+        assert len(errors) == 1
+
+
 class TestBuildPrompt:
     def test_contains_skill_info(self, monkeypatch):
         monkeypatch.setenv("TARGET_NAMESPACES", "default")

--- a/agent-runtime/tests/test_orchestrator.py
+++ b/agent-runtime/tests/test_orchestrator.py
@@ -244,3 +244,32 @@ class TestRunAgent:
                     run_agent([Skill(name="t", dimension="h", tools=[], prompt="p")])
 
         assert chain.invoke.call_count == 6, f"counter should reset after tool_use; got {chain.invoke.call_count}"
+
+    def test_unknown_max_tokens_behavior_defaults_to_continue(self, monkeypatch):
+        """An unrecognized MAX_TOKENS_BEHAVIOR value must fall back to continue, not fail silently."""
+        monkeypatch.setenv("OUTPUT_LANGUAGE", "en")
+        monkeypatch.setenv("MAX_TURNS", "5")
+        monkeypatch.setenv("MAX_TOKENS_BEHAVIOR", "FAIL")  # uppercase typo — not "fail"
+        monkeypatch.delenv("MAX_TOKENS_CONTINUE_LIMIT", raising=False)
+
+        truncated = {
+            "content": [{"type": "text", "text": "..."}],
+            "stop_reason": "max_tokens",
+            "input_tokens": 0, "output_tokens": 0,
+        }
+        end = {
+            "content": [{"type": "text", "text": "done\nFINDINGS_COMPLETE"}],
+            "stop_reason": "end_turn",
+            "input_tokens": 0, "output_tokens": 0,
+        }
+        chain = _make_chain_mock([truncated, end])
+
+        with patch("runtime.orchestrator.discover_tools", return_value=[]):
+            with patch("runtime.orchestrator.ModelChain.from_env", return_value=chain):
+                run_agent([Skill(name="t", dimension="h", tools=[], prompt="p")])
+
+        # If "FAIL" had been silently treated as fail, invoke count would be 1.
+        # With validation, it falls back to continue → 2 invokes.
+        assert chain.invoke.call_count == 2, (
+            "unknown behavior must fall back to continue (not silently fail)"
+        )

--- a/agent-runtime/tests/test_orchestrator.py
+++ b/agent-runtime/tests/test_orchestrator.py
@@ -247,8 +247,8 @@ class TestRunAgent:
 
         finding_json = json.dumps({
             "dimension": "health", "severity": "critical",
-            "title": "Found", "resource_kind": "Pod",
-            "resource_namespace": "default", "resource_name": "p",
+            "title": "Found", "description": "desc", "suggestion": "fix it",
+            "resource_kind": "Pod", "resource_namespace": "default", "resource_name": "p",
         })
         truncated = {
             "content": [{"type": "text", "text": "partial analysis..."}],
@@ -256,7 +256,7 @@ class TestRunAgent:
             "input_tokens": 0, "output_tokens": 0,
         }
         completion = {
-            "content": [{"type": "text", "text": f"{finding_json}\nFINDINGS_COMPLETE"}],
+            "content": [{"type": "text", "text": f"FINDING_JSON: {finding_json}\nFINDINGS_COMPLETE"}],
             "stop_reason": "end_turn",
             "input_tokens": 0, "output_tokens": 0,
         }

--- a/agent-runtime/tests/test_orchestrator.py
+++ b/agent-runtime/tests/test_orchestrator.py
@@ -139,3 +139,108 @@ class TestRunAgent:
             with patch("runtime.orchestrator.ModelChain.from_env", return_value=chain):
                 with pytest.raises(ModelChainExhausted):
                     run_agent([Skill(name="t", dimension="h", tools=[], prompt="p")])
+
+    def test_max_tokens_continues_by_default(self, monkeypatch):
+        """stop_reason=max_tokens with default behavior should continue to next turn."""
+        monkeypatch.setenv("OUTPUT_LANGUAGE", "en")
+        monkeypatch.setenv("MAX_TURNS", "5")
+        monkeypatch.delenv("MAX_TOKENS_BEHAVIOR", raising=False)
+        monkeypatch.delenv("MAX_TOKENS_CONTINUE_LIMIT", raising=False)
+
+        finding_json = json.dumps({
+            "dimension": "health", "severity": "critical",
+            "title": "Found", "resource_kind": "Pod",
+            "resource_namespace": "default", "resource_name": "p",
+        })
+        truncated = {
+            "content": [{"type": "text", "text": "partial analysis..."}],
+            "stop_reason": "max_tokens",
+            "input_tokens": 0, "output_tokens": 0,
+        }
+        completion = {
+            "content": [{"type": "text", "text": f"{finding_json}\nFINDINGS_COMPLETE"}],
+            "stop_reason": "end_turn",
+            "input_tokens": 0, "output_tokens": 0,
+        }
+        chain = _make_chain_mock([truncated, completion])
+
+        with patch("runtime.orchestrator.discover_tools", return_value=[]):
+            with patch("runtime.orchestrator.ModelChain.from_env", return_value=chain):
+                findings = run_agent([Skill(name="t", dimension="h", tools=[], prompt="p")])
+
+        assert chain.invoke.call_count == 2, "should continue past max_tokens"
+        assert len(findings) == 1
+        assert findings[0]["title"] == "Found"
+
+    def test_max_tokens_death_loop_breaks_at_limit(self, monkeypatch):
+        """Consecutive max_tokens beyond the configured limit must stop the loop."""
+        monkeypatch.setenv("OUTPUT_LANGUAGE", "en")
+        monkeypatch.setenv("MAX_TURNS", "10")
+        monkeypatch.setenv("MAX_TOKENS_CONTINUE_LIMIT", "3")
+        monkeypatch.delenv("MAX_TOKENS_BEHAVIOR", raising=False)
+
+        truncated = {
+            "content": [{"type": "text", "text": "..."}],
+            "stop_reason": "max_tokens",
+            "input_tokens": 0, "output_tokens": 0,
+        }
+        chain = _make_chain_mock(truncated)  # always returns max_tokens
+
+        with patch("runtime.orchestrator.discover_tools", return_value=[]):
+            with patch("runtime.orchestrator.ModelChain.from_env", return_value=chain):
+                findings = run_agent([Skill(name="t", dimension="h", tools=[], prompt="p")])
+
+        assert chain.invoke.call_count == 3, f"expected 3 invokes, got {chain.invoke.call_count}"
+        assert findings == []
+
+    def test_max_tokens_behavior_fail_stops_immediately(self, monkeypatch):
+        """MAX_TOKENS_BEHAVIOR=fail must break the loop on the first max_tokens hit."""
+        monkeypatch.setenv("OUTPUT_LANGUAGE", "en")
+        monkeypatch.setenv("MAX_TURNS", "10")
+        monkeypatch.setenv("MAX_TOKENS_BEHAVIOR", "fail")
+
+        truncated = {
+            "content": [{"type": "text", "text": "..."}],
+            "stop_reason": "max_tokens",
+            "input_tokens": 0, "output_tokens": 0,
+        }
+        chain = _make_chain_mock(truncated)
+
+        with patch("runtime.orchestrator.discover_tools", return_value=[]):
+            with patch("runtime.orchestrator.ModelChain.from_env", return_value=chain):
+                findings = run_agent([Skill(name="t", dimension="h", tools=[], prompt="p")])
+
+        assert chain.invoke.call_count == 1, "fail behavior must stop after first hit"
+        assert findings == []
+
+    def test_max_tokens_counter_resets_on_non_max_tokens(self, monkeypatch):
+        """A non-max_tokens turn must reset the consecutive counter."""
+        monkeypatch.setenv("OUTPUT_LANGUAGE", "en")
+        monkeypatch.setenv("MAX_TURNS", "10")
+        monkeypatch.setenv("MAX_TOKENS_CONTINUE_LIMIT", "3")  # limit=3: allows 2 consecutive, breaks on 3rd
+        monkeypatch.delenv("MAX_TOKENS_BEHAVIOR", raising=False)
+
+        max_t = {
+            "content": [{"type": "text", "text": "..."}],
+            "stop_reason": "max_tokens",
+            "input_tokens": 0, "output_tokens": 0,
+        }
+        tool_call = {
+            "content": [{"type": "tool_use", "id": "tu", "name": "kubectl_get", "input": {}}],
+            "stop_reason": "tool_use",
+            "input_tokens": 0, "output_tokens": 0,
+        }
+        end = {
+            "content": [{"type": "text", "text": "FINDINGS_COMPLETE"}],
+            "stop_reason": "end_turn",
+            "input_tokens": 0, "output_tokens": 0,
+        }
+        # Sequence: max, max, tool_use (resets counter), max, max, end_turn → 6 invokes total
+        chain = _make_chain_mock([max_t, max_t, tool_call, max_t, max_t, end])
+
+        with patch("runtime.orchestrator.discover_tools", return_value=[]):
+            with patch("runtime.orchestrator.ModelChain.from_env", return_value=chain):
+                with patch("runtime.orchestrator.call_mcp_tool", return_value="{}"):
+                    run_agent([Skill(name="t", dimension="h", tools=[], prompt="p")])
+
+        assert chain.invoke.call_count == 6, f"counter should reset after tool_use; got {chain.invoke.call_count}"

--- a/agent-runtime/tests/test_orchestrator.py
+++ b/agent-runtime/tests/test_orchestrator.py
@@ -155,13 +155,21 @@ class TestRunAgent:
         monkeypatch.setenv("OUTPUT_LANGUAGE", "en")
         monkeypatch.setenv("MAX_TURNS", "1")
 
-        finding_json = json.dumps({
+        finding_obj = {
             "dimension": "health", "severity": "critical",
-            "title": "CrashLoopBackOff", "resource_kind": "Pod",
+            "title": "CrashLoopBackOff",
+            "description": "Pod restarting repeatedly",
+            "resource_kind": "Pod",
             "resource_namespace": "default", "resource_name": "nginx",
-        })
+            "suggestion": "Inspect container logs",
+        }
+        text = (
+            "Here is a finding:\n"
+            f"FINDING_JSON: {json.dumps(finding_obj)}\n"
+            "FINDINGS_COMPLETE"
+        )
         response = {
-            "content": [{"type": "text", "text": f"Here is a finding:\n{finding_json}\nFINDINGS_COMPLETE"}],
+            "content": [{"type": "text", "text": text}],
             "stop_reason": "end_turn",
             "input_tokens": 0,
             "output_tokens": 0,
@@ -363,3 +371,31 @@ class TestRunAgent:
         assert chain.invoke.call_count == 2, (
             "unknown behavior must fall back to continue (not silently fail)"
         )
+
+    def test_parse_errors_surfaced_via_reporter(self, monkeypatch):
+        """A malformed FINDING_JSON line must be reported via reporter.record_llm_event."""
+        monkeypatch.setenv("OUTPUT_LANGUAGE", "en")
+        monkeypatch.setenv("MAX_TURNS", "1")
+
+        text = (
+            'FINDING_JSON: {"dimension":"BOGUS","severity":"critical","title":"X","description":"d","resource_kind":"Pod","resource_namespace":"n","resource_name":"x","suggestion":"s"}\n'
+            "FINDINGS_COMPLETE"
+        )
+        response = {
+            "content": [{"type": "text", "text": text}],
+            "stop_reason": "end_turn",
+            "input_tokens": 0,
+            "output_tokens": 0,
+        }
+        chain = _make_chain_mock(response)
+
+        with patch("runtime.orchestrator.discover_tools", return_value=[]):
+            with patch("runtime.orchestrator.ModelChain.from_env", return_value=chain):
+                with patch("runtime.orchestrator.reporter.record_llm_event") as mock_event:
+                    findings = run_agent([Skill(name="t", dimension="h", tools=[], prompt="p")])
+
+        assert findings == []  # rejected by enum check
+        mock_event.assert_called()
+        args, _ = mock_event.call_args
+        assert args[0] == "finding_parse_error"
+        assert "dimension" in args[1].get("error", "")

--- a/docs/superpowers/plans/2026-04-30-findings-prefix-extract.md
+++ b/docs/superpowers/plans/2026-04-30-findings-prefix-extract.md
@@ -1,0 +1,474 @@
+# Findings 改用 `FINDING_JSON:` 前缀解析 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 修 #44 — Findings 提取从行级 `startswith("{") + "dimension" in line` 替换为 `FINDING_JSON: <single-line json>` 前缀方案。新解析强 schema（必填字段 + dimension/severity 枚举）；失败有 `logger.warn` + `tracer.event` + `reporter.record_llm_event`（不引入 Prometheus 依赖 —— 控制器侧已经统计 findings 数量）；prompt 模板更新；旧路径完全删除。
+
+**Architecture:**
+- Prompt 模板里把 "output a finding JSON object on its own line" 改成 "Each finding MUST appear on its own line as `FINDING_JSON: {...}` (literal prefix, single-line JSON)"。
+- 抽出 `extract_findings(text: str) -> tuple[list[dict], list[str]]` 纯函数：返回 `(valid_findings, parse_errors)`，把抓取与校验完全独立于 `run_agent` 的循环，便于单测。
+- `run_agent` 在每个 text 块里调一次 `extract_findings`，对 `parse_errors` 触发 `logger.warn` / `tracer.event` / `reporter.record_llm_event`。
+- 不引入 `pydantic` —— 校验用一个 `_FINDING_REQUIRED_FIELDS` set + `_DIMENSION_ENUM` / `_SEVERITY_ENUM` set 手工校验（最小依赖原则）。
+
+**Tech Stack:** Python 3.11+ (`pytest`、`unittest.mock`)、`json`、`logger` (structlog 风格)、`tracer.event` (Langfuse)、`reporter.record_llm_event`（既有 controller-bound 自定义事件通道）。
+
+**Spec:** GitHub issue #44 — 选 "方案 B"（FINDING_JSON 前缀 + 兜底解析）。Pydantic 跳过；Prometheus 跳过（用 reporter 既有事件通道替代）。
+
+---
+
+## File Structure
+
+**Modify:**
+- `agent-runtime/runtime/orchestrator.py` —
+  - `build_prompt` 更新 instructions 块为 FINDING_JSON 前缀格式
+  - `run_agent` 删除 inline 旧 startswith 路径，改调 `extract_findings(text)`
+  - 新增模块级 `extract_findings(text) -> tuple[list[dict], list[str]]` 纯函数 + 校验常量
+- `agent-runtime/tests/test_orchestrator.py` —
+  - 新增 `class TestExtractFindings`（5+ 个 case）
+  - 修改 `TestRunAgent.test_extracts_findings_from_text` 用新格式（旧 case 已不适用）
+
+---
+
+## Task 1: 抽出纯函数 `extract_findings` + 校验
+
+**Files:**
+- Modify: `agent-runtime/runtime/orchestrator.py`
+- Test: `agent-runtime/tests/test_orchestrator.py`
+
+新建独立纯函数，便于 TDD。新函数 / 常量先于 prompt + run_agent 的调整落地，避免一次改太大。
+
+- [ ] **Step 1.1: Append failing tests for `extract_findings`**
+
+在 `agent-runtime/tests/test_orchestrator.py` 顶部 imports 后、第一个 class 之前，新增独立测试类（不在 TestRunAgent 内）：
+
+```python
+class TestExtractFindings:
+    """Tests for the FINDING_JSON: prefix extractor."""
+
+    def test_single_valid_finding(self):
+        text = (
+            "Some preamble.\n"
+            'FINDING_JSON: {"dimension":"health","severity":"critical","title":"Pod CrashLoopBackOff","description":"d","resource_kind":"Pod","resource_namespace":"default","resource_name":"nginx","suggestion":"Restart"}\n'
+            "FINDINGS_COMPLETE"
+        )
+        from runtime.orchestrator import extract_findings
+
+        findings, errors = extract_findings(text)
+        assert errors == []
+        assert len(findings) == 1
+        assert findings[0]["title"] == "Pod CrashLoopBackOff"
+
+    def test_multiple_findings_one_invalid_enum(self):
+        text = (
+            'FINDING_JSON: {"dimension":"health","severity":"critical","title":"A","description":"d","resource_kind":"Pod","resource_namespace":"ns","resource_name":"a","suggestion":"s"}\n'
+            'FINDING_JSON: {"dimension":"BOGUS","severity":"critical","title":"B","description":"d","resource_kind":"Pod","resource_namespace":"ns","resource_name":"b","suggestion":"s"}\n'
+            'FINDING_JSON: {"dimension":"security","severity":"medium","title":"C","description":"d","resource_kind":"Pod","resource_namespace":"ns","resource_name":"c","suggestion":"s"}\n'
+        )
+        from runtime.orchestrator import extract_findings
+
+        findings, errors = extract_findings(text)
+        assert len(findings) == 2  # A and C accepted, B rejected
+        assert {f["title"] for f in findings} == {"A", "C"}
+        assert len(errors) == 1
+        assert "dimension" in errors[0]
+
+    def test_missing_required_field_rejected(self):
+        # No `suggestion` key
+        text = 'FINDING_JSON: {"dimension":"health","severity":"low","title":"X","description":"d","resource_kind":"Pod","resource_namespace":"n","resource_name":"x"}\n'
+        from runtime.orchestrator import extract_findings
+
+        findings, errors = extract_findings(text)
+        assert findings == []
+        assert len(errors) == 1
+        assert "suggestion" in errors[0]
+
+    def test_invalid_severity_enum_rejected(self):
+        text = 'FINDING_JSON: {"dimension":"health","severity":"PANIC","title":"X","description":"d","resource_kind":"Pod","resource_namespace":"n","resource_name":"x","suggestion":"s"}\n'
+        from runtime.orchestrator import extract_findings
+
+        findings, errors = extract_findings(text)
+        assert findings == []
+        assert len(errors) == 1
+        assert "severity" in errors[0]
+
+    def test_markdown_code_fence_json_not_extracted(self):
+        """Old startswith heuristic falsely captured JSON inside ``` blocks. New parser must not."""
+        text = (
+            "Here is an example finding format:\n"
+            "```json\n"
+            '{"dimension":"health","severity":"critical","title":"EXAMPLE","description":"d","resource_kind":"Pod","resource_namespace":"n","resource_name":"e","suggestion":"s"}\n'
+            "```\n"
+            "Now the real one:\n"
+            'FINDING_JSON: {"dimension":"health","severity":"low","title":"REAL","description":"d","resource_kind":"Pod","resource_namespace":"n","resource_name":"r","suggestion":"s"}\n'
+        )
+        from runtime.orchestrator import extract_findings
+
+        findings, errors = extract_findings(text)
+        assert len(findings) == 1
+        assert findings[0]["title"] == "REAL"
+        assert errors == []
+
+    def test_pretty_printed_multiline_json_not_extracted(self):
+        """Multi-line JSON without prefix on first line is rejected — keeps the contract single-line."""
+        text = (
+            "FINDING_JSON: {\n"
+            '  "dimension": "health",\n'
+            '  "severity": "critical"\n'
+            "}\n"
+        )
+        from runtime.orchestrator import extract_findings
+
+        findings, errors = extract_findings(text)
+        # Either parsed nothing (only the prefix line is invalid JSON), or
+        # captured an error — both are acceptable, but findings must be empty.
+        assert findings == []
+
+    def test_garbage_after_prefix_logged(self):
+        text = "FINDING_JSON: not-json-at-all\n"
+        from runtime.orchestrator import extract_findings
+
+        findings, errors = extract_findings(text)
+        assert findings == []
+        assert len(errors) == 1
+```
+
+- [ ] **Step 1.2: Run failing tests**
+
+Run: `cd agent-runtime && python -m pytest tests/test_orchestrator.py::TestExtractFindings -v`
+Expected: FAIL — `cannot import name 'extract_findings' from 'runtime.orchestrator'`
+
+- [ ] **Step 1.3: Implement `extract_findings` + constants**
+
+在 `agent-runtime/runtime/orchestrator.py` 顶部 `TARGET_NAMESPACES = ...` 之后追加：
+
+```python
+# Findings extraction (issue #44): the LLM emits one finding per line as
+# "FINDING_JSON: <single-line json>". Validation runs in extract_findings;
+# malformed entries are returned as parse errors so callers can log + emit
+# observability events.
+_FINDING_PREFIX = "FINDING_JSON: "
+_FINDING_REQUIRED_FIELDS = frozenset({
+    "dimension",
+    "severity",
+    "title",
+    "description",
+    "resource_kind",
+    "resource_namespace",
+    "resource_name",
+    "suggestion",
+})
+_DIMENSION_ENUM = frozenset({"health", "security", "cost", "reliability"})
+_SEVERITY_ENUM = frozenset({"critical", "high", "medium", "low", "info"})
+
+
+def extract_findings(text: str) -> tuple[list[dict], list[str]]:
+    """Parse FINDING_JSON: prefixed lines from LLM text output.
+
+    Returns (valid_findings, parse_errors). Each parse_error is a short
+    human-readable description suitable for logging or trace events.
+    The caller is responsible for emitting logs / metrics / events.
+    """
+    findings: list[dict] = []
+    errors: list[str] = []
+    for raw in text.split("\n"):
+        line = raw.strip()
+        if not line.startswith(_FINDING_PREFIX):
+            continue
+        payload = line[len(_FINDING_PREFIX):].strip()
+        try:
+            obj = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            errors.append(f"json parse failed: {exc.msg}")
+            continue
+        if not isinstance(obj, dict):
+            errors.append("finding payload is not a JSON object")
+            continue
+        missing = _FINDING_REQUIRED_FIELDS - obj.keys()
+        if missing:
+            errors.append(f"missing required field(s): {sorted(missing)}")
+            continue
+        if obj["dimension"] not in _DIMENSION_ENUM:
+            errors.append(f"invalid dimension: {obj['dimension']!r}")
+            continue
+        if obj["severity"] not in _SEVERITY_ENUM:
+            errors.append(f"invalid severity: {obj['severity']!r}")
+            continue
+        findings.append(obj)
+    return findings, errors
+```
+
+- [ ] **Step 1.4: Run failing tests, expect pass**
+
+Run: `cd agent-runtime && python -m pytest tests/test_orchestrator.py::TestExtractFindings -v`
+Expected: 7 个 test 全部 PASS
+
+- [ ] **Step 1.5: Run full orchestrator test file**
+
+Run: `cd agent-runtime && python -m pytest tests/test_orchestrator.py -v`
+Expected: 既有的 TestRunAgent::test_extracts_findings_from_text 仍然 PASS（旧路径还没拆，后续 Task 2 会覆盖）。
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add agent-runtime/runtime/orchestrator.py agent-runtime/tests/test_orchestrator.py
+git commit -m "feat(orchestrator): add extract_findings with FINDING_JSON: prefix + schema check
+
+Pure function that parses LLM text for FINDING_JSON: prefixed lines and
+validates against required-field set + dimension/severity enums. Returns
+(valid_findings, parse_errors) so callers can decide how to emit logs,
+metrics, or trace events. Used by run_agent in the next commit.
+
+Refs #44"
+```
+
+---
+
+## Task 2: `run_agent` 改用 `extract_findings` + 失败上报；prompt 更新
+
+**Files:**
+- Modify: `agent-runtime/runtime/orchestrator.py` (run_agent + build_prompt)
+- Test: `agent-runtime/tests/test_orchestrator.py`
+
+- [ ] **Step 2.1: Update existing test for the new format**
+
+旧 test `TestRunAgent.test_extracts_findings_from_text`（line ~64）的 finding 文本字段不全（缺 description / suggestion 等），且没有 FINDING_JSON: 前缀。需要让它走新格式：
+
+替换 `agent-runtime/tests/test_orchestrator.py` 该 test 函数（行号大概 64-86）：
+
+```python
+    def test_extracts_findings_from_text(self, monkeypatch):
+        monkeypatch.setenv("OUTPUT_LANGUAGE", "en")
+        monkeypatch.setenv("MAX_TURNS", "1")
+
+        finding_obj = {
+            "dimension": "health", "severity": "critical",
+            "title": "CrashLoopBackOff",
+            "description": "Pod restarting repeatedly",
+            "resource_kind": "Pod",
+            "resource_namespace": "default", "resource_name": "nginx",
+            "suggestion": "Inspect container logs",
+        }
+        text = (
+            "Here is a finding:\n"
+            f"FINDING_JSON: {json.dumps(finding_obj)}\n"
+            "FINDINGS_COMPLETE"
+        )
+        response = {
+            "content": [{"type": "text", "text": text}],
+            "stop_reason": "end_turn",
+            "input_tokens": 0,
+            "output_tokens": 0,
+        }
+        chain = _make_chain_mock(response)
+
+        with patch("runtime.orchestrator.discover_tools", return_value=[]):
+            with patch("runtime.orchestrator.ModelChain.from_env", return_value=chain):
+                findings = run_agent([Skill(name="t", dimension="h", tools=[], prompt="p")])
+
+        assert len(findings) == 1
+        assert findings[0]["title"] == "CrashLoopBackOff"
+```
+
+并新增一个 test 验证 parse 错误会触发 reporter 上报：
+
+在 TestRunAgent 末尾追加：
+
+```python
+    def test_parse_errors_surfaced_via_reporter(self, monkeypatch):
+        """A malformed FINDING_JSON line must be reported via reporter.record_llm_event."""
+        monkeypatch.setenv("OUTPUT_LANGUAGE", "en")
+        monkeypatch.setenv("MAX_TURNS", "1")
+
+        text = (
+            'FINDING_JSON: {"dimension":"BOGUS","severity":"critical","title":"X","description":"d","resource_kind":"Pod","resource_namespace":"n","resource_name":"x","suggestion":"s"}\n'
+            "FINDINGS_COMPLETE"
+        )
+        response = {
+            "content": [{"type": "text", "text": text}],
+            "stop_reason": "end_turn",
+            "input_tokens": 0,
+            "output_tokens": 0,
+        }
+        chain = _make_chain_mock(response)
+
+        with patch("runtime.orchestrator.discover_tools", return_value=[]):
+            with patch("runtime.orchestrator.ModelChain.from_env", return_value=chain):
+                with patch("runtime.orchestrator.reporter.record_llm_event") as mock_event:
+                    findings = run_agent([Skill(name="t", dimension="h", tools=[], prompt="p")])
+
+        assert findings == []  # rejected by enum check
+        mock_event.assert_called()
+        args, _ = mock_event.call_args
+        assert args[0] == "finding_parse_error"
+        assert "dimension" in args[1].get("error", "")
+```
+
+- [ ] **Step 2.2: Run failing tests**
+
+Run: `cd agent-runtime && python -m pytest tests/test_orchestrator.py::TestRunAgent::test_extracts_findings_from_text tests/test_orchestrator.py::TestRunAgent::test_parse_errors_surfaced_via_reporter -v`
+Expected: FAIL — first test fails because old startswith path captures the new FINDING_JSON line as a half-formed JSON (the prefix `FINDING_JSON: {...}` does NOT start with `{`); both tests fail because no reporter call happens for invalid enum (old path doesn't validate enums).
+
+- [ ] **Step 2.3: Update `run_agent` to use `extract_findings` + emit on errors**
+
+修改 `agent-runtime/runtime/orchestrator.py` 的 `run_agent`：
+
+(a) 顶部 import 之后追加 `from . import reporter`（如未导入）。检查现有 imports，model_chain 内已经 `from . import reporter`，orchestrator 大概率没有，需要加。
+
+(b) 替换 `run_agent` 内的 inline finding extract（current line 121-129）：
+
+旧：
+
+```python
+            if block["type"] == "text" and block.get("text"):
+                assistant_content.append({"type": "text", "text": block["text"]})
+                logger.debug("text block", chars=len(block['text']), preview=block['text'][:200])
+                # Extract findings from text
+                for line in block["text"].split("\n"):
+                    line = line.strip()
+                    if line.startswith("{") and "dimension" in line:
+                        try:
+                            f = json.loads(line)
+                            findings.append(f)
+                        except json.JSONDecodeError:
+                            pass
+            elif block["type"] == "tool_use":
+```
+
+新：
+
+```python
+            if block["type"] == "text" and block.get("text"):
+                assistant_content.append({"type": "text", "text": block["text"]})
+                logger.debug("text block", chars=len(block['text']), preview=block['text'][:200])
+                block_findings, parse_errors = extract_findings(block["text"])
+                findings.extend(block_findings)
+                for err in parse_errors:
+                    logger.warn("finding parse failed", error=err, turn=turn + 1)
+                    tracer.event(
+                        name="finding_parse_error",
+                        level="WARNING",
+                        metadata={"turn": turn + 1, "error": err},
+                    )
+                    reporter.record_llm_event(
+                        "finding_parse_error",
+                        {"turn": str(turn + 1), "error": err},
+                    )
+            elif block["type"] == "tool_use":
+```
+
+(c) 更新 prompt 模板。修改 `build_prompt` (line 57-72)：
+
+旧：
+
+```python
+    return f"""You are a Kubernetes diagnostic orchestrator.
+
+{lang_instruction}
+
+Target namespaces: {TARGET_NAMESPACES}
+
+Available diagnostic skills:
+{skill_list}
+
+Instructions:
+1. For each skill, analyze the cluster in the target namespaces.
+2. Use the available MCP tools to gather data.
+3. For each issue found, output a finding JSON object on its own line:
+   {{"dimension":"<dim>","severity":"<critical|high|medium|low|info>","title":"<title>","description":"<desc>","resource_kind":"<kind>","resource_namespace":"<ns>","resource_name":"<name>","suggestion":"<suggestion>"}}
+4. After all skills complete, output: FINDINGS_COMPLETE
+"""
+```
+
+新：
+
+```python
+    return f"""You are a Kubernetes diagnostic orchestrator.
+
+{lang_instruction}
+
+Target namespaces: {TARGET_NAMESPACES}
+
+Available diagnostic skills:
+{skill_list}
+
+Instructions:
+1. For each skill, analyze the cluster in the target namespaces.
+2. Use the available MCP tools to gather data.
+3. For each issue found, emit ONE line in this exact format (literal `FINDING_JSON: ` prefix, single-line JSON, no markdown fence, no trailing commentary on the same line):
+   FINDING_JSON: {{"dimension":"<health|security|cost|reliability>","severity":"<critical|high|medium|low|info>","title":"<title>","description":"<desc>","resource_kind":"<kind>","resource_namespace":"<ns>","resource_name":"<name>","suggestion":"<suggestion>"}}
+   All eight fields are REQUIRED. `dimension` and `severity` MUST be one of the listed enum values.
+4. After all skills complete, output: FINDINGS_COMPLETE
+"""
+```
+
+注：原来的 `test_contains_skill_info` 检查 `"FINDINGS_COMPLETE" in prompt`，新模板仍然包含此字符串，无须改 test。
+
+- [ ] **Step 2.4: Run the failing + previously failing tests, expect pass**
+
+Run: `cd agent-runtime && python -m pytest tests/test_orchestrator.py -v`
+Expected: 全部 PASS（4 + 5 = 9 in TestRunAgent；TestBuildPrompt 4 个；TestExtractFindings 7 个）
+
+- [ ] **Step 2.5: Verify build_prompt content sanity**
+
+Run: `cd agent-runtime && python -c "from runtime.orchestrator import build_prompt; from runtime.skill_loader import Skill; print(build_prompt([Skill(name='t', dimension='h', tools=[], prompt='p')]))"`
+Expected: 输出包含 `FINDING_JSON: ` 字符串和 `FINDINGS_COMPLETE`。
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add agent-runtime/runtime/orchestrator.py agent-runtime/tests/test_orchestrator.py
+git commit -m "refactor(orchestrator): switch findings extraction to FINDING_JSON: prefix
+
+Replaces the legacy startswith('{') + 'dimension' in line heuristic with
+extract_findings (issue #44 schema-checked parser). Parse errors flow
+through logger.warn + tracer.event + reporter.record_llm_event for
+ops visibility. Prompt template updated to instruct the LLM to use the
+explicit prefix; markdown code fences and pretty-printed JSON no longer
+contaminate the findings table.
+
+Refs #44"
+```
+
+---
+
+## Task 3: 验收前最终检查
+
+- [ ] **Step 3.1: Lint Python**
+
+Run: `cd agent-runtime && python -m pyflakes runtime/`
+Expected: 无新增 warning。
+
+- [ ] **Step 3.2: Run full Python test suite**
+
+Run: `cd agent-runtime && python -m pytest tests/ -v`
+Expected: 全部 PASS。
+
+- [ ] **Step 3.3: Run full Go test suite (sanity)**
+
+Run: `go test ./...`
+Expected: 全部 PASS（本 PR 不触 Go，纯 sanity check）.
+
+- [ ] **Step 3.4: Confirm no `startswith("{") and "dimension"` heuristic remains**
+
+Run: `grep -rn 'startswith("{")' agent-runtime/runtime/`
+Expected: 无输出（旧路径已删）。
+
+- [ ] **Step 3.5: 留待 user push + open PR**
+
+不在本会话内 push。
+
+---
+
+## 验收对照表（issue #44）
+
+| issue 验收项 | 对应 task |
+|------|---------|
+| `FINDING_JSON:` 前缀生效，旧 startswith 路径删除 | Task 1（添加） + Task 2（替换调用方 + 删除旧路径） |
+| 解析失败有 metric/log | Task 2（logger.warn + tracer.event + reporter.record_llm_event）— Prometheus 跳过（agent-runtime 未引入 prometheus_client；reporter 事件通道作为替代，控制器侧统一聚合） |
+| markdown code fence 内的示例 JSON 不再被误抓（回归测试） | Task 1 (`test_markdown_code_fence_json_not_extracted`) |
+| 缺字段 / 错误 enum 不进 findings 表 | Task 1 (`test_missing_required_field_rejected`, `test_invalid_severity_enum_rejected`, `test_multiple_findings_one_invalid_enum`) |
+
+## 已知未实现 / 推迟
+
+- **Pydantic schema 校验** — 用 frozenset + 手工校验代替（避免引入新依赖）。如果未来引入 pydantic，可平移此处的校验逻辑。
+- **Prometheus `findings_parse_errors_total` / `findings_submitted_total` counter** — 推迟。reporter.record_llm_event 已经把 finding_parse_error 上报到控制器；控制器侧的 Prometheus 由 `metrics` 包统一处理。如果以后需要单独的 agent-pod 内 Prometheus 端点，再加依赖与采集 endpoint。

--- a/docs/superpowers/plans/2026-04-30-orchestrator-max-tokens.md
+++ b/docs/superpowers/plans/2026-04-30-orchestrator-max-tokens.md
@@ -1,0 +1,643 @@
+# Orchestrator `max_tokens` ENV + Continue 续写护栏 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 修 #42 — agent-runtime 的 `max_tokens` 默认从 4096 提到 8192；orchestrator 在 `stop_reason == "max_tokens"` 命中时默认 continue 续写（带死循环护栏），可通过 ENV `MAX_TOKENS_BEHAVIOR=fail` 切换为 fail；Translator 把 `MAX_TOKENS` 注入到 Agent Pod env，单测覆盖。
+
+**Architecture:** 三层修改：
+1. **`agent-runtime/runtime/model_chain.py:89`** — ENV 已经在读，只把默认值从 `"4096"` 改成 `"8192"`。
+2. **`agent-runtime/runtime/orchestrator.py:140-157`** — 在 `tool_use` 与 `else` 之间插入 `elif stop_reason == "max_tokens":` 分支：默认 `continue`（让 LLM 在已存的 messages 历史上续写下一 turn），通过同一 turn 链上的连续 `max_tokens` 计数实现死循环护栏（`MAX_TOKENS_CONTINUE_LIMIT`，默认 3）；ENV `MAX_TOKENS_BEHAVIOR=fail` 时直接 break。
+3. **`internal/controller/translator/translator.go:185`** — `baseEnv` 加入 `MAX_TOKENS`，值取自新加的 `Config.MaxTokens`（默认 8192）。
+
+**Tech Stack:** Python 3.11+ (`pytest`、`unittest.mock`)、Go (controller-runtime、testify)、httpx 直连 SSE。
+
+**Spec:** GitHub issue #42
+
+---
+
+## File Structure
+
+**Modify:**
+- `agent-runtime/runtime/model_chain.py:89` — bump default
+- `agent-runtime/runtime/orchestrator.py` — `run_agent` 内加 max_tokens 分支与死循环护栏
+- `agent-runtime/tests/test_model_chain.py` — 加 default 8192 验证 test
+- `agent-runtime/tests/test_orchestrator.py` — 加 continue / death-loop / fail 三个 test
+- `internal/controller/translator/translator.go` — `Config.MaxTokens` 字段 + baseEnv 注入
+- `internal/controller/translator/translator_test.go` — 验证 MAX_TOKENS env 注入
+
+**Do not modify:**
+- ModelConfig CRD（per-run override 是更大的需求，超出 #42 范围）
+- `_stream_one` 函数体本身（除 default 外）
+
+---
+
+## Task 1: `_stream_one` `max_tokens` default 4096 → 8192
+
+**Files:**
+- Modify: `agent-runtime/runtime/model_chain.py:89`
+- Test: `agent-runtime/tests/test_model_chain.py`
+
+- [ ] **Step 1.1: Write failing test asserting default max_tokens is 8192**
+
+在 `agent-runtime/tests/test_model_chain.py` 的 `class TestStreamOne` 末尾追加（紧跟 `test_thinking_blocks_dropped` 后）：
+
+```python
+    def test_default_max_tokens_is_8192(self, monkeypatch):
+        """When MAX_TOKENS env is unset, _stream_one must request 8192."""
+        monkeypatch.delenv("MAX_TOKENS", raising=False)
+        events = ['{"type":"message_stop"}']
+        ep = ModelEndpoint(base_url="", model="m", api_key="k", retries=0)
+
+        with patch("runtime.model_chain.httpx.stream") as mock_stream:
+            mock_stream.return_value = _fake_stream(_make_sse_lines(events))
+            _stream_one(ep, tools=[], messages=[])
+
+        _, kwargs = mock_stream.call_args
+        assert kwargs["json"]["max_tokens"] == 8192
+
+    def test_max_tokens_env_override(self, monkeypatch):
+        """MAX_TOKENS env overrides the default."""
+        monkeypatch.setenv("MAX_TOKENS", "16384")
+        events = ['{"type":"message_stop"}']
+        ep = ModelEndpoint(base_url="", model="m", api_key="k", retries=0)
+
+        with patch("runtime.model_chain.httpx.stream") as mock_stream:
+            mock_stream.return_value = _fake_stream(_make_sse_lines(events))
+            _stream_one(ep, tools=[], messages=[])
+
+        _, kwargs = mock_stream.call_args
+        assert kwargs["json"]["max_tokens"] == 16384
+```
+
+- [ ] **Step 1.2: Run the failing test**
+
+Run: `cd agent-runtime && python -m pytest tests/test_model_chain.py::TestStreamOne::test_default_max_tokens_is_8192 -v`
+Expected: FAIL — `assert 4096 == 8192`
+
+- [ ] **Step 1.3: Bump default**
+
+替换 `agent-runtime/runtime/model_chain.py:89`：
+
+```python
+        "max_tokens": int(os.environ.get("MAX_TOKENS", "4096")),
+```
+
+为：
+
+```python
+        "max_tokens": int(os.environ.get("MAX_TOKENS", "8192")),
+```
+
+- [ ] **Step 1.4: Run the tests, expect pass**
+
+Run: `cd agent-runtime && python -m pytest tests/test_model_chain.py::TestStreamOne -v`
+Expected: 全部 PASS（含 6 个原有 + 2 个新增 = 8 个）
+
+- [ ] **Step 1.5: Run full model_chain test file to confirm no regression**
+
+Run: `cd agent-runtime && python -m pytest tests/test_model_chain.py -v`
+Expected: 全部 PASS
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add agent-runtime/runtime/model_chain.py agent-runtime/tests/test_model_chain.py
+git commit -m "fix(agent-runtime): bump default MAX_TOKENS from 4096 to 8192
+
+Claude 4.x models support far higher single-turn output limits than 4096.
+At 4096, large-cluster diagnostics routinely hit max_tokens during
+tool_use input_json_delta streaming, corrupting tool calls. Default to
+8192 (still a safe lower bound; ENV override unchanged).
+
+Refs #42"
+```
+
+---
+
+## Task 2: orchestrator `stop_reason == "max_tokens"` continue + 护栏
+
+**Files:**
+- Modify: `agent-runtime/runtime/orchestrator.py`
+- Test: `agent-runtime/tests/test_orchestrator.py`
+
+- [ ] **Step 2.1: Write failing tests for continue + death-loop + fail**
+
+在 `agent-runtime/tests/test_orchestrator.py` 的 `class TestRunAgent` 末尾追加：
+
+```python
+    def test_max_tokens_continues_by_default(self, monkeypatch):
+        """stop_reason=max_tokens with default behavior should continue to next turn."""
+        monkeypatch.setenv("OUTPUT_LANGUAGE", "en")
+        monkeypatch.setenv("MAX_TURNS", "5")
+        monkeypatch.delenv("MAX_TOKENS_BEHAVIOR", raising=False)
+        monkeypatch.delenv("MAX_TOKENS_CONTINUE_LIMIT", raising=False)
+
+        finding_json = json.dumps({
+            "dimension": "health", "severity": "critical",
+            "title": "Found", "resource_kind": "Pod",
+            "resource_namespace": "default", "resource_name": "p",
+        })
+        truncated = {
+            "content": [{"type": "text", "text": "partial analysis..."}],
+            "stop_reason": "max_tokens",
+            "input_tokens": 0, "output_tokens": 0,
+        }
+        completion = {
+            "content": [{"type": "text", "text": f"{finding_json}\nFINDINGS_COMPLETE"}],
+            "stop_reason": "end_turn",
+            "input_tokens": 0, "output_tokens": 0,
+        }
+        chain = _make_chain_mock([truncated, completion])
+
+        with patch("runtime.orchestrator.discover_tools", return_value=[]):
+            with patch("runtime.orchestrator.ModelChain.from_env", return_value=chain):
+                findings = run_agent([Skill(name="t", dimension="h", tools=[], prompt="p")])
+
+        assert chain.invoke.call_count == 2, "should continue past max_tokens"
+        assert len(findings) == 1
+        assert findings[0]["title"] == "Found"
+
+    def test_max_tokens_death_loop_breaks_at_limit(self, monkeypatch):
+        """Consecutive max_tokens beyond the configured limit must stop the loop."""
+        monkeypatch.setenv("OUTPUT_LANGUAGE", "en")
+        monkeypatch.setenv("MAX_TURNS", "10")
+        monkeypatch.setenv("MAX_TOKENS_CONTINUE_LIMIT", "3")
+        monkeypatch.delenv("MAX_TOKENS_BEHAVIOR", raising=False)
+
+        truncated = {
+            "content": [{"type": "text", "text": "..."}],
+            "stop_reason": "max_tokens",
+            "input_tokens": 0, "output_tokens": 0,
+        }
+        chain = _make_chain_mock(truncated)  # always returns max_tokens
+
+        with patch("runtime.orchestrator.discover_tools", return_value=[]):
+            with patch("runtime.orchestrator.ModelChain.from_env", return_value=chain):
+                findings = run_agent([Skill(name="t", dimension="h", tools=[], prompt="p")])
+
+        # Limit is 3 → expect at most 3 invokes before the death-loop guard fires.
+        assert chain.invoke.call_count == 3, f"expected 3 invokes, got {chain.invoke.call_count}"
+        assert findings == []
+
+    def test_max_tokens_behavior_fail_stops_immediately(self, monkeypatch):
+        """MAX_TOKENS_BEHAVIOR=fail must break the loop on the first max_tokens hit."""
+        monkeypatch.setenv("OUTPUT_LANGUAGE", "en")
+        monkeypatch.setenv("MAX_TURNS", "10")
+        monkeypatch.setenv("MAX_TOKENS_BEHAVIOR", "fail")
+
+        truncated = {
+            "content": [{"type": "text", "text": "..."}],
+            "stop_reason": "max_tokens",
+            "input_tokens": 0, "output_tokens": 0,
+        }
+        chain = _make_chain_mock(truncated)
+
+        with patch("runtime.orchestrator.discover_tools", return_value=[]):
+            with patch("runtime.orchestrator.ModelChain.from_env", return_value=chain):
+                findings = run_agent([Skill(name="t", dimension="h", tools=[], prompt="p")])
+
+        assert chain.invoke.call_count == 1, "fail behavior must stop after first hit"
+        assert findings == []
+
+    def test_max_tokens_counter_resets_on_non_max_tokens(self, monkeypatch):
+        """A non-max_tokens turn must reset the consecutive counter."""
+        monkeypatch.setenv("OUTPUT_LANGUAGE", "en")
+        monkeypatch.setenv("MAX_TURNS", "10")
+        # limit=3: with `>=` semantics, allows 2 consecutive max_tokens before
+        # break; the test sequence has 2-then-2 around a tool_use reset, so
+        # with limit=3 neither pair triggers the guard.
+        monkeypatch.setenv("MAX_TOKENS_CONTINUE_LIMIT", "3")
+        monkeypatch.delenv("MAX_TOKENS_BEHAVIOR", raising=False)
+
+        max_t = {
+            "content": [{"type": "text", "text": "..."}],
+            "stop_reason": "max_tokens",
+            "input_tokens": 0, "output_tokens": 0,
+        }
+        tool_call = {
+            "content": [{"type": "tool_use", "id": "tu", "name": "kubectl_get", "input": {}}],
+            "stop_reason": "tool_use",
+            "input_tokens": 0, "output_tokens": 0,
+        }
+        end = {
+            "content": [{"type": "text", "text": "FINDINGS_COMPLETE"}],
+            "stop_reason": "end_turn",
+            "input_tokens": 0, "output_tokens": 0,
+        }
+        # Sequence: max, max, tool_use (resets counter), max, max, end_turn → 6 invokes total
+        chain = _make_chain_mock([max_t, max_t, tool_call, max_t, max_t, end])
+
+        with patch("runtime.orchestrator.discover_tools", return_value=[]):
+            with patch("runtime.orchestrator.ModelChain.from_env", return_value=chain):
+                with patch("runtime.orchestrator.call_mcp_tool", return_value="{}"):
+                    run_agent([Skill(name="t", dimension="h", tools=[], prompt="p")])
+
+        assert chain.invoke.call_count == 6, f"counter should reset after tool_use; got {chain.invoke.call_count}"
+```
+
+- [ ] **Step 2.2: Run the failing tests**
+
+Run: `cd agent-runtime && python -m pytest tests/test_orchestrator.py::TestRunAgent -v -k max_tokens`
+Expected: 4 个新测试全 FAIL（第一个会因为 max_tokens 进入 else 分支并 break，invoke 仅 1 次而非 2 次；第二个会因为没有 limit 跑满 MAX_TURNS=10）
+
+- [ ] **Step 2.3: Implement the `max_tokens` branch in `run_agent`**
+
+修改 `agent-runtime/runtime/orchestrator.py` —— 在 `run_agent` 函数体内：
+
+**(a)** 在 `findings = []` 之后（约 line 91）追加初始化：
+
+```python
+    findings = []
+    max_turns = int(os.environ.get("MAX_TURNS", "10"))
+    max_tokens_continue_limit = int(os.environ.get("MAX_TOKENS_CONTINUE_LIMIT", "3"))
+    max_tokens_behavior = os.environ.get("MAX_TOKENS_BEHAVIOR", "continue")
+    consecutive_max_tokens = 0
+```
+
+**(b)** 替换原有的 `tool_use` / `else` 分支（约 line 143-157）：
+
+旧代码：
+
+```python
+        if response["stop_reason"] == "tool_use":
+            tool_results = []
+            for block in response["content"]:
+                if block["type"] == "tool_use":
+                    result = call_mcp_tool(block["name"], block["input"])
+                    logger.debug("tool result", tool=block['name'], preview=result[:200])
+                    tool_results.append({
+                        "type": "tool_result",
+                        "tool_use_id": block["id"],
+                        "content": result,
+                    })
+            messages.append({"role": "user", "content": tool_results})
+        else:
+            logger.warn("unexpected stop_reason, stopping", stop_reason=response['stop_reason'])
+            break
+```
+
+替换为：
+
+```python
+        if response["stop_reason"] == "tool_use":
+            consecutive_max_tokens = 0
+            tool_results = []
+            for block in response["content"]:
+                if block["type"] == "tool_use":
+                    result = call_mcp_tool(block["name"], block["input"])
+                    logger.debug("tool result", tool=block['name'], preview=result[:200])
+                    tool_results.append({
+                        "type": "tool_result",
+                        "tool_use_id": block["id"],
+                        "content": result,
+                    })
+            messages.append({"role": "user", "content": tool_results})
+        elif response["stop_reason"] == "max_tokens":
+            logger.warn(
+                "hit max_tokens",
+                turn=turn + 1,
+                behavior=max_tokens_behavior,
+                consecutive=consecutive_max_tokens + 1,
+                limit=max_tokens_continue_limit,
+            )
+            tracer.event(
+                name="max_tokens_hit",
+                level="WARNING",
+                metadata={
+                    "turn": turn + 1,
+                    "behavior": max_tokens_behavior,
+                    "consecutive": consecutive_max_tokens + 1,
+                },
+            )
+            if max_tokens_behavior == "fail":
+                break
+            consecutive_max_tokens += 1
+            if consecutive_max_tokens >= max_tokens_continue_limit:
+                logger.warn(
+                    "max_tokens continue limit reached, stopping",
+                    limit=max_tokens_continue_limit,
+                )
+                break
+            # behavior == "continue": loop iterates again with the now-extended
+            # messages history; assistant_content has already been appended above.
+        else:
+            logger.warn("unexpected stop_reason, stopping", stop_reason=response['stop_reason'])
+            break
+```
+
+注意三处细节：
+1. `tool_use` 分支首行加 `consecutive_max_tokens = 0`（成功的 tool_use 也算 reset 的依据）。
+2. `end_turn` 直接 break，无需 reset（出 loop 后变量销毁）。
+3. `max_tokens` 分支先 increment 后判断（保证第 N 次连续命中是真的第 N 次而不是 N+1）。修正：plan 中 `consecutive_max_tokens + 1` 用在 logger 的展示，递增放在 if 之外，比较时是 `>=`。看实现，逻辑等价于：每次进入 max_tokens 分支就 +1，达到 limit 即 break。
+
+- [ ] **Step 2.4: Run the failing tests, expect pass**
+
+Run: `cd agent-runtime && python -m pytest tests/test_orchestrator.py::TestRunAgent -v -k max_tokens`
+Expected: 4 个 test 全部 PASS
+
+- [ ] **Step 2.5: Run full orchestrator test file to confirm no regression**
+
+Run: `cd agent-runtime && python -m pytest tests/test_orchestrator.py -v`
+Expected: 全部 PASS（4 个 + 4 个原 = 8 个 in TestRunAgent；TestBuildPrompt 4 个不动）
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add agent-runtime/runtime/orchestrator.py agent-runtime/tests/test_orchestrator.py
+git commit -m "feat(orchestrator): handle stop_reason=max_tokens with continue + death-loop guard
+
+Default behavior is continue: keep iterating run_agent's loop with the
+existing messages history so the LLM can pick up where it left off. A
+consecutive-hit counter (MAX_TOKENS_CONTINUE_LIMIT, default 3) prevents
+runaway loops when the model can't fit a single response. ENV
+MAX_TOKENS_BEHAVIOR=fail switches to immediate break + Langfuse trace.
+
+Refs #42"
+```
+
+---
+
+## Task 3: Translator 注入 `MAX_TOKENS` 到 Agent Pod env
+
+**Files:**
+- Modify: `internal/controller/translator/translator.go`
+- Test: `internal/controller/translator/translator_test.go`
+
+- [ ] **Step 3.1: Write failing Go test**
+
+在 `internal/controller/translator/translator_test.go` 末尾追加（确认 `envByName` 或 `envMap` helper 已存在 — 看现有测试用什么模式）：
+
+先 grep 现有 envMap 模式：
+
+Run: `grep -n "envMap\|TARGET_NAMESPACES" internal/controller/translator/translator_test.go | head -10`
+
+预期看到 `envMap[\"TARGET_NAMESPACES\"]` 类似用法。沿用同模式追加：
+
+```go
+func TestTranslator_InjectsMaxTokens(t *testing.T) {
+	tr := translator.New(translator.Config{
+		AgentImage:    "agent:test",
+		ControllerURL: "http://ctrl:8080",
+		MaxTokens:     8192,
+	}, &mockSkillProvider{skills: []*store.Skill{
+		{Name: "pod-health", Dimension: "health", Prompt: "p", ToolsJSON: "[]", Enabled: true},
+	}})
+
+	run := &k8saiV1.DiagnosticRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "default", UID: "uid"},
+		Spec: k8saiV1.DiagnosticRunSpec{
+			Target:         k8saiV1.TargetSpec{Scope: "namespace", Namespaces: []string{"default"}},
+			Skills:         []string{"pod-health"},
+			ModelConfigRef: "claude-default",
+		},
+	}
+
+	objects, err := tr.Compile(context.Background(), run)
+	require.NoError(t, err)
+
+	// Find the Job and inspect env
+	var job *batchv1.Job
+	for _, obj := range objects {
+		if j, ok := obj.(*batchv1.Job); ok {
+			job = j
+			break
+		}
+	}
+	require.NotNil(t, job, "Compile must produce a Job")
+
+	envMap := make(map[string]string)
+	for _, e := range job.Spec.Template.Spec.Containers[0].Env {
+		envMap[e.Name] = e.Value
+	}
+	assert.Equal(t, "8192", envMap["MAX_TOKENS"])
+}
+
+func TestTranslator_DefaultMaxTokensWhenZero(t *testing.T) {
+	// When Config.MaxTokens is 0 (unset), Translator must inject 8192 default.
+	tr := translator.New(translator.Config{
+		AgentImage:    "agent:test",
+		ControllerURL: "http://ctrl:8080",
+		// MaxTokens: 0 (default zero-value)
+	}, &mockSkillProvider{skills: []*store.Skill{
+		{Name: "pod-health", Dimension: "health", Prompt: "p", ToolsJSON: "[]", Enabled: true},
+	}})
+
+	run := &k8saiV1.DiagnosticRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "default", UID: "uid"},
+		Spec: k8saiV1.DiagnosticRunSpec{
+			Target:         k8saiV1.TargetSpec{Scope: "namespace", Namespaces: []string{"default"}},
+			Skills:         []string{"pod-health"},
+			ModelConfigRef: "claude-default",
+		},
+	}
+
+	objects, err := tr.Compile(context.Background(), run)
+	require.NoError(t, err)
+	var job *batchv1.Job
+	for _, obj := range objects {
+		if j, ok := obj.(*batchv1.Job); ok {
+			job = j
+			break
+		}
+	}
+	require.NotNil(t, job)
+	envMap := make(map[string]string)
+	for _, e := range job.Spec.Template.Spec.Containers[0].Env {
+		envMap[e.Name] = e.Value
+	}
+	assert.Equal(t, "8192", envMap["MAX_TOKENS"], "zero MaxTokens must fall back to 8192 default")
+}
+```
+
+注意：测试假设 `mockSkillProvider` 已经定义在 `translator_test.go`（`internal/controller/translator/translator_test.go`）—— 如果不在，看现有测试用什么 provider 套路，沿用。
+
+注：如果 `Compile` 需要 `client.Client` 等额外依赖（看现有的 `TestTranslator_*` 测试怎么构造），按现有模式搭。如果现有测试用的是 `tr := translator.New(translator.Config{...}, provider)` 这种最简形式，直接抄。
+
+- [ ] **Step 3.2: Run the failing tests**
+
+Run: `go test ./internal/controller/translator/ -run TestTranslator_InjectsMaxTokens -v`
+Expected: FAIL — `Config has no field MaxTokens` (compile error)
+
+- [ ] **Step 3.3: Add `Config.MaxTokens` field + baseEnv injection**
+
+修改 `internal/controller/translator/translator.go`：
+
+(a) 在 `Config` struct (line 39) 加字段：
+
+旧：
+
+```go
+type Config struct {
+	AgentImage          string
+	ControllerURL       string
+	AnthropicBaseURL    string
+	Model               string
+	PrometheusURL       string
+	LangfuseSecretName  string // optional; if set, injects LANGFUSE_* env vars
+}
+```
+
+新：
+
+```go
+type Config struct {
+	AgentImage          string
+	ControllerURL       string
+	AnthropicBaseURL    string
+	Model               string
+	PrometheusURL       string
+	LangfuseSecretName  string // optional; if set, injects LANGFUSE_* env vars
+	MaxTokens           int    // optional; 0 = use defaultMaxTokens (8192)
+}
+```
+
+(b) 在文件顶部（imports 之后，types 之前）加常量：
+
+```go
+// defaultMaxTokens is the per-request output cap injected into the agent pod
+// env when Config.MaxTokens is unset. Matches agent-runtime's own default so
+// behavior is identical whether the env is injected or not.
+const defaultMaxTokens = 8192
+```
+
+(c) 在 `baseEnv` 列表 (line 185-198) 内追加 MAX_TOKENS:
+
+旧：
+
+```go
+	baseEnv := []corev1.EnvVar{
+		{Name: "RUN_ID", Value: runID},
+		{Name: "TARGET_NAMESPACES", Value: strings.Join(run.Spec.Target.Namespaces, ",")},
+		{Name: "CONTROLLER_URL", Value: t.cfg.ControllerURL},
+		{Name: "MCP_SERVER_PATH", Value: "/usr/local/bin/k8s-mcp-server"},
+		{Name: "PROMETHEUS_URL", Value: t.cfg.PrometheusURL},
+		{Name: "SKILL_NAMES", Value: strings.Join(skillNames, ",")},
+		{Name: "OUTPUT_LANGUAGE", Value: func() string {
+			if run.Spec.OutputLanguage != "" {
+				return run.Spec.OutputLanguage
+			}
+			return "en"
+		}()},
+	}
+```
+
+新（在 OUTPUT_LANGUAGE 之后追加 MAX_TOKENS）：
+
+```go
+	maxTokens := t.cfg.MaxTokens
+	if maxTokens == 0 {
+		maxTokens = defaultMaxTokens
+	}
+	baseEnv := []corev1.EnvVar{
+		{Name: "RUN_ID", Value: runID},
+		{Name: "TARGET_NAMESPACES", Value: strings.Join(run.Spec.Target.Namespaces, ",")},
+		{Name: "CONTROLLER_URL", Value: t.cfg.ControllerURL},
+		{Name: "MCP_SERVER_PATH", Value: "/usr/local/bin/k8s-mcp-server"},
+		{Name: "PROMETHEUS_URL", Value: t.cfg.PrometheusURL},
+		{Name: "SKILL_NAMES", Value: strings.Join(skillNames, ",")},
+		{Name: "OUTPUT_LANGUAGE", Value: func() string {
+			if run.Spec.OutputLanguage != "" {
+				return run.Spec.OutputLanguage
+			}
+			return "en"
+		}()},
+		{Name: "MAX_TOKENS", Value: strconv.Itoa(maxTokens)},
+	}
+```
+
+并 import `strconv`（如未导入）。
+
+- [ ] **Step 3.4: Run the failing tests, expect pass**
+
+Run: `go test ./internal/controller/translator/ -run TestTranslator_InjectsMaxTokens -v && go test ./internal/controller/translator/ -run TestTranslator_DefaultMaxTokensWhenZero -v`
+Expected: 两个 test 全部 PASS
+
+- [ ] **Step 3.5: Run full translator suite + build to confirm no regression**
+
+Run: `go test ./internal/controller/translator/... && go build ./...`
+Expected: 全部 PASS，零 build error
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add internal/controller/translator/translator.go internal/controller/translator/translator_test.go
+git commit -m "feat(translator): inject MAX_TOKENS env var into agent pod
+
+Adds Config.MaxTokens (default 8192 via defaultMaxTokens const) so the
+controller can set the per-request output cap consumed by agent-runtime.
+Without this injection, the pod fell back to its own runtime default,
+making MAX_TOKENS ungovernable from the controller side.
+
+Refs #42"
+```
+
+---
+
+## Task 4: 调用方 Translator 配置位置 — 是否需要 wire-up
+
+调用 `translator.New(translator.Config{...})` 的地方需要确认是否要传 `MaxTokens`。在不破坏现有调用的前提下保持零改动（zero-value 0 → falls back to 8192 by Task 3 的 default 逻辑）。
+
+- [ ] **Step 4.1: Identify all `translator.New` call sites**
+
+Run: `grep -rn "translator.New" --include="*.go"`
+Expected output 列出所有调用方（一般在 `cmd/controller/main.go` 或 `internal/controller/manager.go` 之类）。
+
+- [ ] **Step 4.2: Verify zero-value compatibility**
+
+读每个调用方的 Config 字面量。如果都没设 `MaxTokens`，Task 3 的零值兜底会自动用 8192，无需改动。
+
+如果 main 已经从 ENV 读 controller-level 配置（如 `os.Getenv("MAX_TOKENS")`），可以选择性追加：
+
+```go
+maxTokens, _ := strconv.Atoi(os.Getenv("CONTROLLER_AGENT_MAX_TOKENS"))
+translator.New(translator.Config{
+    ...,
+    MaxTokens: maxTokens,  // 0 → falls back to 8192 default in translator
+}, provider)
+```
+
+但**这一步不强制做**——保留为可选增强，不在 #42 PR 范围内（除非调用方现有就有读 env 的 idiom）。
+
+- [ ] **Step 4.3: Do nothing or commit a tiny call-site change**
+
+如果做了修改，commit；否则跳过。
+
+---
+
+## Task 5: 验收前最终检查
+
+- [ ] **Step 5.1: Lint + format**
+
+Run: `gofmt -l internal/controller/translator/`
+Expected: 无输出（如有 pre-existing 违规，按 #43 PR 的处理风格在 PR body 中说明）
+
+Run: `go vet ./...`
+Expected: 无输出
+
+Run: `cd agent-runtime && python -m pyflakes runtime/`
+Expected: 无输出
+
+- [ ] **Step 5.2: Run full Go test suite**
+
+Run: `go test ./...`
+Expected: 全部 PASS
+
+- [ ] **Step 5.3: Run full Python test suite**
+
+Run: `cd agent-runtime && python -m pytest tests/ -v`
+Expected: 全部 PASS
+
+- [ ] **Step 5.4: 留待 user push + open PR**
+
+不在本会话内 push。Commits 留在本地 `fix/orchestrator-max-tokens` 分支由用户自行 push。
+
+---
+
+## 验收对照表（issue #42）
+
+| issue 验收项 | 对应 task |
+|------|---------|
+| `MAX_TOKENS` ENV 生效，默认 8192 | Task 1 |
+| Translator 注入到 Agent Pod | Task 3 |
+| `stop_reason == "max_tokens"` 有显式日志/trace | Task 2（logger.warn + tracer.event） |
+| 单测覆盖 | Task 1（default 8192 + ENV override）+ Task 2（continue / death-loop / fail / counter reset）+ Task 3（env injected + zero-value default） |

--- a/internal/controller/reconciler/run_reconciler.go
+++ b/internal/controller/reconciler/run_reconciler.go
@@ -411,3 +411,17 @@ func mustJSON(v any) string {
 	b, _ := json.Marshal(v)
 	return string(b)
 }
+
+// MarshalJSON marshals v to a JSON string. Returns an error instead of
+// silently swallowing — callers must surface marshal failures (e.g. via
+// failRun) so they don't become silent data corruption in the store.
+//
+// Exported for unit tests; internal callers should treat this like a
+// package-private helper.
+func MarshalJSON(v any) (string, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", fmt.Errorf("json.Marshal: %w", err)
+	}
+	return string(b), nil
+}

--- a/internal/controller/reconciler/run_reconciler.go
+++ b/internal/controller/reconciler/run_reconciler.go
@@ -385,7 +385,7 @@ func (r *DiagnosticRunReconciler) collectPodLogs(ctx context.Context, run *k8sai
 // Buffer is sized to 1MB max — agent tool_result JSON for kubectl_get
 // or events_list against large namespaces routinely exceeds the 64KB
 // bufio.Scanner default. Lines beyond 1MB are dropped (Scanner returns
-// io.ErrShortBuffer) and the error is returned to the caller.
+// bufio.ErrTooLong) and the error is returned to the caller.
 func ParsePodLogStream(ctx context.Context, st store.Store, runID string, r io.Reader) error {
 	const maxLogLine = 1 << 20 // 1MB
 	scanner := bufio.NewScanner(r)

--- a/internal/controller/reconciler/run_reconciler.go
+++ b/internal/controller/reconciler/run_reconciler.go
@@ -101,10 +101,19 @@ func (r *DiagnosticRunReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 
 		// Persist to store
+		targetJSON, err := MarshalJSONFn(run.Spec.Target)
+		if err != nil {
+			return r.failRun(ctx, &run, fmt.Sprintf("marshal target: %s", err))
+		}
+		skillsJSON, err := MarshalJSONFn(run.Spec.Skills)
+		if err != nil {
+			return r.failRun(ctx, &run, fmt.Sprintf("marshal skills: %s", err))
+		}
+
 		storeRun := &store.DiagnosticRun{
 			ID:          string(run.UID),
-			TargetJSON:  mustJSON(run.Spec.Target),
-			SkillsJSON:  mustJSON(run.Spec.Skills),
+			TargetJSON:  targetJSON,
+			SkillsJSON:  skillsJSON,
 			Status:      store.PhasePending,
 			ClusterName: clusterName,
 		}
@@ -407,11 +416,6 @@ func (r *DiagnosticRunReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func mustJSON(v any) string {
-	b, _ := json.Marshal(v)
-	return string(b)
-}
-
 // MarshalJSON marshals v to a JSON string. Returns an error instead of
 // silently swallowing — callers must surface marshal failures (e.g. via
 // failRun) so they don't become silent data corruption in the store.
@@ -425,3 +429,7 @@ func MarshalJSON(v any) (string, error) {
 	}
 	return string(b), nil
 }
+
+// MarshalJSONFn is the package-level marshal hook. Tests may override it
+// to inject failures; production code keeps the default.
+var MarshalJSONFn = MarshalJSON

--- a/internal/controller/reconciler/run_reconciler.go
+++ b/internal/controller/reconciler/run_reconciler.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -368,45 +369,66 @@ func (r *DiagnosticRunReconciler) collectPodLogs(ctx context.Context, run *k8sai
 			continue
 		}
 
-		scanner := bufio.NewScanner(stream)
-		for scanner.Scan() {
-			line := scanner.Text()
-			var entry struct {
-				Timestamp string      `json:"timestamp"`
-				RunID     string      `json:"run_id"`
-				Type      string      `json:"type"`
-				Message   string      `json:"message"`
-				Data      interface{} `json:"data"`
-			}
-
-			logEntry := store.RunLog{RunID: runID}
-			if err := json.Unmarshal([]byte(line), &entry); err == nil && entry.Message != "" {
-				logEntry.Timestamp = entry.Timestamp
-				logEntry.Type = entry.Type
-				logEntry.Message = entry.Message
-				if entry.Data != nil {
-					dataBytes, _ := json.Marshal(entry.Data)
-					logEntry.Data = string(dataBytes)
-				}
-			} else {
-				// Non-JSON line — store as info
-				logEntry.Timestamp = time.Now().UTC().Format(time.RFC3339Nano)
-				logEntry.Type = "info"
-				logEntry.Message = line
-			}
-			if logEntry.Type == "" {
-				logEntry.Type = "info"
-			}
-			if logEntry.Timestamp == "" {
-				logEntry.Timestamp = time.Now().UTC().Format(time.RFC3339Nano)
-			}
-
-			if err := r.Store.AppendRunLog(ctx, logEntry); err != nil {
-				logger.Error(err, "failed to persist log entry")
-			}
+		if err := ParsePodLogStream(ctx, r.Store, runID, stream); err != nil {
+			logger.Error(err, "failed to parse pod log stream", "pod", pod.Name)
 		}
 		stream.Close()
 	}
+}
+
+// ParsePodLogStream reads structured log entries from r line-by-line and
+// persists each via store.AppendRunLog. Lines that don't parse as the
+// agent runtime's JSON envelope are stored as type=info entries.
+//
+// Exported for unit tests; internal callers go through collectPodLogs.
+//
+// Buffer is sized to 1MB max — agent tool_result JSON for kubectl_get
+// or events_list against large namespaces routinely exceeds the 64KB
+// bufio.Scanner default. Lines beyond 1MB are dropped (Scanner returns
+// io.ErrShortBuffer) and the error is returned to the caller.
+func ParsePodLogStream(ctx context.Context, st store.Store, runID string, r io.Reader) error {
+	const maxLogLine = 1 << 20 // 1MB
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxLogLine)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		var entry struct {
+			Timestamp string      `json:"timestamp"`
+			RunID     string      `json:"run_id"`
+			Type      string      `json:"type"`
+			Message   string      `json:"message"`
+			Data      interface{} `json:"data"`
+		}
+
+		logEntry := store.RunLog{RunID: runID}
+		if err := json.Unmarshal([]byte(line), &entry); err == nil && entry.Message != "" {
+			logEntry.Timestamp = entry.Timestamp
+			logEntry.Type = entry.Type
+			logEntry.Message = entry.Message
+			if entry.Data != nil {
+				dataBytes, err := json.Marshal(entry.Data)
+				if err == nil {
+					logEntry.Data = string(dataBytes)
+				}
+			}
+		} else {
+			logEntry.Timestamp = time.Now().UTC().Format(time.RFC3339Nano)
+			logEntry.Type = "info"
+			logEntry.Message = line
+		}
+		if logEntry.Type == "" {
+			logEntry.Type = "info"
+		}
+		if logEntry.Timestamp == "" {
+			logEntry.Timestamp = time.Now().UTC().Format(time.RFC3339Nano)
+		}
+
+		if err := st.AppendRunLog(ctx, logEntry); err != nil {
+			return fmt.Errorf("AppendRunLog: %w", err)
+		}
+	}
+	return scanner.Err()
 }
 
 func (r *DiagnosticRunReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/controller/reconciler/run_reconciler.go
+++ b/internal/controller/reconciler/run_reconciler.go
@@ -420,8 +420,10 @@ func (r *DiagnosticRunReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // silently swallowing — callers must surface marshal failures (e.g. via
 // failRun) so they don't become silent data corruption in the store.
 //
-// Exported for unit tests; internal callers should treat this like a
-// package-private helper.
+// Exported because MarshalJSONFn (the production dispatch hook) defaults
+// to it and external tests in package reconciler_test need to reference
+// both symbols. Production code paths go through MarshalJSONFn, not this
+// function directly.
 func MarshalJSON(v any) (string, error) {
 	b, err := json.Marshal(v)
 	if err != nil {

--- a/internal/controller/reconciler/run_reconciler_test.go
+++ b/internal/controller/reconciler/run_reconciler_test.go
@@ -580,3 +580,18 @@ func TestRunReconciler_RunningNoTimeoutWhenZero(t *testing.T) {
 		types.NamespacedName{Name: "test-run", Namespace: "default"}, &updated))
 	assert.Equal(t, "Running", updated.Status.Phase, "should remain Running with timeout=0")
 }
+
+// ── marshalJSON ───────────────────────────────────────────────────────────────
+
+func TestMarshalJSON_Success(t *testing.T) {
+	got, err := reconciler.MarshalJSON(map[string]string{"k": "v"})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"k":"v"}`, got)
+}
+
+func TestMarshalJSON_Error(t *testing.T) {
+	// channels are unsupported by encoding/json → triggers the error path
+	_, err := reconciler.MarshalJSON(make(chan int))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "json.Marshal")
+}

--- a/internal/controller/reconciler/run_reconciler_test.go
+++ b/internal/controller/reconciler/run_reconciler_test.go
@@ -2,6 +2,7 @@ package reconciler_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -594,4 +595,35 @@ func TestMarshalJSON_Error(t *testing.T) {
 	_, err := reconciler.MarshalJSON(make(chan int))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "json.Marshal")
+}
+
+func TestRunReconciler_TargetMarshalError_FailsRun(t *testing.T) {
+	// Arrange: hijack MarshalJSONFn to return an error for any input
+	orig := reconciler.MarshalJSONFn
+	reconciler.MarshalJSONFn = func(_ any) (string, error) {
+		return "", fmt.Errorf("synthetic marshal error")
+	}
+	t.Cleanup(func() { reconciler.MarshalJSONFn = orig })
+
+	run := testRun()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(run).
+		WithStatusSubresource(run).
+		Build()
+
+	ms := newMemStore()
+	r := &reconciler.DiagnosticRunReconciler{
+		Client: fakeClient, Store: ms, Translator: testTranslator(),
+	}
+
+	// Act
+	_ = reconcileOnce(t, r)
+
+	// Assert: run is now Failed and message references marshal error
+	var updated k8saiV1.DiagnosticRun
+	require.NoError(t, fakeClient.Get(context.Background(),
+		types.NamespacedName{Name: "test-run", Namespace: "default"}, &updated))
+	assert.Equal(t, "Failed", updated.Status.Phase)
+	assert.Contains(t, updated.Status.Message, "marshal")
 }

--- a/internal/controller/reconciler/run_reconciler_test.go
+++ b/internal/controller/reconciler/run_reconciler_test.go
@@ -3,6 +3,7 @@ package reconciler_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -626,4 +627,62 @@ func TestRunReconciler_TargetMarshalError_FailsRun(t *testing.T) {
 		types.NamespacedName{Name: "test-run", Namespace: "default"}, &updated))
 	assert.Equal(t, "Failed", updated.Status.Phase)
 	assert.Contains(t, updated.Status.Message, "marshal")
+}
+
+// ── parsePodLogStream ─────────────────────────────────────────────────────────
+
+// recordingStore captures AppendRunLog calls for assertions.
+type recordingStore struct {
+	*memStore
+	logs []store.RunLog
+}
+
+func newRecordingStore() *recordingStore {
+	return &recordingStore{memStore: newMemStore()}
+}
+
+func (r *recordingStore) AppendRunLog(_ context.Context, l store.RunLog) error {
+	r.logs = append(r.logs, l)
+	return nil
+}
+
+func TestParsePodLogStream_HandlesMultipleLines(t *testing.T) {
+	rs := newRecordingStore()
+	body := strings.NewReader(
+		`{"timestamp":"2026-04-30T10:00:00Z","run_id":"uid-1","type":"tool_use","message":"calling kubectl_get"}` + "\n" +
+			`{"timestamp":"2026-04-30T10:00:01Z","run_id":"uid-1","type":"tool_result","message":"ok"}` + "\n",
+	)
+
+	require.NoError(t, reconciler.ParsePodLogStream(context.Background(), rs, "uid-1", body))
+	require.Len(t, rs.logs, 2)
+	assert.Equal(t, "tool_use", rs.logs[0].Type)
+	assert.Equal(t, "tool_result", rs.logs[1].Type)
+}
+
+func TestParsePodLogStream_LongLineExceeds64KBNotTruncated(t *testing.T) {
+	// Build a single tool_result line > 64KB (default bufio.Scanner cap)
+	bigData := strings.Repeat("x", 80*1024) // 80KB > 64KB default
+	line := fmt.Sprintf(
+		`{"timestamp":"2026-04-30T10:00:00Z","run_id":"uid-1","type":"tool_result","message":"big","data":{"raw":"%s"}}`+"\n",
+		bigData,
+	)
+
+	rs := newRecordingStore()
+	require.NoError(t, reconciler.ParsePodLogStream(context.Background(), rs, "uid-1", strings.NewReader(line)))
+
+	require.Len(t, rs.logs, 1, "long line must NOT cause Scanner to drop the entry")
+	assert.Equal(t, "tool_result", rs.logs[0].Type)
+	assert.Equal(t, "big", rs.logs[0].Message)
+}
+
+func TestParsePodLogStream_NonJSONLineBecomesInfo(t *testing.T) {
+	rs := newRecordingStore()
+	body := strings.NewReader("starting up\nshutdown\n")
+
+	require.NoError(t, reconciler.ParsePodLogStream(context.Background(), rs, "uid-1", body))
+	require.Len(t, rs.logs, 2)
+	assert.Equal(t, "info", rs.logs[0].Type)
+	assert.Equal(t, "starting up", rs.logs[0].Message)
+	assert.Equal(t, "info", rs.logs[1].Type)
+	assert.Equal(t, "shutdown", rs.logs[1].Message)
 }

--- a/internal/controller/reconciler/run_reconciler_test.go
+++ b/internal/controller/reconciler/run_reconciler_test.go
@@ -1,6 +1,7 @@
 package reconciler_test
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"strings"
@@ -685,4 +686,15 @@ func TestParsePodLogStream_NonJSONLineBecomesInfo(t *testing.T) {
 	assert.Equal(t, "starting up", rs.logs[0].Message)
 	assert.Equal(t, "info", rs.logs[1].Type)
 	assert.Equal(t, "shutdown", rs.logs[1].Message)
+}
+
+func TestParsePodLogStream_LineExceeds1MBReturnsError(t *testing.T) {
+	// Build a single line > 1MB to exceed the helper's hard cap
+	huge := strings.Repeat("x", (1<<20)+1024) // 1MB + 1KB
+	rs := newRecordingStore()
+
+	err := reconciler.ParsePodLogStream(context.Background(), rs, "uid-1", strings.NewReader(huge+"\n"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, bufio.ErrTooLong)
+	assert.Empty(t, rs.logs, "no entries should be persisted when scanner aborts on oversized line")
 }

--- a/internal/controller/translator/translator.go
+++ b/internal/controller/translator/translator.go
@@ -23,7 +23,6 @@ package translator
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -206,7 +205,7 @@ func (t *Translator) buildJob(run *k8saiV1.DiagnosticRun, runID, saName, cmName 
 			}
 			return "en"
 		}()},
-		{Name: "MAX_TOKENS", Value: strconv.Itoa(maxTokens)},
+		{Name: "MAX_TOKENS", Value: fmt.Sprintf("%d", maxTokens)},
 	}
 	allEnv := append(baseEnv, buildChainEnv(chain)...)
 	allEnv = append(allEnv, langfuseEnvVars(t.cfg.LangfuseSecretName)...)

--- a/internal/controller/translator/translator.go
+++ b/internal/controller/translator/translator.go
@@ -23,6 +23,7 @@ package translator
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -36,6 +37,11 @@ import (
 	"github.com/kube-agent-helper/kube-agent-helper/internal/store"
 )
 
+// defaultMaxTokens is the per-request output cap injected into the agent pod
+// env when Config.MaxTokens is unset. Matches agent-runtime's own default so
+// behavior is identical whether or not the controller overrides.
+const defaultMaxTokens = 8192
+
 type Config struct {
 	AgentImage          string
 	ControllerURL       string
@@ -43,6 +49,7 @@ type Config struct {
 	Model               string
 	PrometheusURL       string
 	LangfuseSecretName  string // optional; if set, injects LANGFUSE_* env vars
+	MaxTokens           int    // optional; 0 = use defaultMaxTokens (8192)
 }
 
 // SkillProvider is the interface Translator uses to fetch enabled skills.
@@ -182,6 +189,10 @@ func (t *Translator) buildJob(run *k8saiV1.DiagnosticRun, runID, saName, cmName 
 		skillNames[i] = s.Name
 	}
 
+	maxTokens := t.cfg.MaxTokens
+	if maxTokens == 0 {
+		maxTokens = defaultMaxTokens
+	}
 	baseEnv := []corev1.EnvVar{
 		{Name: "RUN_ID", Value: runID},
 		{Name: "TARGET_NAMESPACES", Value: strings.Join(run.Spec.Target.Namespaces, ",")},
@@ -195,6 +206,7 @@ func (t *Translator) buildJob(run *k8saiV1.DiagnosticRun, runID, saName, cmName 
 			}
 			return "en"
 		}()},
+		{Name: "MAX_TOKENS", Value: strconv.Itoa(maxTokens)},
 	}
 	allEnv := append(baseEnv, buildChainEnv(chain)...)
 	allEnv = append(allEnv, langfuseEnvVars(t.cfg.LangfuseSecretName)...)

--- a/internal/controller/translator/translator_test.go
+++ b/internal/controller/translator/translator_test.go
@@ -397,3 +397,52 @@ func TestCompile_OutputLanguageDefaultsToEn(t *testing.T) {
 	}
 	assert.Equal(t, "en", gotLang, "default should be 'en'")
 }
+
+func TestTranslator_InjectsMaxTokensFromConfig(t *testing.T) {
+	tr := translator.New(translator.Config{
+		AgentImage:    "agent:test",
+		ControllerURL: "http://ctrl:8080",
+		MaxTokens:     16384,
+	}, &mockProvider{skills: testSkills})
+
+	run := newRun("r", "default", "uid", []string{"pod-health-analyst"}, []string{"default"})
+	objects, err := tr.Compile(context.Background(), run)
+	require.NoError(t, err)
+
+	var job *batchv1.Job
+	for _, o := range objects {
+		if j, ok := o.(*batchv1.Job); ok {
+			job = j
+			break
+		}
+	}
+	require.NotNil(t, job, "Compile must produce a Job")
+
+	envMap := envToMap(job.Spec.Template.Spec.Containers[0].Env)
+	assert.Equal(t, "16384", envMap["MAX_TOKENS"])
+}
+
+func TestTranslator_DefaultMaxTokensWhenZero(t *testing.T) {
+	// Zero (unset) Config.MaxTokens must fall back to 8192.
+	tr := translator.New(translator.Config{
+		AgentImage:    "agent:test",
+		ControllerURL: "http://ctrl:8080",
+		// MaxTokens: 0 (zero-value)
+	}, &mockProvider{skills: testSkills})
+
+	run := newRun("r", "default", "uid", []string{"pod-health-analyst"}, []string{"default"})
+	objects, err := tr.Compile(context.Background(), run)
+	require.NoError(t, err)
+
+	var job *batchv1.Job
+	for _, o := range objects {
+		if j, ok := o.(*batchv1.Job); ok {
+			job = j
+			break
+		}
+	}
+	require.NotNil(t, job)
+
+	envMap := envToMap(job.Spec.Template.Spec.Containers[0].Env)
+	assert.Equal(t, "8192", envMap["MAX_TOKENS"], "zero MaxTokens must fall back to 8192 default")
+}

--- a/internal/mcptools/deps_test.go
+++ b/internal/mcptools/deps_test.go
@@ -1,0 +1,28 @@
+package mcptools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultSanitizeOpts_Empty(t *testing.T) {
+	opts, err := DefaultSanitizeOpts("")
+	require.NoError(t, err)
+	assert.Nil(t, opts.ConfigMapKeyMask)
+}
+
+func TestDefaultSanitizeOpts_ValidRegex(t *testing.T) {
+	opts, err := DefaultSanitizeOpts("(?i)password|token")
+	require.NoError(t, err)
+	require.NotNil(t, opts.ConfigMapKeyMask)
+	assert.True(t, opts.ConfigMapKeyMask.MatchString("PASSWORD"))
+	assert.True(t, opts.ConfigMapKeyMask.MatchString("api_token"))
+	assert.False(t, opts.ConfigMapKeyMask.MatchString("config"))
+}
+
+func TestDefaultSanitizeOpts_InvalidRegex(t *testing.T) {
+	_, err := DefaultSanitizeOpts("[unclosed")
+	require.Error(t, err)
+}

--- a/internal/mcptools/events_history_test.go
+++ b/internal/mcptools/events_history_test.go
@@ -1,0 +1,118 @@
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kube-agent-helper/kube-agent-helper/internal/store"
+)
+
+// mockEventsStore overrides ListEvents on top of nopStore.
+type mockEventsStore struct {
+	nopStore
+	events       []*store.Event
+	err          error
+	capturedOpts store.ListEventsOpts
+}
+
+func (m *mockEventsStore) ListEvents(_ context.Context, opts store.ListEventsOpts) ([]*store.Event, error) {
+	m.capturedOpts = opts
+	return m.events, m.err
+}
+
+// --- Tests ---
+
+func TestEventsHistory_NoStore(t *testing.T) {
+	d := &Deps{Store: nil}
+	handler := NewEventsHistoryHandler(d)
+
+	req := mcp.CallToolRequest{}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &payload))
+	assert.Equal(t, false, payload["available"])
+	assert.Equal(t, "event store not available", payload["error"])
+}
+
+func TestEventsHistory_DefaultOpts(t *testing.T) {
+	ms := &mockEventsStore{}
+	d := &Deps{Store: ms}
+	handler := NewEventsHistoryHandler(d)
+
+	req := mcp.CallToolRequest{}
+	// No arguments — all defaults apply.
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	assert.Equal(t, 100, ms.capturedOpts.Limit, "expected default Limit=100")
+	assert.Equal(t, "", ms.capturedOpts.Namespace)
+	assert.Equal(t, "", ms.capturedOpts.Name)
+	assert.Equal(t, 0, ms.capturedOpts.SinceMinutes)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &payload))
+	assert.Equal(t, float64(0), payload["count"])
+}
+
+func TestEventsHistory_AllArgsParsed(t *testing.T) {
+	ms := &mockEventsStore{}
+	d := &Deps{Store: ms}
+	handler := NewEventsHistoryHandler(d)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{
+		"namespace":     "kube-system",
+		"name":          "coredns",
+		"since_minutes": float64(30),
+		"limit":         float64(50),
+	}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	assert.Equal(t, "kube-system", ms.capturedOpts.Namespace)
+	assert.Equal(t, "coredns", ms.capturedOpts.Name)
+	assert.Equal(t, 30, ms.capturedOpts.SinceMinutes)
+	assert.Equal(t, 50, ms.capturedOpts.Limit)
+}
+
+func TestEventsHistory_ZeroLimitKeepsDefault(t *testing.T) {
+	ms := &mockEventsStore{}
+	d := &Deps{Store: ms}
+	handler := NewEventsHistoryHandler(d)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{
+		"limit": float64(0), // zero — must NOT override the default 100
+	}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	assert.Equal(t, 100, ms.capturedOpts.Limit, "zero limit must not override default of 100")
+}
+
+func TestEventsHistory_StoreError(t *testing.T) {
+	ms := &mockEventsStore{err: errors.New("db down")}
+	d := &Deps{Store: ms}
+	handler := NewEventsHistoryHandler(d)
+
+	req := mcp.CallToolRequest{}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &payload))
+	assert.Equal(t, "db down", payload["error"])
+}

--- a/internal/mcptools/kubectl_logs_test.go
+++ b/internal/mcptools/kubectl_logs_test.go
@@ -45,3 +45,93 @@ func TestKubectlLogs_MultiContainerRequiresExplicit(t *testing.T) {
 	assert.Contains(t, textOf(result), "main")
 	assert.Contains(t, textOf(result), "sidecar")
 }
+
+func TestKubectlLogs_TailLinesTooLarge(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c"}}},
+	}
+	d := &Deps{Typed: fake.NewSimpleClientset(pod)}
+	handler := NewKubectlLogsHandler(d)
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{
+		"namespace": "ns", "pod": "p",
+		"tailLines": float64(5000), // > maxTailLines (2000)
+	}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, textOf(result), "tailLines")
+}
+
+func TestKubectlLogs_TailLinesNegative(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c"}}},
+	}
+	d := &Deps{Typed: fake.NewSimpleClientset(pod)}
+	handler := NewKubectlLogsHandler(d)
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{
+		"namespace": "ns", "pod": "p",
+		"tailLines": float64(-1),
+	}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, textOf(result), "tailLines")
+}
+
+func TestKubectlLogs_SingleContainerSucceeds(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}},
+	}
+	d := &Deps{Typed: fake.NewSimpleClientset(pod)}
+	handler := NewKubectlLogsHandler(d)
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{
+		"namespace": "ns", "pod": "p",
+		"tailLines": float64(100),
+	}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	assert.False(t, result.IsError, "single-container path should succeed: %s", textOf(result))
+	// The result body is JSON with "logs", "truncated", "lineCount" keys.
+	assert.Contains(t, textOf(result), "truncated")
+	assert.Contains(t, textOf(result), "lineCount")
+}
+
+func TestKubectlLogs_ExplicitContainerWithSinceSecondsAndPrevious(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{
+			{Name: "main"}, {Name: "sidecar"},
+		}},
+	}
+	d := &Deps{Typed: fake.NewSimpleClientset(pod)}
+	handler := NewKubectlLogsHandler(d)
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{
+		"namespace":    "ns",
+		"pod":          "p",
+		"container":    "main",
+		"sinceSeconds": float64(300),
+		"previous":     true,
+	}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	assert.False(t, result.IsError, "explicit container path should succeed: %s", textOf(result))
+}
+
+func TestKubectlLogs_PodNotFound(t *testing.T) {
+	d := &Deps{Typed: fake.NewSimpleClientset()} // no pods
+	handler := NewKubectlLogsHandler(d)
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{
+		"namespace": "ns", "pod": "ghost",
+	}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}

--- a/internal/mcptools/metric_history_test.go
+++ b/internal/mcptools/metric_history_test.go
@@ -1,0 +1,200 @@
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kube-agent-helper/kube-agent-helper/internal/store"
+)
+
+// nopStore implements store.Store with no-op stubs.
+type nopStore struct{}
+
+func (nopStore) CreateRun(_ context.Context, _ *store.DiagnosticRun) error { return nil }
+func (nopStore) GetRun(_ context.Context, _ string) (*store.DiagnosticRun, error) {
+	return nil, nil
+}
+func (nopStore) UpdateRunStatus(_ context.Context, _ string, _ store.Phase, _ string) error {
+	return nil
+}
+func (nopStore) ListRuns(_ context.Context, _ store.ListOpts) ([]*store.DiagnosticRun, error) {
+	return nil, nil
+}
+func (nopStore) CreateFinding(_ context.Context, _ *store.Finding) error   { return nil }
+func (nopStore) ListFindings(_ context.Context, _ string) ([]*store.Finding, error) {
+	return nil, nil
+}
+func (nopStore) UpsertSkill(_ context.Context, _ *store.Skill) error  { return nil }
+func (nopStore) ListSkills(_ context.Context) ([]*store.Skill, error) { return nil, nil }
+func (nopStore) GetSkill(_ context.Context, _ string) (*store.Skill, error) {
+	return nil, nil
+}
+func (nopStore) DeleteSkill(_ context.Context, _ string) error { return nil }
+func (nopStore) CreateFix(_ context.Context, _ *store.Fix) error { return nil }
+func (nopStore) GetFix(_ context.Context, _ string) (*store.Fix, error) { return nil, nil }
+func (nopStore) ListFixes(_ context.Context, _ store.ListOpts) ([]*store.Fix, error) {
+	return nil, nil
+}
+func (nopStore) ListFixesByRun(_ context.Context, _ string) ([]*store.Fix, error) {
+	return nil, nil
+}
+func (nopStore) UpdateFixPhase(_ context.Context, _ string, _ store.FixPhase, _ string) error {
+	return nil
+}
+func (nopStore) UpdateFixApproval(_ context.Context, _ string, _ string) error { return nil }
+func (nopStore) UpdateFixSnapshot(_ context.Context, _ string, _ string) error { return nil }
+func (nopStore) UpsertEvent(_ context.Context, _ *store.Event) error           { return nil }
+func (nopStore) ListEvents(_ context.Context, _ store.ListEventsOpts) ([]*store.Event, error) {
+	return nil, nil
+}
+func (nopStore) InsertMetricSnapshot(_ context.Context, _ *store.MetricSnapshot) error { return nil }
+func (nopStore) QueryMetricHistory(_ context.Context, _ string, _ int) ([]*store.MetricSnapshot, error) {
+	return nil, nil
+}
+func (nopStore) ListRunsPaginated(_ context.Context, _ store.ListOpts) (store.PaginatedResult[*store.DiagnosticRun], error) {
+	return store.PaginatedResult[*store.DiagnosticRun]{}, nil
+}
+func (nopStore) ListFixesPaginated(_ context.Context, _ store.ListOpts) (store.PaginatedResult[*store.Fix], error) {
+	return store.PaginatedResult[*store.Fix]{}, nil
+}
+func (nopStore) ListEventsPaginated(_ context.Context, _ store.ListEventsOpts, _, _ int) (store.PaginatedResult[*store.Event], error) {
+	return store.PaginatedResult[*store.Event]{}, nil
+}
+func (nopStore) DeleteRuns(_ context.Context, _ []string) error { return nil }
+func (nopStore) BatchUpdateFixPhase(_ context.Context, _ []string, _ store.FixPhase, _ string) error {
+	return nil
+}
+func (nopStore) AppendRunLog(_ context.Context, _ store.RunLog) error { return nil }
+func (nopStore) ListRunLogs(_ context.Context, _ string, _ int64) ([]store.RunLog, error) {
+	return nil, nil
+}
+func (nopStore) ListNotificationConfigs(_ context.Context) ([]*store.NotificationConfig, error) {
+	return nil, nil
+}
+func (nopStore) GetNotificationConfig(_ context.Context, _ string) (*store.NotificationConfig, error) {
+	return nil, nil
+}
+func (nopStore) CreateNotificationConfig(_ context.Context, _ *store.NotificationConfig) error {
+	return nil
+}
+func (nopStore) UpdateNotificationConfig(_ context.Context, _ *store.NotificationConfig) error {
+	return nil
+}
+func (nopStore) DeleteNotificationConfig(_ context.Context, _ string) error   { return nil }
+func (nopStore) PurgeOldEvents(_ context.Context, _ time.Time) error          { return nil }
+func (nopStore) PurgeOldMetrics(_ context.Context, _ time.Time) error         { return nil }
+func (nopStore) Close() error                                                  { return nil }
+
+// mockMetricStore overrides QueryMetricHistory on top of nopStore.
+type mockMetricStore struct {
+	nopStore
+	snaps        []*store.MetricSnapshot
+	err          error
+	capturedMins int
+}
+
+func (m *mockMetricStore) QueryMetricHistory(_ context.Context, _ string, sinceMinutes int) ([]*store.MetricSnapshot, error) {
+	m.capturedMins = sinceMinutes
+	return m.snaps, m.err
+}
+
+// --- Tests ---
+
+func TestMetricHistory_NoStore(t *testing.T) {
+	d := &Deps{Store: nil}
+	handler := NewMetricHistoryHandler(d)
+
+	req := mcp.CallToolRequest{}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &payload))
+	assert.Equal(t, false, payload["available"])
+	assert.Equal(t, "metric store not available", payload["error"])
+}
+
+func TestMetricHistory_QueryRequired(t *testing.T) {
+	d := &Deps{Store: &mockMetricStore{}}
+	handler := NewMetricHistoryHandler(d)
+
+	req := mcp.CallToolRequest{}
+	// No "query" argument set.
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &payload))
+	assert.Equal(t, "query is required", payload["error"])
+}
+
+func TestMetricHistory_DefaultSinceMinutes(t *testing.T) {
+	snap := &store.MetricSnapshot{ID: 1, Query: "up", Value: 1.0, Ts: time.Now()}
+	ms := &mockMetricStore{snaps: []*store.MetricSnapshot{snap}}
+	d := &Deps{Store: ms}
+	handler := NewMetricHistoryHandler(d)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{
+		"query": "up",
+		// since_minutes intentionally omitted → should default to 60
+	}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	assert.Equal(t, 60, ms.capturedMins, "expected default since_minutes=60")
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &payload))
+	assert.Equal(t, float64(1), payload["count"])
+}
+
+func TestMetricHistory_CustomSinceMinutes(t *testing.T) {
+	ms := &mockMetricStore{snaps: []*store.MetricSnapshot{}}
+	d := &Deps{Store: ms}
+	handler := NewMetricHistoryHandler(d)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{
+		"query":         "node_cpu_seconds_total",
+		"since_minutes": float64(30),
+	}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	assert.Equal(t, 30, ms.capturedMins, "expected since_minutes=30")
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &payload))
+	assert.Equal(t, float64(0), payload["count"])
+}
+
+func TestMetricHistory_StoreError(t *testing.T) {
+	storeErr := errors.New("database unavailable")
+	ms := &mockMetricStore{err: storeErr}
+	d := &Deps{Store: ms}
+	handler := NewMetricHistoryHandler(d)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{
+		"query": "up",
+	}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &payload))
+	assert.Equal(t, "database unavailable", payload["error"])
+}

--- a/internal/mcptools/prometheus_query_test.go
+++ b/internal/mcptools/prometheus_query_test.go
@@ -62,3 +62,62 @@ func TestPrometheusQuery_Instant(t *testing.T) {
 	require.True(t, ok)
 	assert.Len(t, data, 1)
 }
+
+func TestPrometheusQuery_MissingQuery(t *testing.T) {
+	d := &Deps{Prometheus: &fakePrometheus{}}
+	handler := NewPrometheusQueryHandler(d)
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	assert.Contains(t, textOf(result), "query is required")
+}
+
+func TestPrometheusQuery_RangeDefaults(t *testing.T) {
+	mat := model.Matrix{
+		&model.SampleStream{
+			Metric: model.Metric{"__name__": "up"},
+			Values: []model.SamplePair{
+				{Timestamp: model.TimeFromUnix(1700000000), Value: 1},
+				{Timestamp: model.TimeFromUnix(1700000060), Value: 1},
+			},
+		},
+	}
+	d := &Deps{Prometheus: &fakePrometheus{queryResult: mat}}
+	handler := NewPrometheusQueryHandler(d)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{"query": "up", "mode": "range"}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &payload))
+	assert.Equal(t, "range", payload["mode"])
+	data, ok := payload["data"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, data, 1)
+}
+
+func TestPrometheusQuery_RangeCustomStartEndStep(t *testing.T) {
+	d := &Deps{Prometheus: &fakePrometheus{queryResult: model.Matrix{}}}
+	handler := NewPrometheusQueryHandler(d)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{
+		"query": "rate(http_requests_total[5m])",
+		"mode":  "range",
+		"start": "2026-04-30T10:00:00Z",
+		"end":   "2026-04-30T11:00:00Z",
+		"step":  "30s",
+	}
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &payload))
+	assert.Equal(t, "range", payload["mode"])
+}


### PR DESCRIPTION
## Summary

Resolves four independent issues in a single batch PR.

### #43 — `mustJSON` silent error + `bufio.Scanner` 64KB truncation (reconciler)
- Replaced `mustJSON` (silently swallowed errors) with `MarshalJSON(v any) (string, error)` + `MarshalJSONFn` test seam
- Extracted `ParsePodLogStream(ctx, store, runID, io.Reader)` with `scanner.Buffer(…, 1MB)` to prevent silent truncation of pod log lines >64KB
- Tests: `TestMarshalJSON_*`, `TestParsePodLogStream_*` (including 80KB and >1MB line cases)

### #42 — `MAX_TOKENS` env-configurable + `stop_reason=max_tokens` handling (orchestrator + translator)
- `translator.Config.MaxTokens` + `defaultMaxTokens = 8192` const; `MAX_TOKENS` env var injected into agent pod
- `agent-runtime` default bumped from 4096 → 8192 to match
- `run_agent()` now handles `stop_reason=max_tokens`: `MAX_TOKENS_BEHAVIOR=continue` (default) loops; `fail` stops immediately; consecutive-hit guard (`MAX_TOKENS_CONTINUE_LIMIT`, default 3) prevents death loops
- Tests: `test_max_tokens_*` (5 cases) + `TestTranslator_InjectsMaxTokensFromConfig/DefaultMaxTokensWhenZero`

### #44 — `FINDING_JSON:` prefix + schema validation for findings extraction (orchestrator)
- Replaced brittle `startswith("{") + "dimension" in line` heuristic with explicit `FINDING_JSON: <json>` prefix protocol
- `extract_findings(text) -> (valid_findings, parse_errors)` pure function validates all 8 required fields + enum values
- Parse errors routed to logger, Langfuse tracer, and `reporter.record_llm_event`
- `build_prompt` updated to instruct LLM to emit `FINDING_JSON:` lines
- Tests: `TestExtractFindings` (7 cases) + `test_parse_errors_surfaced_via_reporter`

### #41 — mcptools test coverage expansion + CI pytest-cov (scoped)
- `kubectl_logs`: bounds checks, single-container, sinceSeconds+previous → 92.5%
- `metric_history`: full coverage with `nopStore` + `mockMetricStore` → 100%
- `events_history`: full coverage → 100%
- `prometheus_query`: `handleRange` + missing-query → 93.8%
- `deps`: `DefaultSanitizeOpts` regex paths → 100%
- CI: `pytest-cov` added to `python-test` job with XML/HTML reports + `$GITHUB_STEP_SUMMARY` table

## Test plan
- [x] `go test ./...` — all packages pass
- [x] `python -m pytest agent-runtime/tests/` — 73 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)