### PR TITLE
docs(examples): add fallback chain, security/cost skills, more samples

### DIFF
--- a/docs/examples/clusterconfig/multi-cluster.yaml
+++ b/docs/examples/clusterconfig/multi-cluster.yaml
@@ -1,0 +1,27 @@
+# 一份文件声明多个 ClusterConfig（staging + prod），方便 GitOps 批量管理。
+# 前置：每个集群对应的 kubeconfig 已存在 Secret（可参考 remote-with-sa-token.yaml
+# 中创建只读 SA + token 的步骤）。
+---
+apiVersion: k8sai.io/v1alpha1
+kind: ClusterConfig
+metadata:
+  name: staging
+  namespace: kube-agent-helper
+spec:
+  kubeConfigRef:
+    name: staging-kubeconfig
+    key: kubeconfig
+  prometheusURL: "http://prometheus.monitoring:9090"
+  description: "Staging cluster (us-east-1)"
+---
+apiVersion: k8sai.io/v1alpha1
+kind: ClusterConfig
+metadata:
+  name: prod
+  namespace: kube-agent-helper
+spec:
+  kubeConfigRef:
+    name: prod-kubeconfig
+    key: kubeconfig
+  prometheusURL: "http://prometheus.monitoring:9090"
+  description: "Production cluster (us-east-1)"

--- a/docs/examples/diagnosticfix/add-resource-limits.yaml
+++ b/docs/examples/diagnosticfix/add-resource-limits.yaml
@@ -1,0 +1,38 @@
+# 给 Deployment 容器补上 resources.limits + requests，避免节点资源耗尽。
+# 适用于来自 cost-waste-analyst 或 reliability-analyst 的 finding。
+#
+# 与 dry-run-preview.yaml 的差异：strategy=auto 会真正下发，并配套全套回滚。
+apiVersion: k8sai.io/v1alpha1
+kind: DiagnosticFix
+metadata:
+  name: add-resource-limits
+  namespace: kube-agent-helper
+spec:
+  diagnosticRunRef: prod-full-audit
+  findingTitle: "Containers without resource limits"
+  target:
+    kind: Deployment
+    namespace: production
+    name: api-server
+  strategy: auto
+  approvalRequired: true
+  patch:
+    type: strategic-merge
+    content: |
+      spec:
+        template:
+          spec:
+            containers:
+            - name: api
+              resources:
+                requests:
+                  cpu: 200m
+                  memory: 256Mi
+                limits:
+                  cpu: "1"
+                  memory: 512Mi
+  rollback:
+    enabled: true
+    snapshotBefore: true
+    autoRollbackOnFailure: true
+    healthCheckTimeout: 180

--- a/docs/examples/diagnosticrun/with-fallback-models.yaml
+++ b/docs/examples/diagnosticrun/with-fallback-models.yaml
@@ -1,0 +1,23 @@
+# 使用模型 fallback 链：主 Opus 失败后按顺序尝试 Sonnet → Haiku。
+# 需先创建 docs/examples/modelconfig/with-fallback.yaml 中的三个 ModelConfig。
+#
+# 行为：
+#   1. 用 opus-primary 跑，含其自身 retries=3
+#   2. 用尽后切 sonnet-fallback（retries=2）
+#   3. 仍失败则切 haiku-emergency（retries=1）保底产出
+#   4. 三个都失败 → DiagnosticRun 状态 Failed
+apiVersion: k8sai.io/v1alpha1
+kind: DiagnosticRun
+metadata:
+  name: resilient-prod-audit
+  namespace: kube-agent-helper
+spec:
+  target:
+    scope: namespace
+    namespaces: [production]
+  modelConfigRef: opus-primary
+  fallbackModelConfigRefs:
+    - sonnet-fallback
+    - haiku-emergency
+  outputLanguage: zh
+  timeoutSeconds: 600

--- a/docs/examples/diagnosticskill/cost-waste-analyst.yaml
+++ b/docs/examples/diagnosticskill/cost-waste-analyst.yaml
@@ -1,0 +1,46 @@
+apiVersion: k8sai.io/v1alpha1
+kind: DiagnosticSkill
+metadata:
+  name: cost-waste-analyst
+  namespace: kube-agent-helper
+spec:
+  description: "检测资源浪费：超额 limits、僵尸 Deployment、未释放的 PVC"
+  dimension: cost
+  enabled: true
+  priority: 80
+  tools:
+    - kubectl_get
+    - top_pods
+    - top_nodes
+    - pvc_status
+    - node_status_summary
+  requiresData:
+    - pods
+    - nodes
+    - metrics
+  prompt: |
+    你是 Kubernetes 成本优化专家。
+
+    ## 步骤
+    1. 用 kubectl_get（kind=Pod）汇总所有容器的 resources.requests / limits
+    2. 用 top_pods 拉取每个命名空间实际 CPU/内存用量
+    3. 对每个容器计算 actual / request 比值：
+       - actual CPU < 20% request 持续 → 过量配置
+       - actual memory < 30% request 持续 → 过量配置
+       - 同一 Deployment 下 ≥3 个 Pod 命中 → 合并为单条 finding
+    4. 用 kubectl_get（kind=Deployment）找 spec.replicas=0 的僵尸 Deployment
+    5. 用 pvc_status 列出 status.phase=Released 或无 Pod 引用的 PVC
+    6. 用 top_nodes + node_status_summary 找 allocated < 20% 的低利用率节点
+    7. 输出 finding（dimension: cost）。建议优先聚合到 Deployment 级别，避免每个 Pod 一条
+
+    ## Finding 输出格式（每行一个 JSON）
+    {"dimension":"cost","severity":"<high|medium|low>",
+     "title":"<简短标题>","description":"<请求 vs 实际用量数据>",
+     "resource_kind":"<Deployment|StatefulSet|PersistentVolumeClaim|Node>",
+     "resource_namespace":"<ns>","resource_name":"<name>",
+     "suggestion":"<建议下调 limits 至具体数值，或删除资源>"}
+
+    ## 严重程度
+    - high: >50% 资源浪费横跨多个 Pod，或低利用率节点
+    - medium: 20-50% 过量配置，或孤儿 PVC
+    - low: 单 Pod 轻度过量

--- a/docs/examples/diagnosticskill/secret-leak-analyst.yaml
+++ b/docs/examples/diagnosticskill/secret-leak-analyst.yaml
@@ -1,0 +1,39 @@
+apiVersion: k8sai.io/v1alpha1
+kind: DiagnosticSkill
+metadata:
+  name: secret-leak-analyst
+  namespace: kube-agent-helper
+spec:
+  description: "检测明文写入 env 或 ConfigMap 中的敏感凭据"
+  dimension: security
+  enabled: true
+  priority: 50
+  tools:
+    - kubectl_get
+    - kubectl_describe
+  requiresData:
+    - pods
+  prompt: |
+    你是 Kubernetes 凭据泄露排查专家。
+
+    ## 步骤
+    1. 用 kubectl_get（kind=Pod）拉取目标命名空间所有 Pod，仅看 spec.containers[*].env
+    2. 用 kubectl_get（kind=ConfigMap）拉取所有 ConfigMap 的 data 段
+    3. 在 env value、ConfigMap data 中匹配以下高风险模式：
+       - `password=`、`PASSWORD=`、`SECRET=`、`TOKEN=`、`API_KEY=`
+       - 形如 `AKIA[0-9A-Z]{16}`（AWS access key）
+       - 以 `-----BEGIN` 开头的 PEM 私钥
+       - 出现 `mongodb://`、`postgres://`、`mysql://` 且 URL 中带密码段
+    4. 命中后输出 finding。同一资源多条命中合并为一条，severity 取最高
+    5. 推荐修复：迁移到 Secret + envFrom.secretKeyRef，或使用 ExternalSecrets
+
+    ## Finding 输出格式（每行一个 JSON）
+    {"dimension":"security","severity":"<critical|high|medium>",
+     "title":"<简短标题>","description":"<命中字段与样本>",
+     "resource_kind":"<Pod|ConfigMap>","resource_namespace":"<ns>","resource_name":"<name>",
+     "suggestion":"<迁移到 Secret 的具体建议>"}
+
+    ## 严重程度
+    - critical: AWS access key / 私钥 / 数据库连接串明文
+    - high: 通用 token / api_key 明文
+    - medium: 仅命中关键字但 value 形似占位符

--- a/docs/examples/modelconfig/with-fallback.yaml
+++ b/docs/examples/modelconfig/with-fallback.yaml
@@ -1,0 +1,48 @@
+# 演示 ModelConfig 的 retries（瞬时错误重试）+ 配套 fallback 链。
+# 配合 DiagnosticRun.spec.fallbackModelConfigRefs 使用：
+# 主 Opus 用尽 retries 后切到 Sonnet，再切到 Haiku 兜底。
+#
+# 触发条件：5xx / 429 / 网络超时 / connection error。
+# 4xx（鉴权失败、模型不存在等）永不重试，直接切下一个。
+---
+apiVersion: k8sai.io/v1alpha1
+kind: ModelConfig
+metadata:
+  name: opus-primary
+  namespace: kube-agent-helper
+spec:
+  provider: anthropic
+  model: claude-opus-4-7
+  apiKeyRef:
+    name: anthropic-credentials
+    key: apiKey
+  maxTurns: 40
+  retries: 3
+---
+apiVersion: k8sai.io/v1alpha1
+kind: ModelConfig
+metadata:
+  name: sonnet-fallback
+  namespace: kube-agent-helper
+spec:
+  provider: anthropic
+  model: claude-sonnet-4-6
+  apiKeyRef:
+    name: anthropic-credentials
+    key: apiKey
+  maxTurns: 30
+  retries: 2
+---
+apiVersion: k8sai.io/v1alpha1
+kind: ModelConfig
+metadata:
+  name: haiku-emergency
+  namespace: kube-agent-helper
+spec:
+  provider: anthropic
+  model: claude-haiku-4-5-20251001
+  apiKeyRef:
+    name: anthropic-credentials
+    key: apiKey
+  maxTurns: 15
+  retries: 1


### PR DESCRIPTION
## Summary
补充 6 个 CRD 示例，覆盖此前 examples 目录里没有覆盖的特性和维度：

- **`modelconfig/with-fallback.yaml`** — `retries` + 三段式 fallback 链（opus → sonnet → haiku），对齐 2026-04-29 的 fallback/retry 设计
- **`diagnosticrun/with-fallback-models.yaml`** — 实际使用 `fallbackModelConfigRefs` 串起上面三个 ModelConfig
- **`diagnosticskill/secret-leak-analyst.yaml`** — `dimension: security`（之前 3 个内置示例都是 reliability）
- **`diagnosticskill/cost-waste-analyst.yaml`** — `dimension: cost`，用 `top_pods` / `pvc_status` / `node_status_summary`
- **`diagnosticfix/add-resource-limits.yaml`** — `strategy: auto` + 完整 rollback 配置（与 `dry-run-preview.yaml` 互补）
- **`clusterconfig/multi-cluster.yaml`** — staging + prod 两个 ClusterConfig 同文件声明

所有示例引用的 skill 名、tool 名、CRD 字段均已对照 `internal/mcptools/register.go` 与 `deploy/crds/*.yaml` 校验。

## Test plan
- [x] 6 个文件均通过 `yaml.safe_load_all` 解析
- [x] 所引用的工具名（`top_pods`、`pvc_status`、`node_status_summary` 等）与 `internal/mcptools/register.go` 中的注册名一致
- [x] `dimension` 取值（security / cost）在 CRD enum 范围内
- [ ] 将示例 apply 到 kind 集群验证 webhook / controller 接受（建议 reviewer 跑一次 `kubectl apply -f docs/examples/...`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)