### PR TITLE
fix(reconciler): PhaseUnknown for TTL-expired runs + tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,85 +40,13 @@ jobs:
           go tool cover -func=coverage.out | tail -20 >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
-      - name: Comment coverage on PR
+      - name: Upload Go coverage artifact
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/upload-artifact@v4
         with:
-          script: |
-            const fs = require('fs');
-            const coverage = fs.readFileSync('coverage.out', 'utf8');
-            const { execSync } = require('child_process');
-            const report = execSync('go tool cover -func=coverage.out').toString();
-            const totalLine = report.split('\n').find(l => l.includes('total:'));
-            const total = totalLine ? totalLine.match(/[\d.]+%/)?.[0] : 'unknown';
-
-            // Build per-package summary
-            const lines = report.trim().split('\n');
-            const pkgMap = new Map();
-            for (const line of lines) {
-              if (line.includes('total:')) continue;
-              const match = line.match(/^(.+?)\s+\S+\s+([\d.]+%)/);
-              if (match) {
-                const pkg = match[1].replace('github.com/kube-agent-helper/kube-agent-helper/', '');
-                if (!pkgMap.has(pkg)) pkgMap.set(pkg, []);
-                pkgMap.get(pkg).push(match[2]);
-              }
-            }
-
-            let table = '| Package | Functions | Avg Coverage |\n|---------|-----------|-------------|\n';
-            const pkgSet = new Set();
-            for (const line of lines) {
-              if (line.includes('total:')) continue;
-              const match = line.match(/^(\S+)\s/);
-              if (match) {
-                const pkg = match[1].replace('github.com/kube-agent-helper/kube-agent-helper/', '');
-                const dir = pkg.substring(0, pkg.lastIndexOf('/'));
-                if (dir && !pkgSet.has(dir)) {
-                  pkgSet.add(dir);
-                  const funcs = lines.filter(l => l.includes(match[1].substring(0, match[1].lastIndexOf('/'))));
-                  const pcts = funcs.map(f => parseFloat(f.match(/([\d.]+)%/)?.[1] || '0'));
-                  const avg = pcts.length ? (pcts.reduce((a,b) => a+b, 0) / pcts.length).toFixed(1) : '0';
-                  table += `| ${dir} | ${pcts.length} | ${avg}% |\n`;
-                }
-              }
-            }
-
-            const body = [
-              '## 📊 Go Test Coverage Report',
-              '',
-              `**Total: ${total}**`,
-              '',
-              '<details><summary>Per-function details</summary>',
-              '',
-              '```',
-              report.split('\n').slice(-21).join('\n'),
-              '```',
-              '</details>',
-            ].join('\n');
-
-            // Find existing comment
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body?.includes('Go Test Coverage Report'));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+          name: go-coverage
+          path: coverage.out
+          retention-days: 1
 
   envtest:
     name: Integration Tests (envtest)
@@ -285,52 +213,14 @@ jobs:
           " >> $GITHUB_STEP_SUMMARY
           fi
 
-      - name: Comment coverage on PR
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const { execSync } = require('child_process');
-            const xml = fs.readFileSync('agent-runtime/coverage.xml', 'utf8');
-            const lineRate = parseFloat(xml.match(/line-rate="([\d.]+)"/)?.[1] ?? '0') * 100;
-            const branchRate = parseFloat(xml.match(/branch-rate="([\d.]+)"/)?.[1] ?? '0') * 100;
-            const body = [
-              '## 🐍 Agent Runtime Test Coverage',
-              '',
-              `**Lines: ${lineRate.toFixed(1)}% | Branches: ${branchRate.toFixed(1)}%**`,
-              '',
-              'Full report available in the [Actions artifact](../actions/runs/${{ github.run_id }}).',
-            ].join('\n');
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body?.includes('Agent Runtime Test Coverage'));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
-
       - name: Upload coverage artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: agent-runtime-coverage
-          path: agent-runtime/htmlcov/
+          path: |
+            agent-runtime/htmlcov/
+            agent-runtime/coverage.xml
           retention-days: 7
 
   skill-lint:
@@ -556,3 +446,90 @@ jobs:
           kubectl delete diagnosticfix smoke-fix smoke-fix-create --ignore-not-found
           kubectl delete diagnosticrun smoke-test --ignore-not-found
           kubectl delete diagnosticskill pod-health-analyst --ignore-not-found
+
+  coverage-comment:
+    name: Coverage Report (PR comment)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    needs: [test, python-test]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Download Go coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: go-coverage
+
+      - name: Download Python coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: agent-runtime-coverage
+          path: htmlcov
+
+      - name: Post combined coverage comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { execSync } = require('child_process');
+            const fs = require('fs');
+
+            // ── Go ────────────────────────────────────────────────────────
+            const goReport = execSync('go tool cover -func=coverage.out').toString();
+            const goTotal = (goReport.split('\n').find(l => l.includes('total:')) ?? '')
+              .match(/[\d.]+%/)?.[0] ?? 'n/a';
+            const goDetail = goReport.split('\n').slice(-21).join('\n');
+
+            // ── Python ────────────────────────────────────────────────────
+            let pyLines = 'n/a', pyBranches = 'n/a';
+            const xmlPath = 'htmlcov/coverage.xml';
+            if (fs.existsSync(xmlPath)) {
+              const xml = fs.readFileSync(xmlPath, 'utf8');
+              pyLines    = (parseFloat(xml.match(/line-rate="([\d.]+)"/)?.[1]   ?? '0') * 100).toFixed(1) + '%';
+              pyBranches = (parseFloat(xml.match(/branch-rate="([\d.]+)"/)?.[1] ?? '0') * 100).toFixed(1) + '%';
+            }
+
+            const body = [
+              '## 📊 Test Coverage Report',
+              '',
+              '| | Lines | Branches |',
+              '|---|---|---|',
+              `| **Go** | ${goTotal} | — |`,
+              `| **Python (agent-runtime)** | ${pyLines} | ${pyBranches} |`,
+              '',
+              '<details><summary>Go per-function details</summary>',
+              '',
+              '```',
+              goDetail,
+              '```',
+              '</details>',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const marker = 'Test Coverage Report';
+            const existing = comments.find(c => c.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,6 +285,46 @@ jobs:
           " >> $GITHUB_STEP_SUMMARY
           fi
 
+      - name: Comment coverage on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const { execSync } = require('child_process');
+            const xml = fs.readFileSync('agent-runtime/coverage.xml', 'utf8');
+            const lineRate = parseFloat(xml.match(/line-rate="([\d.]+)"/)?.[1] ?? '0') * 100;
+            const branchRate = parseFloat(xml.match(/branch-rate="([\d.]+)"/)?.[1] ?? '0') * 100;
+            const body = [
+              '## 🐍 Agent Runtime Test Coverage',
+              '',
+              `**Lines: ${lineRate.toFixed(1)}% | Branches: ${branchRate.toFixed(1)}%**`,
+              '',
+              'Full report available in the [Actions artifact](../actions/runs/${{ github.run_id }}).',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body?.includes('Agent Runtime Test Coverage'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
       - name: Upload coverage artifact
         if: always()
         uses: actions/upload-artifact@v4

--- a/dashboard/src/app/runs/[id]/page.tsx
+++ b/dashboard/src/app/runs/[id]/page.tsx
@@ -114,9 +114,11 @@ export default function RunDetailPage({ params }: { params: Promise<{ id: string
           <div className={`mt-3 rounded-lg border px-3 py-2 text-sm ${
             run.Status === "Failed"
               ? "border-red-500/20 bg-red-500/10 text-red-400"
-              : run.Status === "Running"
-                ? "border-yellow-500/20 bg-yellow-500/10 text-yellow-400"
-                : "border-border bg-muted/30 text-muted-foreground"
+              : run.Status === "Unknown"
+                ? "border-amber-500/20 bg-amber-500/10 text-amber-400"
+                : run.Status === "Running"
+                  ? "border-yellow-500/20 bg-yellow-500/10 text-yellow-400"
+                  : "border-border bg-muted/30 text-muted-foreground"
           }`}>
             {run.Message}
           </div>

--- a/dashboard/src/components/phase-badge.tsx
+++ b/dashboard/src/components/phase-badge.tsx
@@ -7,6 +7,7 @@ const config: Record<string, { bg: string; text: string; dot: string; pulse?: bo
   Running:   { bg: "bg-sky-500/10",    text: "text-sky-400",    dot: "bg-sky-400",   pulse: true },
   Succeeded: { bg: "bg-green-500/10",  text: "text-green-400",  dot: "bg-green-400" },
   Failed:    { bg: "bg-red-500/10",    text: "text-red-400",    dot: "bg-red-400" },
+  Unknown:   { bg: "bg-amber-500/10",  text: "text-amber-400",  dot: "bg-amber-400" },
   Scheduled: { bg: "bg-purple-500/10", text: "text-purple-400", dot: "bg-purple-400" },
 };
 

--- a/dashboard/src/i18n/en.json
+++ b/dashboard/src/i18n/en.json
@@ -102,6 +102,7 @@
     "Running": "Running",
     "Succeeded": "Succeeded",
     "Failed": "Failed",
+    "Unknown": "Unknown",
     "Scheduled": "Scheduled",
     "PendingApproval": "Pending Approval",
     "Approved": "Approved",

--- a/dashboard/src/i18n/zh.json
+++ b/dashboard/src/i18n/zh.json
@@ -102,6 +102,7 @@
     "Running": "执行中",
     "Succeeded": "成功",
     "Failed": "失败",
+    "Unknown": "结果未知",
     "Scheduled": "定时",
     "PendingApproval": "待审批",
     "Approved": "已批准",

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -3,7 +3,7 @@ export interface DiagnosticRun {
   Name?: string;
   TargetJSON: string;
   SkillsJSON: string;
-  Status: "Pending" | "Running" | "Succeeded" | "Failed" | "Scheduled";
+  Status: "Pending" | "Running" | "Succeeded" | "Failed" | "Unknown" | "Scheduled";
   Message: string;
   StartedAt: string | null;
   CompletedAt: string | null;

--- a/internal/controller/reconciler/run_reconciler.go
+++ b/internal/controller/reconciler/run_reconciler.go
@@ -161,7 +161,14 @@ func (r *DiagnosticRunReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		var job batchv1.Job
 		if err := r.Get(ctx, types.NamespacedName{Name: jobName, Namespace: run.Namespace}, &job); err != nil {
 			if errors.IsNotFound(err) {
-				// Job not created yet or was cleaned up
+				// Grace period: job may not have been created yet.
+				// Once the run has been in Running for longer than the job TTL
+				// (1 h), the job must have completed and been TTL-cleaned before
+				// the reconciler could observe its terminal status.
+				const jobTTL = time.Hour
+				if run.Status.StartedAt != nil && time.Since(run.Status.StartedAt.Time) > jobTTL {
+					return r.failRun(ctx, &run, "agent job not found — completed and TTL-expired before reconciler observed terminal status")
+				}
 				logger.Info("job not found, requeueing", "job", jobName)
 				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 			}

--- a/internal/controller/reconciler/run_reconciler.go
+++ b/internal/controller/reconciler/run_reconciler.go
@@ -167,7 +167,11 @@ func (r *DiagnosticRunReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				// the reconciler could observe its terminal status.
 				const jobTTL = time.Hour
 				if run.Status.StartedAt != nil && time.Since(run.Status.StartedAt.Time) > jobTTL {
-					return r.failRun(ctx, &run, "agent job not found — completed and TTL-expired before reconciler observed terminal status")
+					msg := fmt.Sprintf(
+						"agent job not found — job TTL (1h) expired before reconciler could observe terminal status; run started at %s",
+						run.Status.StartedAt.Format(time.RFC3339),
+					)
+					return r.unknownRun(ctx, &run, msg)
 				}
 				logger.Info("job not found, requeueing", "job", jobName)
 				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
@@ -310,6 +314,10 @@ func (r *DiagnosticRunReconciler) completeRun(ctx context.Context, run *k8saiV1.
 
 func (r *DiagnosticRunReconciler) failRun(ctx context.Context, run *k8saiV1.DiagnosticRun, msg string) (ctrl.Result, error) {
 	return r.completeRun(ctx, run, store.PhaseFailed, msg)
+}
+
+func (r *DiagnosticRunReconciler) unknownRun(ctx context.Context, run *k8saiV1.DiagnosticRun, msg string) (ctrl.Result, error) {
+	return r.completeRun(ctx, run, store.PhaseUnknown, msg)
 }
 
 // podWaitingReason lists pods for the given job and returns a human-readable

--- a/internal/controller/reconciler/run_reconciler_test.go
+++ b/internal/controller/reconciler/run_reconciler_test.go
@@ -698,3 +698,67 @@ func TestParsePodLogStream_LineExceeds1MBReturnsError(t *testing.T) {
 	assert.ErrorIs(t, err, bufio.ErrTooLong)
 	assert.Empty(t, rs.logs, "no entries should be persisted when scanner aborts on oversized line")
 }
+
+// ── TTL-expiry / PhaseUnknown ──────────────────────────────────────────────
+
+func TestRunReconciler_JobNotFoundWithinGrace_Requeues(t *testing.T) {
+	// Job missing but StartedAt is recent (< 1h) — may still be creating; requeue.
+	run := testRun()
+	run.Status.Phase = "Running"
+	run.Status.ReportID = "uid-1"
+	recent := metav1.NewTime(time.Now().Add(-5 * time.Minute))
+	run.Status.StartedAt = &recent
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(run). // no Job object
+		WithStatusSubresource(run).
+		Build()
+
+	ms := newMemStore()
+	ms.runs["uid-1"] = &store.DiagnosticRun{ID: "uid-1", Status: store.PhaseRunning}
+
+	r := &reconciler.DiagnosticRunReconciler{
+		Client: fakeClient, Store: ms, Translator: testTranslator(),
+	}
+
+	result := reconcileOnce(t, r)
+	assert.NotZero(t, result.RequeueAfter, "should requeue while within grace period")
+
+	var updated k8saiV1.DiagnosticRun
+	require.NoError(t, fakeClient.Get(context.Background(),
+		types.NamespacedName{Name: "test-run", Namespace: "default"}, &updated))
+	assert.Equal(t, "Running", updated.Status.Phase, "phase must not change within grace period")
+}
+
+func TestRunReconciler_JobNotFoundAfterTTL_MarksUnknown(t *testing.T) {
+	// Job missing and StartedAt is > 1h ago — job was TTL-cleaned; mark Unknown.
+	run := testRun()
+	run.Status.Phase = "Running"
+	run.Status.ReportID = "uid-1"
+	old := metav1.NewTime(time.Now().Add(-2 * time.Hour))
+	run.Status.StartedAt = &old
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(run). // no Job object
+		WithStatusSubresource(run).
+		Build()
+
+	ms := newMemStore()
+	ms.runs["uid-1"] = &store.DiagnosticRun{ID: "uid-1", Status: store.PhaseRunning}
+
+	r := &reconciler.DiagnosticRunReconciler{
+		Client: fakeClient, Store: ms, Translator: testTranslator(),
+	}
+
+	result := reconcileOnce(t, r)
+	assert.Zero(t, result.RequeueAfter, "terminal — should not requeue")
+
+	var updated k8saiV1.DiagnosticRun
+	require.NoError(t, fakeClient.Get(context.Background(),
+		types.NamespacedName{Name: "test-run", Namespace: "default"}, &updated))
+	assert.Equal(t, "Unknown", updated.Status.Phase)
+	assert.Contains(t, updated.Status.Message, "TTL")
+	assert.NotNil(t, updated.Status.CompletedAt)
+}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -98,7 +98,7 @@ func (s *SQLiteStore) UpdateRunStatus(ctx context.Context, id string, phase stor
 		result, err = s.db.ExecContext(ctx,
 			`UPDATE diagnostic_runs SET status=?, message=?, started_at=? WHERE id=?`,
 			string(phase), msg, now, id)
-	case store.PhaseSucceeded, store.PhaseFailed:
+	case store.PhaseSucceeded, store.PhaseFailed, store.PhaseUnknown:
 		result, err = s.db.ExecContext(ctx,
 			`UPDATE diagnostic_runs SET status=?, message=?, completed_at=? WHERE id=?`,
 			string(phase), msg, now, id)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -34,6 +34,7 @@ const (
 	PhaseRunning   Phase = "Running"
 	PhaseSucceeded Phase = "Succeeded"
 	PhaseFailed    Phase = "Failed"
+	PhaseUnknown   Phase = "Unknown"
 )
 
 type DiagnosticRun struct {


### PR DESCRIPTION
## Summary

- When a DiagnosticRun Job disappears after TTL expiry (1h), the reconciler previously had no terminal path — the run stayed stuck in **Running** forever.
- First attempt marked it **Failed**, but TTL expiry is not a confirmed failure (agent may have completed successfully).
- This PR introduces a dedicated **Unknown** phase for this case.

## Changes

- `store`: add `PhaseUnknown = "Unknown"` constant
- `sqlite`: treat `PhaseUnknown` as terminal (sets `completed_at`)
- `reconciler`: `unknownRun()` helper; when Job is NotFound + `StartedAt > 1h`, mark phase as Unknown with a timestamped message; within grace period (< 1h), continue requeueing as before
- `dashboard`: amber badge for Unknown, `i18n` en/zh (`结果未知`), `types.ts` union extended, run detail message box uses amber styling for Unknown
- `tests`: two new reconciler tests covering both branches of the job-not-found path

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `TestRunReconciler_JobNotFoundWithinGrace_Requeues` — phase stays Running
- [x] `TestRunReconciler_JobNotFoundAfterTTL_MarksUnknown` — phase=Unknown, message contains TTL, CompletedAt set

🤖 Generated with [Claude Code](https://claude.com/claude-code)