### PR TITLE
test: critical-path coverage push (8 packages, 0 production changes)

### DIFF
--- a/agent-runtime/tests/test_fix_main.py
+++ b/agent-runtime/tests/test_fix_main.py
@@ -1,0 +1,328 @@
+"""Tests for runtime.fix_main entrypoint and helpers.
+
+The module reads CONTROLLER_URL at import time, so we set it on os.environ
+before importing. Helpers like build_prompt, parse_patch_json, and
+_api_version_for_kind are pure and can be exercised directly. main() is
+exercised end-to-end with mocked MCP, LLM, tracer, and httpx.
+"""
+import base64
+import importlib
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure module-level env vars exist before fix_main is first imported anywhere
+# in this test process. fix_main reads CONTROLLER_URL at import time.
+os.environ.setdefault("CONTROLLER_URL", "http://controller.test:8080")
+
+from runtime import fix_main  # noqa: E402
+
+
+# ── Pure helpers ────────────────────────────────────────────────────────────
+
+
+class TestApiVersionForKind:
+    def test_known_kinds(self):
+        cases = {
+            "Deployment": "apps/v1",
+            "StatefulSet": "apps/v1",
+            "DaemonSet": "apps/v1",
+            "Pod": "v1",
+            "Service": "v1",
+            "ConfigMap": "v1",
+            "Secret": "v1",
+            "ServiceAccount": "v1",
+            "Namespace": "v1",
+            "PersistentVolumeClaim": "v1",
+            "ResourceQuota": "v1",
+            "LimitRange": "v1",
+            "Job": "batch/v1",
+            "CronJob": "batch/v1",
+            "Ingress": "networking.k8s.io/v1",
+            "NetworkPolicy": "networking.k8s.io/v1",
+            "PodDisruptionBudget": "policy/v1",
+            "HorizontalPodAutoscaler": "autoscaling/v2",
+        }
+        for kind, expected in cases.items():
+            assert fix_main._api_version_for_kind(kind) == expected, kind
+
+    def test_unknown_kind_returns_empty(self):
+        assert fix_main._api_version_for_kind("WidgetCRD") == ""
+
+
+class TestBuildPrompt:
+    def test_english_prompt(self):
+        finding = {"title": "T", "description": "D", "suggestion": "S"}
+        out = fix_main.build_prompt(finding, "current: yaml", "en")
+        assert "Title: T" in out
+        assert "Description: D" in out
+        assert "current: yaml" in out
+        assert "English" in out
+
+    def test_chinese_prompt(self):
+        finding = {"title": "T"}
+        out = fix_main.build_prompt(finding, "y", "zh")
+        assert "简体中文" in out
+
+
+class TestBuildCreatePrompt:
+    def test_english_prompt(self):
+        finding = {
+            "title": "T",
+            "description": "D",
+            "suggestion": "S",
+            "target": {"namespace": "ns1"},
+        }
+        out = fix_main.build_create_prompt(finding, "en")
+        assert "Title: T" in out
+        assert "Target namespace: ns1" in out
+        assert "does not exist yet" in out
+        assert "English" in out
+
+    def test_chinese_prompt(self):
+        out = fix_main.build_create_prompt({"target": {"namespace": "ns"}}, "zh")
+        assert "简体中文" in out
+
+    def test_default_namespace_used_when_missing(self):
+        out = fix_main.build_create_prompt({"target": {}}, "en")
+        assert "Target namespace: default" in out
+
+
+class TestParsePatchJson:
+    def test_plain_json(self):
+        s = '{"type":"strategic-merge","content":"{}","explanation":"x"}'
+        out = fix_main.parse_patch_json(s)
+        assert out["type"] == "strategic-merge"
+
+    def test_with_code_fence(self):
+        s = '```json\n{"content":"x"}\n```'
+        out = fix_main.parse_patch_json(s)
+        assert out["content"] == "x"
+
+    def test_with_bare_fence(self):
+        s = '```\n{"content":"x"}\n```'
+        out = fix_main.parse_patch_json(s)
+        assert out["content"] == "x"
+
+    def test_with_surrounding_whitespace(self):
+        s = '   \n  {"content":"x"} \n  '
+        assert fix_main.parse_patch_json(s)["content"] == "x"
+
+    def test_non_object_raises(self):
+        with pytest.raises(ValueError, match="expected JSON object"):
+            fix_main.parse_patch_json("[1,2,3]")
+
+    def test_missing_content_raises(self):
+        with pytest.raises(ValueError, match="missing 'content'"):
+            fix_main.parse_patch_json('{"type":"strategic-merge"}')
+
+    def test_invalid_json_raises(self):
+        with pytest.raises(json.JSONDecodeError):
+            fix_main.parse_patch_json("not json at all")
+
+
+# ── _stream_llm_call ────────────────────────────────────────────────────────
+
+
+class TestStreamLLMCall:
+    def _stub_resp(self, lines):
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=ctx)
+        ctx.__exit__ = MagicMock(return_value=False)
+        ctx.raise_for_status = MagicMock()
+        ctx.iter_lines = MagicMock(return_value=iter(lines))
+        return ctx
+
+    def test_parses_text_deltas_and_token_counts(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "key")
+        events = [
+            f"data: {json.dumps({'type':'message_start','message':{'usage':{'input_tokens':123}}})}",
+            f"data: {json.dumps({'type':'content_block_delta','delta':{'type':'text_delta','text':'hello '}})}",
+            f"data: {json.dumps({'type':'content_block_delta','delta':{'type':'text_delta','text':'world'}})}",
+            f"data: {json.dumps({'type':'message_delta','usage':{'output_tokens':45}})}",
+            "data: [DONE]",
+        ]
+        with patch.object(fix_main.httpx, "stream", return_value=self._stub_resp(events)):
+            text, in_tok, out_tok = fix_main._stream_llm_call("prompt")
+        assert text == "hello world"
+        assert in_tok == 123
+        assert out_tok == 45
+
+    def test_skips_empty_lines_and_non_data(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "key")
+        events = [
+            "",
+            "event: ping",
+            "data:",
+            "data: not json either",
+            f"data: {json.dumps({'type':'content_block_delta','delta':{'type':'text_delta','text':'ok'}})}",
+            "data: [DONE]",
+        ]
+        with patch.object(fix_main.httpx, "stream", return_value=self._stub_resp(events)):
+            text, _, _ = fix_main._stream_llm_call("p")
+        assert text == "ok"
+
+    def test_uses_explicit_messages_endpoint_when_provided(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "key")
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://proxy.example.com/v1/messages")
+
+        captured = {}
+
+        def fake_stream(method, url, headers, json, timeout):
+            captured["url"] = url
+            return self._stub_resp([])
+
+        with patch.object(fix_main.httpx, "stream", side_effect=fake_stream):
+            fix_main._stream_llm_call("p")
+        assert captured["url"] == "https://proxy.example.com/v1/messages"
+
+    def test_appends_messages_path_otherwise(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "key")
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://api.anthropic.com/")
+        captured = {}
+
+        def fake_stream(method, url, headers, json, timeout):
+            captured["url"] = url
+            return self._stub_resp([])
+
+        with patch.object(fix_main.httpx, "stream", side_effect=fake_stream):
+            fix_main._stream_llm_call("p")
+        assert captured["url"] == "https://api.anthropic.com/v1/messages"
+
+
+# ── main() end-to-end ───────────────────────────────────────────────────────
+
+
+def _finding_env(monkeypatch, **overrides):
+    finding = {
+        "findingID": "f1",
+        "runID": "r1",
+        "title": "Pod missing limits",
+        "description": "no resource limits set",
+        "suggestion": "add limits",
+        "target": {"kind": "Deployment", "namespace": "default", "name": "nginx"},
+    }
+    finding.update(overrides)
+    monkeypatch.setenv("FIX_INPUT_JSON", json.dumps(finding))
+    return finding
+
+
+class TestMain:
+    def test_patch_existing_resource_happy_path(self, monkeypatch):
+        _finding_env(monkeypatch)
+
+        # MCP returns a JSON-serialised Deployment.
+        mcp = MagicMock(return_value=json.dumps({
+            "apiVersion": "apps/v1", "kind": "Deployment",
+            "metadata": {"name": "nginx", "namespace": "default"},
+            "spec": {"replicas": 1},
+        }))
+        # LLM returns a wrapped patch.
+        llm = MagicMock(return_value=(
+            json.dumps({"type": "strategic-merge", "content": "{\"spec\":{\"replicas\":3}}", "explanation": "scale up"}),
+            200, 50,
+        ))
+        post = MagicMock()
+        post.return_value.json = MagicMock(return_value={"metadata": {"name": "fix-1"}})
+        post.return_value.raise_for_status = MagicMock()
+        # tracer.init_fix returns a stub.
+        tr = MagicMock()
+        tr_init = MagicMock(return_value=tr)
+
+        with patch.object(fix_main, "call_mcp_tool", mcp), \
+             patch.object(fix_main, "_stream_llm_call", llm), \
+             patch.object(fix_main, "_tracer", MagicMock(init_fix=tr_init)), \
+             patch.object(fix_main.httpx, "post", post):
+            rc = fix_main.main()
+
+        assert rc == 0
+        # The POST body should encode strategy=dry-run when resource exists.
+        body = post.call_args.kwargs["json"]
+        assert body["strategy"] == "dry-run"
+        assert body["target"]["kind"] == "Deployment"
+        assert body["explanation"] == "scale up"
+        # beforeSnapshot should be base64 of the current YAML.
+        assert isinstance(body["beforeSnapshot"], str) and body["beforeSnapshot"]
+        decoded = base64.b64decode(body["beforeSnapshot"]).decode("utf-8")
+        assert "nginx" in decoded
+        # tracer.generation + flush were both called.
+        tr.generation.assert_called_once()
+        tr.flush.assert_called()
+
+    def test_create_when_target_missing(self, monkeypatch):
+        _finding_env(monkeypatch)
+
+        # MCP returns "not found" → code path swaps to create strategy.
+        mcp = MagicMock(return_value="tool error: not found")
+        llm = MagicMock(return_value=(
+            json.dumps({"type": "create", "content": "{\"apiVersion\":\"v1\"}"}),
+            10, 5,
+        ))
+        post = MagicMock()
+        post.return_value.json = MagicMock(return_value={"metadata": {"name": "fix-x"}})
+        post.return_value.raise_for_status = MagicMock()
+
+        with patch.object(fix_main, "call_mcp_tool", mcp), \
+             patch.object(fix_main, "_stream_llm_call", llm), \
+             patch.object(fix_main, "_tracer", MagicMock(init_fix=MagicMock(return_value=MagicMock()))), \
+             patch.object(fix_main.httpx, "post", post):
+            rc = fix_main.main()
+
+        assert rc == 0
+        body = post.call_args.kwargs["json"]
+        assert body["strategy"] == "create"
+        # No snapshot when resource didn't exist.
+        assert body["beforeSnapshot"] == ""
+
+    def test_llm_failure_returns_2(self, monkeypatch):
+        _finding_env(monkeypatch)
+
+        mcp = MagicMock(return_value=json.dumps({"kind": "Deployment"}))
+        llm = MagicMock(side_effect=RuntimeError("api down"))
+        tr = MagicMock()
+
+        with patch.object(fix_main, "call_mcp_tool", mcp), \
+             patch.object(fix_main, "_stream_llm_call", llm), \
+             patch.object(fix_main, "_tracer", MagicMock(init_fix=MagicMock(return_value=tr))):
+            rc = fix_main.main()
+
+        assert rc == 2
+        tr.flush.assert_called()  # tracer must be flushed even on failure
+
+    def test_invalid_patch_json_returns_2(self, monkeypatch):
+        _finding_env(monkeypatch)
+
+        mcp = MagicMock(return_value=json.dumps({"kind": "Deployment"}))
+        llm = MagicMock(return_value=("{not really json}", 1, 1))
+
+        with patch.object(fix_main, "call_mcp_tool", mcp), \
+             patch.object(fix_main, "_stream_llm_call", llm), \
+             patch.object(fix_main, "_tracer", MagicMock(init_fix=MagicMock(return_value=MagicMock()))):
+            rc = fix_main.main()
+        assert rc == 2
+
+    def test_mcp_returns_invalid_json_falls_back_to_raw_text(self, monkeypatch):
+        _finding_env(monkeypatch)
+
+        # Non-JSON response that doesn't match the "not found" / "tool error"
+        # markers — the code falls through to current_yaml = raw.
+        mcp = MagicMock(return_value="some plaintext describing the resource")
+        llm = MagicMock(return_value=(
+            json.dumps({"type": "strategic-merge", "content": "{}"}),
+            1, 1,
+        ))
+        post = MagicMock()
+        post.return_value.json = MagicMock(return_value={"metadata": {"name": "fix"}})
+        post.return_value.raise_for_status = MagicMock()
+
+        with patch.object(fix_main, "call_mcp_tool", mcp), \
+             patch.object(fix_main, "_stream_llm_call", llm), \
+             patch.object(fix_main, "_tracer", MagicMock(init_fix=MagicMock(return_value=MagicMock()))), \
+             patch.object(fix_main.httpx, "post", post):
+            rc = fix_main.main()
+        assert rc == 0
+        body = post.call_args.kwargs["json"]
+        assert body["strategy"] == "dry-run", "raw text counts as 'resource exists'"

--- a/agent-runtime/tests/test_tracer_extra.py
+++ b/agent-runtime/tests/test_tracer_extra.py
@@ -1,0 +1,256 @@
+"""Extended tests for runtime.tracer to cover init/, sanitize_messages,
+_NoOp helpers, _Tracer.generation/span/flush, and degradation paths.
+"""
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from runtime import tracer
+from runtime.tracer import _NoOp, _Tracer
+
+
+# ── init / init_fix ─────────────────────────────────────────────────────────
+
+
+class TestInit:
+    def test_no_keys_returns_noop(self, monkeypatch):
+        monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+        monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+        t = tracer.init("run-1", ["skill-a"])
+        assert isinstance(t, _NoOp)
+
+    def test_only_public_key_returns_noop(self, monkeypatch):
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk")
+        monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+        t = tracer.init("run-1", [])
+        assert isinstance(t, _NoOp)
+
+    def test_with_keys_constructs_tracer(self, monkeypatch):
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk")
+
+        fake_lf = MagicMock()
+        fake_trace = MagicMock()
+        fake_lf.trace.return_value = fake_trace
+
+        with patch.dict(sys.modules, {"langfuse": MagicMock(Langfuse=lambda: fake_lf)}):
+            t = tracer.init("run-1", ["s1", "s2"])
+
+        assert isinstance(t, _Tracer)
+        fake_lf.trace.assert_called_once()
+        kwargs = fake_lf.trace.call_args.kwargs
+        assert kwargs["id"] == "run-1"
+        assert kwargs["name"] == "diagnostic-run"
+        assert kwargs["metadata"] == {"skills": ["s1", "s2"]}
+
+    def test_sdk_failure_degrades_to_noop(self, monkeypatch):
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk")
+
+        broken = MagicMock()
+        broken.Langfuse = MagicMock(side_effect=RuntimeError("sdk boom"))
+        with patch.dict(sys.modules, {"langfuse": broken}):
+            t = tracer.init("run-1", [])
+        assert isinstance(t, _NoOp), "init must return _NoOp when SDK explodes"
+
+
+class TestInitFix:
+    def test_no_keys_returns_noop(self, monkeypatch):
+        monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+        t = tracer.init_fix("finding-1", "run-1")
+        assert isinstance(t, _NoOp)
+
+    def test_with_keys_constructs_tracer(self, monkeypatch):
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk")
+
+        fake_lf = MagicMock()
+        fake_trace = MagicMock()
+        fake_lf.trace.return_value = fake_trace
+
+        with patch.dict(sys.modules, {"langfuse": MagicMock(Langfuse=lambda: fake_lf)}):
+            t = tracer.init_fix("finding-9", "run-9")
+
+        assert isinstance(t, _Tracer)
+        kwargs = fake_lf.trace.call_args.kwargs
+        assert kwargs["name"] == "fix-generation"
+        assert kwargs["metadata"] == {"finding_id": "finding-9", "run_id": "run-9"}
+        assert "fix" in kwargs["tags"]
+
+    def test_sdk_failure_degrades_to_noop(self, monkeypatch):
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk")
+        broken = MagicMock()
+        broken.Langfuse = MagicMock(side_effect=ValueError("nope"))
+        with patch.dict(sys.modules, {"langfuse": broken}):
+            t = tracer.init_fix("f", "r")
+        assert isinstance(t, _NoOp)
+
+
+# ── sanitize_messages ───────────────────────────────────────────────────────
+
+
+class TestSanitizeMessages:
+    def test_string_content_truncated(self):
+        out = tracer.sanitize_messages([{"role": "user", "content": "x" * 1000}], max_content_chars=10)
+        assert out == [{"role": "user", "content": "x" * 10}]
+
+    def test_tool_result_truncated(self):
+        msg = {
+            "role": "user",
+            "content": [
+                {"type": "tool_result", "tool_use_id": "t1", "content": "y" * 800},
+            ],
+        }
+        out = tracer.sanitize_messages([msg], max_content_chars=20)
+        block = out[0]["content"][0]
+        assert block["type"] == "tool_result"
+        assert block["tool_use_id"] == "t1"
+        assert block["content"] == "y" * 20
+
+    def test_tool_result_non_string_content_is_stringified(self):
+        msg = {
+            "role": "user",
+            "content": [
+                {"type": "tool_result", "tool_use_id": "t1", "content": {"k": "v" * 200}},
+            ],
+        }
+        out = tracer.sanitize_messages([msg], max_content_chars=15)
+        # Non-str content gets str()'d then truncated
+        assert isinstance(out[0]["content"][0]["content"], str)
+        assert len(out[0]["content"][0]["content"]) <= 15
+
+    def test_text_block_truncated(self):
+        msg = {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "z" * 500}],
+        }
+        out = tracer.sanitize_messages([msg], max_content_chars=8)
+        assert out[0]["content"][0] == {"type": "text", "text": "z" * 8}
+
+    def test_tool_use_preserves_name_and_input(self):
+        msg = {
+            "role": "assistant",
+            "content": [
+                {"type": "tool_use", "name": "kubectl_get", "input": {"resource": "pod"}, "id": "tu1"},
+            ],
+        }
+        out = tracer.sanitize_messages([msg])
+        assert out[0]["content"][0] == {
+            "type": "tool_use",
+            "name": "kubectl_get",
+            "input": {"resource": "pod"},
+        }
+
+    def test_unknown_block_type_keeps_only_type(self):
+        msg = {
+            "role": "user",
+            "content": [{"type": "unknown_block", "secret": "hush"}],
+        }
+        out = tracer.sanitize_messages([msg])
+        assert out[0]["content"][0] == {"type": "unknown_block"}
+
+    def test_non_str_non_list_content_keeps_role_only(self):
+        msg = {"role": "system", "content": 42}
+        out = tracer.sanitize_messages([msg])
+        assert out == [{"role": "system"}]
+
+    def test_default_max_content_chars(self):
+        long = "x" * 1000
+        out = tracer.sanitize_messages([{"role": "user", "content": long}])
+        # default is 300
+        assert len(out[0]["content"]) == 300
+
+
+# ── _NoOp ───────────────────────────────────────────────────────────────────
+
+
+class TestNoOpAllMethods:
+    def test_generation_returns_noop_chain(self):
+        n = _NoOp()
+        nested = n.generation(name="x")
+        assert isinstance(nested, _NoOp)
+        # Method chaining keeps returning _NoOp
+        assert isinstance(nested.span(name="y"), _NoOp)
+
+    def test_event_end_flush_no_raise(self):
+        n = _NoOp()
+        assert n.end(meta="x") is None
+        assert n.flush() is None
+
+
+# ── _Tracer.generation / span / flush ──────────────────────────────────────
+
+
+class TestTracerGenerationSpan:
+    def test_generation_delegates(self):
+        fake_lf = MagicMock()
+        fake_trace = MagicMock()
+        fake_trace.generation.return_value = "gen-handle"
+        t = _Tracer(fake_lf, fake_trace)
+        assert t.generation(name="x") == "gen-handle"
+        fake_trace.generation.assert_called_once_with(name="x")
+
+    def test_span_delegates(self):
+        fake_lf = MagicMock()
+        fake_trace = MagicMock()
+        fake_trace.span.return_value = "span-handle"
+        t = _Tracer(fake_lf, fake_trace)
+        assert t.span(name="x") == "span-handle"
+
+    def test_generation_failure_degrades(self):
+        fake_trace = MagicMock()
+        fake_trace.generation.side_effect = RuntimeError("boom")
+        t = _Tracer(MagicMock(), fake_trace)
+        result = t.generation(name="x")
+        assert isinstance(result, _NoOp)
+        assert t._degraded is True
+
+        # Subsequent call short-circuits to _NoOp without invoking SDK.
+        fake_trace.generation.reset_mock()
+        result2 = t.generation(name="y")
+        assert isinstance(result2, _NoOp)
+        fake_trace.generation.assert_not_called()
+
+    def test_span_failure_degrades(self):
+        fake_trace = MagicMock()
+        fake_trace.span.side_effect = RuntimeError("boom")
+        t = _Tracer(MagicMock(), fake_trace)
+        result = t.span(name="x")
+        assert isinstance(result, _NoOp)
+        assert t._degraded is True
+
+        # Once degraded, span returns _NoOp without calling underlying SDK.
+        fake_trace.span.reset_mock()
+        assert isinstance(t.span(name="y"), _NoOp)
+        fake_trace.span.assert_not_called()
+
+
+class TestTracerFlush:
+    def test_flush_calls_lf(self):
+        fake_lf = MagicMock()
+        t = _Tracer(fake_lf, MagicMock())
+        t.flush()
+        fake_lf.flush.assert_called_once()
+
+    def test_flush_swallows_errors(self):
+        fake_lf = MagicMock()
+        fake_lf.flush.side_effect = RuntimeError("flush boom")
+        t = _Tracer(fake_lf, MagicMock())
+        t.flush()  # must not raise
+
+
+# ── Integration: a degraded tracer keeps event() silent ─────────────────────
+
+
+def test_event_after_degradation_is_silent():
+    fake_trace = MagicMock()
+    fake_trace.span.side_effect = RuntimeError("trip")
+
+    t = _Tracer(MagicMock(), fake_trace)
+    t.span(name="x")  # trips degraded flag
+    fake_trace.event.reset_mock()
+
+    t.event(name="ev1")
+    fake_trace.event.assert_not_called()

--- a/docs/superpowers/specs/2026-05-01-critical-path-test-coverage-design.md
+++ b/docs/superpowers/specs/2026-05-01-critical-path-test-coverage-design.md
@@ -1,0 +1,233 @@
+# Critical-Path Test Coverage — Design
+
+**Date:** 2026-05-01
+**Author:** Claude (with @googs1025)
+**Status:** Approved, pending implementation plan
+
+## Goal
+
+Raise unit-test coverage on the **8 highest-risk packages** of `kube-agent-helper`
+to **≥80%** each, prioritising business-critical and bug-prone code over
+"easy" boilerplate. CI thresholds are not modified by this work — they may be
+revisited after merge based on the new baseline.
+
+## Non-Goals
+
+- Touching CLI entrypoints (`cmd/...`, `cmd/kah/cmd/*`) — they are 0% but low
+  business risk and high test cost.
+- Touching CRD generated code (`internal/controller/api/v1alpha1`) — generated.
+- Refactoring production code beyond the **3 explicitly-listed minor changes**
+  required to make tests possible (see Risks).
+- Raising coverage of already-strong packages
+  (`audit` 97.5%, `registry` 95%, `sanitize` 93%, `trimmer` 86%, `translator` 85%).
+
+## Baseline (snapshot, 2026-05-01)
+
+| # | Package | Before | Target | Lang |
+|---|---|---|---|---|
+| 1 | `internal/agent` | 0.0% | ≥80% | Go |
+| 2 | `internal/k8sclient` | 34.3% | ≥80% | Go |
+| 3 | `internal/store/sqlite` | 44.0% | ≥80% | Go |
+| 4 | `internal/collector` | 19.8% | ≥80% | Go |
+| 5 | `internal/controller/httpserver` | 58.9% | ≥80% | Go |
+| 6 | `internal/controller/reconciler` | 49.1% | ≥80% | Go |
+| 7 | `agent-runtime/runtime/tracer.py` | 53% | ≥80% | Python |
+| 8 | `agent-runtime/runtime/fix_main.py` | 0% | ≥80% | Python |
+
+## Workflow
+
+- New branch off `main`: `test/critical-path-coverage`.
+- 8 **test commits** on that branch, one per target package, in the order above
+  (bottom-up: dependencies first, then their consumers). Up to 2 small
+  `refactor(...)` commits may be inserted before specific test commits to add
+  test seams (see Risks). Total commit count: 8–10.
+- Single PR into `main`.
+- Existing test style is preserved:
+  - Go: `fake.NewClientBuilder()` (controller-runtime), `fake.NewSimpleClientset()`
+    (client-go), real SQLite tmpfile, `httptest`, table-driven tests.
+  - Python: `pytest` + `unittest.mock` + `monkeypatch`. No new test deps.
+
+## Per-Commit Strategy
+
+### [1] `test(agent): cover EmitEvent log emission`
+
+Only `EmitEvent` is uncovered (writes structured JSON to stdout).
+
+- Pipe `os.Stdout`, call `EmitEvent`, decode back into `LogEntry`, assert fields.
+- Cases: happy path with non-nil `Data`, `nil` data omits the field, RFC3339Nano
+  timestamp format, each `LogType*` constant value used.
+- ~3-4 cases.
+
+### [2] `test(k8sclient): cover Build, mapper.{NewMapper,ResolveGVR,Discovery}`
+
+- `Build`: error path with malformed kubeconfig; success path with a fake
+  `*rest.Config`. Skip the in-cluster branch.
+- `mapper.ResolveGVR`: table-driven over GVK→GVR resolution using
+  `fake.NewSimpleClientset()`'s discovery; cover `unknown kind` error.
+- ~5-6 cases.
+
+### [3] `test(sqlite): cover paginated/notification/log/batch ops`
+
+- `setupTestStore(t)` (existing helper) + tmpfile.
+- `AppendRunLog`/`ListRunLogs`: ordering, tail limit.
+- `*Paginated` (`ListRunsPaginated`, `ListFixesPaginated`, `ListEventsPaginated`):
+  multi-page, sort-column whitelist via `sanitizeSortOrder`, page out-of-range.
+- `sanitizeSortOrder`: table-driven, including injection attempts and
+  ASC/DESC normalisation.
+- `NotificationConfig` 5 CRUDs: create→get→list→update→delete lifecycle plus
+  Get/Update/Delete-on-missing.
+- `DeleteRuns` (cascade), `BatchUpdateFixPhase` (multi-id update).
+- `ListSkills` (currently 0%).
+- ~15-20 cases.
+
+### [4] `test(collector): cover watch/scrape/purge loops`
+
+- `DefaultConfig`, `NeedLeaderElection`: single-line asserts.
+- `watchEvents`: `fake.NewSimpleClientset()` event watcher; inject an Event,
+  assert sanitised version reaches the store; `ctx.Cancel` exits cleanly.
+- `scrapeAll`: fake `metrics.k8s.io` clientset; inject `PodMetrics`, assert
+  `InsertMetricSnapshot` called with correct fields.
+- `runPurge`: stub `Store` counting `PurgeOldEvents`/`PurgeOldMetrics`;
+  `ctx.Cancel` exits.
+- `Start`: only that startup→cancel→exit does not panic; inner loop body is
+  exercised via the helper-level tests above.
+- ~10-12 cases.
+
+### [5] `test(httpserver): cover 0% handlers and weak branches`
+
+- 0% handlers to cover end-to-end: `handleAPIModelConfigs`,
+  `handleAPINotificationConfigs`, `handleAPINotificationConfigDetail`,
+  `reloadNotificationChannels`, `runFromK8s`, `WithNotifier`/
+  `WithNotificationManager`.
+- Weak handlers — add error branches (parse failure, k8s `NotFound`, missing
+  namespace, partial-failure batches): `handleAPIK8sResources` (53%),
+  `handleK8sResource` (61%), `handleAPIRunCRD` (45%), `handleAPIFindingAction`
+  (55%), `handleAPIFixesBatchReject` (47%), `handleAPIFixDetail` (57%),
+  `handleInternal` (55%), `findFixCRByStoreID` (42%), `streamLogsFromPod` (36%).
+- `parsePodLogLine` (53%): table-driven across all formats.
+- Use `httptest.NewRecorder()` + fake k8s client + tmpfile sqlite.
+- A small `newTestServer(t, opts...)` factory may be added in a `_test.go`
+  file if the existing helper proves insufficient.
+- Skip `Start` (real listener).
+- ~25-30 cases.
+
+### [6] `test(reconciler): cover fix patch/rollback, scheduled_run, run.collectPodLogs`
+
+- `fix_reconciler.applyPatch`/`rollback`: build a Fix CR and target Deployment
+  with `fake.NewClientBuilder()`; assert post-patch fields and rollback restore.
+- `fix_reconciler.kindToGVK`: table-driven.
+- `scheduled_run_reconciler.Reconcile`: requires a clock injection seam — see
+  Risks. Cases: trigger child Run on schedule, `enforceHistoryLimit` deletes
+  old runs, `appendUnique`/`removeFromSlice` direct unit tests.
+- `run_reconciler.collectPodLogs` (11%): fake clientset + fake corev1 pod logs
+  stream (existing `ParsePodLogStream` is already 88% covered, reuse it).
+- `run_reconciler.completeRun` (56%) and `podWaitingReason` (53%): cover each
+  pod phase / waiting reason branch.
+- Skip the 6 `SetupWithManager` calls.
+- ~25-30 cases.
+
+### [7] `test(tracer.py): cover error paths and disabled state`
+
+- Inspect `coverage report -m` for `tracer.py` missing line numbers.
+- Add cases for: exception inside traced block, context-manager exit on error,
+  no-op when tracing disabled, long-trace truncation.
+- ~5-8 cases.
+
+### [8] `test(fix_main.py): cover apply/rollback/CLI`
+
+- New `tests/test_fix_main.py`. Mock `kubernetes.client` and the LLM client.
+- Cases: success path (Job→patch→apply), apply failure → rollback,
+  reporter callback invoked, `argparse` errors on bad CLI input,
+  `KUBECONFIG` env var resolution.
+- ~8-10 cases.
+
+## Exemptions (Out of Scope of the 80%)
+
+The following kinds of code are explicitly **not required to be tested**.
+Note that `go test -coverprofile` reports coverage over **all** statements,
+so heavily-exempted packages may not be able to reach exactly 80% even when
+all reasonable code is covered. Operating rule: **aim for 80% reported
+coverage; if exempted code blocks make 80% unreachable, the package may land
+at up to 5 points below 80%, provided every non-exempt function is covered.**
+Exempted categories:
+
+- `SetupWithManager(mgr ctrl.Manager)` — needs a real manager; low value.
+- `Start(ctx)` long-running goroutines — only that startup/exit doesn't panic
+  is tested; inner loop body is split into helpers tested separately.
+- Generated code (`MarshalJSON` boilerplate, `zz_generated_*.go`).
+- `main()` entrypoints (none in scope here anyway).
+
+## Verification (per commit)
+
+```bash
+# Go
+go test -race -count=1 -coverprofile=/tmp/before.out ./<pkg>
+# ... write tests ...
+go test -race -count=1 -coverprofile=/tmp/after.out ./<pkg>
+go tool cover -func=/tmp/after.out | tail -1   # confirm ≥ 80%
+go vet ./<pkg>
+golangci-lint run ./<pkg>
+go test -race -count=1 ./...                   # full regression
+
+# Python
+pytest agent-runtime/tests/ --cov=agent-runtime/runtime/<x> \
+    --cov-report=term-missing
+pytest agent-runtime/tests/                    # full regression
+```
+
+Each commit must:
+- Reach ≥80% on the target package.
+- Pass full `go test ./...` and full `pytest`.
+- Add no new `go vet` / `golangci-lint` warnings.
+- Modify **no business code** (see Risks for the 3 exceptions).
+
+## Commit Message Format
+
+Existing convention is preserved:
+
+```
+test(<pkg>): cover <area>
+
+- <case 1>
+- <case 2>
+- ...
+
+Coverage: X.X% → Y.Y%
+```
+
+If a test exposes a real bug, it goes in a separate `fix(<pkg>): ...` commit
+**inserted before** the test commit. Test commits never bundle production fixes.
+
+## Risks & Required Production-Code Changes
+
+3 minor production changes are accepted as separate refactor commits inserted
+before the relevant test commit. They are pure seam additions (no behaviour
+change):
+
+1. **Clock injection in `scheduled_run_reconciler`** —
+   `refactor(reconciler): inject clock seam for scheduled_run`. Adds a `now
+   func() time.Time` field, default `time.Now`. Inserted before commit [6].
+2. **Optional `metrics.k8s.io` lister extraction in `collector`** —
+   only if the `metrics/pkg/client/clientset/versioned/fake` fake proves
+   insufficient. Inserted before commit [4]. Wraps the lister so tests can
+   inject `PodMetrics`.
+3. **Test helper `newTestServer` in `httpserver` `_test.go`** — *not* production
+   code, just a test file. Listed here for visibility because it expands the
+   testing surface. Inserted as part of commit [5].
+
+If any of these turn out to need more invasive surgery than expected, the
+relevant commit is reduced in scope (e.g. `httpserver` lands at 75% instead
+of 80%) rather than extending the production-code change.
+
+## Deliverables
+
+- This design (`docs/superpowers/specs/2026-05-01-critical-path-test-coverage-design.md`).
+- Implementation plan (`docs/superpowers/plans/2026-05-01-critical-path-test-coverage.md`)
+  produced by the writing-plans skill after this design is approved.
+- Branch `test/critical-path-coverage` off `main`, 8 commits, single PR.
+- Net result: each of the 8 target packages ≥80%, total ~100 new test cases,
+  zero new dependencies.
+
+## Open Questions
+
+None. Design approved 2026-05-01.

--- a/internal/agent/logging_test.go
+++ b/internal/agent/logging_test.go
@@ -1,0 +1,159 @@
+package agent
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// captureStdout redirects os.Stdout into a pipe, runs fn, restores Stdout, and
+// returns whatever fn wrote. Used because EmitEvent writes directly to stdout.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+	os.Stdout = origStdout
+	return <-done
+}
+
+func TestEmitEvent_HappyPathWithData(t *testing.T) {
+	type payload struct {
+		Step   int    `json:"step"`
+		Reason string `json:"reason"`
+	}
+	out := captureStdout(t, func() {
+		EmitEvent("run-123", LogTypeStep, "checking pod", payload{Step: 2, Reason: "pending"})
+	})
+
+	var got LogEntry
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &got); err != nil {
+		t.Fatalf("unmarshal emitted line: %v\nraw=%q", err, out)
+	}
+
+	if got.RunID != "run-123" {
+		t.Errorf("RunID = %q, want run-123", got.RunID)
+	}
+	if got.Type != LogTypeStep {
+		t.Errorf("Type = %q, want %q", got.Type, LogTypeStep)
+	}
+	if got.Message != "checking pod" {
+		t.Errorf("Message = %q, want %q", got.Message, "checking pod")
+	}
+	if got.Data == nil {
+		t.Errorf("Data = nil, want non-nil")
+	}
+	if _, err := time.Parse(time.RFC3339Nano, got.Timestamp); err != nil {
+		t.Errorf("Timestamp %q does not parse as RFC3339Nano: %v", got.Timestamp, err)
+	}
+}
+
+func TestEmitEvent_NilDataOmitsField(t *testing.T) {
+	out := captureStdout(t, func() {
+		EmitEvent("run-7", LogTypeInfo, "starting", nil)
+	})
+
+	// `data,omitempty` means nil should not produce the key at all.
+	if strings.Contains(out, `"data"`) {
+		t.Errorf("expected no \"data\" field for nil data, got: %s", out)
+	}
+
+	var got LogEntry
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &got); err != nil {
+		t.Fatalf("unmarshal: %v\nraw=%q", err, out)
+	}
+	if got.Data != nil {
+		t.Errorf("Data = %v, want nil", got.Data)
+	}
+}
+
+func TestEmitEvent_AllLogTypes(t *testing.T) {
+	cases := []struct {
+		name    string
+		logType string
+	}{
+		{"step", LogTypeStep},
+		{"finding", LogTypeFinding},
+		{"fix", LogTypeFix},
+		{"error", LogTypeError},
+		{"info", LogTypeInfo},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			out := captureStdout(t, func() {
+				EmitEvent("r1", tc.logType, "msg", nil)
+			})
+			var got LogEntry
+			if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &got); err != nil {
+				t.Fatalf("unmarshal: %v\nraw=%q", err, out)
+			}
+			if got.Type != tc.logType {
+				t.Errorf("Type = %q, want %q", got.Type, tc.logType)
+			}
+		})
+	}
+}
+
+func TestLogTypeConstantsAreStable(t *testing.T) {
+	// These constant values are read by the controller-side log tailer
+	// and must not silently drift. Lock them down.
+	cases := map[string]string{
+		"step":    LogTypeStep,
+		"finding": LogTypeFinding,
+		"fix":     LogTypeFix,
+		"error":   LogTypeError,
+		"info":    LogTypeInfo,
+	}
+	for want, got := range cases {
+		if got != want {
+			t.Errorf("LogType for %q = %q, want %q", want, got, want)
+		}
+	}
+}
+
+func TestEmitEvent_TimestampMonotonic(t *testing.T) {
+	// Two consecutive calls should produce non-decreasing timestamps.
+	out := captureStdout(t, func() {
+		EmitEvent("r", LogTypeInfo, "first", nil)
+		EmitEvent("r", LogTypeInfo, "second", nil)
+	})
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %q", len(lines), out)
+	}
+	var a, b LogEntry
+	if err := json.Unmarshal([]byte(lines[0]), &a); err != nil {
+		t.Fatalf("line0 unmarshal: %v", err)
+	}
+	if err := json.Unmarshal([]byte(lines[1]), &b); err != nil {
+		t.Fatalf("line1 unmarshal: %v", err)
+	}
+	ta, _ := time.Parse(time.RFC3339Nano, a.Timestamp)
+	tb, _ := time.Parse(time.RFC3339Nano, b.Timestamp)
+	if tb.Before(ta) {
+		t.Errorf("second timestamp %v is before first %v", tb, ta)
+	}
+}

--- a/internal/collector/collector_extra_test.go
+++ b/internal/collector/collector_extra_test.go
@@ -1,0 +1,411 @@
+package collector
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/kube-agent-helper/kube-agent-helper/internal/store"
+	sqlitestore "github.com/kube-agent-helper/kube-agent-helper/internal/store/sqlite"
+)
+
+// newCollectorTestStore returns a real sqlite store backed by a tmpfile.
+// Using the real store keeps the test honest about row-level behaviour.
+func newCollectorTestStore(t *testing.T) store.Store {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "collector-*.db")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	s, err := sqlitestore.New(filepath.Clean(f.Name()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// ── Trivial helpers ──────────────────────────────────────────────────────────
+
+func TestDefaultConfig_Values(t *testing.T) {
+	c := DefaultConfig()
+	assert.Equal(t, 100, c.EventBatchSize)
+	assert.Equal(t, 5*time.Second, c.EventFlushPeriod)
+	assert.Equal(t, time.Hour, c.PurgePeriod)
+	assert.Equal(t, 7, c.RetentionDays)
+}
+
+func TestNeedLeaderElection_True(t *testing.T) {
+	c := &Collector{}
+	assert.True(t, c.NeedLeaderElection())
+}
+
+// ── runPurge ─────────────────────────────────────────────────────────────────
+
+// purgeCounterStore wraps a real Store and counts Purge* calls so tests can
+// observe the loop firing without needing tmpfile inspection.
+type purgeCounterStore struct {
+	store.Store
+	purgeEvents  atomic.Int32
+	purgeMetrics atomic.Int32
+}
+
+func (s *purgeCounterStore) PurgeOldEvents(ctx context.Context, before time.Time) error {
+	s.purgeEvents.Add(1)
+	return s.Store.PurgeOldEvents(ctx, before)
+}
+
+func (s *purgeCounterStore) PurgeOldMetrics(ctx context.Context, before time.Time) error {
+	s.purgeMetrics.Add(1)
+	return s.Store.PurgeOldMetrics(ctx, before)
+}
+
+func TestRunPurge_FiresOnTickAndExitsOnCancel(t *testing.T) {
+	cs := &purgeCounterStore{Store: newCollectorTestStore(t)}
+	c := &Collector{
+		Config: Config{PurgePeriod: 5 * time.Millisecond, RetentionDays: 7},
+		Store:  cs,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		c.runPurge(ctx)
+		close(done)
+	}()
+
+	// Wait long enough for several ticks.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("runPurge did not exit within 1s of ctx cancel")
+	}
+
+	assert.Greater(t, int(cs.purgeEvents.Load()), 0, "PurgeOldEvents should fire at least once")
+	assert.Greater(t, int(cs.purgeMetrics.Load()), 0, "PurgeOldMetrics should fire at least once")
+}
+
+// ── watchEvents ──────────────────────────────────────────────────────────────
+
+func TestWatchEvents_DrainsListedWarnings(t *testing.T) {
+	now := time.Now()
+	preExisting := &corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{UID: types.UID("ev-1"), Namespace: "default", Name: "pod.x.1"},
+		InvolvedObject: corev1.ObjectReference{Kind: "Pod", Name: "pod-x"},
+		Reason:         "BackOff",
+		Message:        "back-off restarting",
+		Type:           "Warning",
+		Count:          1,
+		FirstTimestamp: metav1.NewTime(now),
+		LastTimestamp:  metav1.NewTime(now),
+	}
+
+	clientset := fake.NewSimpleClientset(preExisting)
+
+	c := &Collector{
+		Config: DefaultConfig(),
+		Client: clientset,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan *store.Event, 10)
+	errCh := make(chan error, 1)
+	go func() { errCh <- c.watchEvents(ctx, ch) }()
+
+	select {
+	case ev := <-ch:
+		assert.Equal(t, "ev-1", ev.UID)
+		assert.Equal(t, "BackOff", ev.Reason)
+		assert.Equal(t, "Pod", ev.Kind)
+	case <-time.After(time.Second):
+		t.Fatal("expected pre-existing Warning event on channel within 1s")
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		assert.NoError(t, err, "watchEvents should return nil on ctx cancel")
+	case <-time.After(time.Second):
+		t.Fatal("watchEvents did not return after cancel")
+	}
+}
+
+func TestWatchEvents_HandlesAddedEventFromWatcher(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+
+	// Inject a fake watcher we control.
+	w := watch.NewFake()
+	clientset.PrependWatchReactor("events", func(_ k8stesting.Action) (bool, watch.Interface, error) {
+		return true, w, nil
+	})
+
+	c := &Collector{Config: DefaultConfig(), Client: clientset}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan *store.Event, 10)
+	errCh := make(chan error, 1)
+	go func() { errCh <- c.watchEvents(ctx, ch) }()
+
+	now := time.Now()
+	w.Add(&corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{UID: types.UID("ev-2"), Namespace: "kube-system"},
+		InvolvedObject: corev1.ObjectReference{Kind: "Node", Name: "node-1"},
+		Reason:         "NodeNotReady",
+		Type:           "Warning",
+		Count:          3,
+		FirstTimestamp: metav1.NewTime(now),
+		LastTimestamp:  metav1.NewTime(now),
+	})
+
+	select {
+	case ev := <-ch:
+		assert.Equal(t, "ev-2", ev.UID)
+		assert.Equal(t, "NodeNotReady", ev.Reason)
+	case <-time.After(time.Second):
+		t.Fatal("expected watcher-injected event on channel within 1s")
+	}
+
+	cancel()
+	<-errCh
+}
+
+func TestWatchEvents_ListErrorReturned(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	clientset.PrependReactor("list", "events", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, assertErr("list boom")
+	})
+
+	c := &Collector{Config: DefaultConfig(), Client: clientset}
+	err := c.watchEvents(context.Background(), make(chan *store.Event, 1))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list boom")
+}
+
+// assertErr is a tiny helper to build an error; keeps imports minimal.
+type assertErr string
+
+func (e assertErr) Error() string { return string(e) }
+
+// ── scrapeAll ────────────────────────────────────────────────────────────────
+
+// stubPromAPI implements prometheusv1.API and returns a configurable result for
+// Query. All other methods panic — callers should only invoke Query.
+type stubPromAPI struct {
+	prometheusv1.API
+	queryResult model.Value
+	queryErr    error
+	queries     []string
+	mu          sync.Mutex
+}
+
+func (s *stubPromAPI) Query(_ context.Context, q string, _ time.Time, _ ...prometheusv1.Option) (model.Value, prometheusv1.Warnings, error) {
+	s.mu.Lock()
+	s.queries = append(s.queries, q)
+	s.mu.Unlock()
+	return s.queryResult, prometheusv1.Warnings{"sample warning"}, s.queryErr
+}
+
+func TestScrapeAll_StoresVectorSamples(t *testing.T) {
+	s := newCollectorTestStore(t)
+	c := &Collector{
+		Config: Config{
+			MetricsQueries: []string{`up{job="kubelet"}`},
+		},
+		Store: s,
+	}
+
+	ts := model.TimeFromUnix(time.Now().Unix())
+	api := &stubPromAPI{
+		queryResult: model.Vector{
+			&model.Sample{
+				Metric:    model.Metric{"__name__": "up", "job": "kubelet", "instance": "n1"},
+				Value:     model.SampleValue(1),
+				Timestamp: ts,
+			},
+			&model.Sample{
+				Metric:    model.Metric{"__name__": "up", "job": "kubelet", "instance": "n2"},
+				Value:     model.SampleValue(0),
+				Timestamp: ts,
+			},
+		},
+	}
+
+	c.scrapeAll(context.Background(), api)
+
+	// Query the snapshots back via store interface.
+	snaps, err := s.QueryMetricHistory(context.Background(), `up{job="kubelet"}`, 60)
+	require.NoError(t, err)
+	assert.Len(t, snaps, 2)
+}
+
+func TestScrapeAll_SkipsNonVectorResult(t *testing.T) {
+	s := newCollectorTestStore(t)
+	c := &Collector{
+		Config: Config{MetricsQueries: []string{`scalar_query`}},
+		Store:  s,
+	}
+	api := &stubPromAPI{
+		queryResult: &model.Scalar{Timestamp: model.TimeFromUnix(time.Now().Unix()), Value: 42},
+	}
+	c.scrapeAll(context.Background(), api)
+
+	snaps, err := s.QueryMetricHistory(context.Background(), `scalar_query`, 60)
+	require.NoError(t, err)
+	assert.Empty(t, snaps, "non-Vector result should be silently skipped")
+}
+
+func TestScrapeAll_QueryErrorIsLoggedAndContinues(t *testing.T) {
+	s := newCollectorTestStore(t)
+	c := &Collector{
+		Config: Config{MetricsQueries: []string{`bad_query`, `good_query`}},
+		Store:  s,
+	}
+	ts := model.TimeFromUnix(time.Now().Unix())
+
+	calls := 0
+	api := &errThenSuccessStub{
+		onQuery: func(q string) (model.Value, error) {
+			calls++
+			if q == "bad_query" {
+				return nil, assertErr("query boom")
+			}
+			return model.Vector{
+				&model.Sample{
+					Metric:    model.Metric{"__name__": "good"},
+					Value:     1,
+					Timestamp: ts,
+				},
+			}, nil
+		},
+	}
+
+	c.scrapeAll(context.Background(), api)
+
+	snaps, err := s.QueryMetricHistory(context.Background(), `good_query`, 60)
+	require.NoError(t, err)
+	assert.Len(t, snaps, 1, "successful query should still record despite earlier failure")
+	assert.Equal(t, 2, calls, "both queries must be attempted")
+}
+
+// errThenSuccessStub lets each query return a tailored value.
+type errThenSuccessStub struct {
+	prometheusv1.API
+	onQuery func(q string) (model.Value, error)
+}
+
+func (s *errThenSuccessStub) Query(_ context.Context, q string, _ time.Time, _ ...prometheusv1.Option) (model.Value, prometheusv1.Warnings, error) {
+	v, err := s.onQuery(q)
+	return v, nil, err
+}
+
+func TestScrapeAll_TruncatesOversizedVector(t *testing.T) {
+	s := newCollectorTestStore(t)
+	c := &Collector{
+		Config: Config{MetricsQueries: []string{`huge`}},
+		Store:  s,
+	}
+
+	ts := model.TimeFromUnix(time.Now().Unix())
+	vec := make(model.Vector, maxSeriesPerQuery+50)
+	for i := range vec {
+		vec[i] = &model.Sample{
+			Metric:    model.Metric{"__name__": "x", "i": model.LabelValue(string(rune('a' + i%26)))},
+			Value:     model.SampleValue(i),
+			Timestamp: ts,
+		}
+	}
+	api := &stubPromAPI{queryResult: vec}
+
+	c.scrapeAll(context.Background(), api)
+
+	snaps, err := s.QueryMetricHistory(context.Background(), `huge`, 60)
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(snaps), maxSeriesPerQuery, "oversized vector must be truncated to maxSeriesPerQuery")
+}
+
+// ── Start (full launcher) ────────────────────────────────────────────────────
+
+func TestCollector_Start_LaunchesAndExitsOnCancel(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	store := newCollectorTestStore(t)
+
+	c := &Collector{
+		Config: Config{
+			PurgePeriod:      5 * time.Millisecond,
+			RetentionDays:    7,
+			EventBatchSize:   10,
+			EventFlushPeriod: 100 * time.Millisecond,
+			// PrometheusURL empty + no Queries → metric goroutine is skipped.
+		},
+		Store:  store,
+		Client: clientset,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- c.Start(ctx) }()
+
+	time.Sleep(30 * time.Millisecond) // give goroutines time to spin up
+	cancel()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return within 2s of cancel")
+	}
+}
+
+func TestCollector_Start_WithMetricsConfigSpawnsMetricGoroutine(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	store := newCollectorTestStore(t)
+
+	c := &Collector{
+		Config: Config{
+			PurgePeriod:      time.Second,
+			EventBatchSize:   10,
+			EventFlushPeriod: 100 * time.Millisecond,
+			// runMetricCollector branch — uses real prometheusapi.NewClient with
+			// an unreachable address; since we cancel before any tick, no
+			// network call is actually made.
+			PrometheusURL:  "http://prom.invalid:9090",
+			MetricsQueries: []string{`up`},
+		},
+		Store:  store,
+		Client: clientset,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- c.Start(ctx) }()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return")
+	}
+}

--- a/internal/controller/httpserver/internal_helpers_test.go
+++ b/internal/controller/httpserver/internal_helpers_test.go
@@ -1,0 +1,116 @@
+package httpserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// parsePodLogLine and parsePagination are unexported, so this test file lives
+// inside `package httpserver` rather than the external `_test` package.
+
+func TestParsePodLogLine_StructuredJSONWithData(t *testing.T) {
+	line := `{"timestamp":"2026-05-01T12:00:00Z","run_id":"r1","type":"step","message":"hello","data":{"k":"v"}}`
+	entry := parsePodLogLine(line, "r1", 7)
+	assert.Equal(t, int64(7), entry.ID)
+	assert.Equal(t, "r1", entry.RunID)
+	assert.Equal(t, "2026-05-01T12:00:00Z", entry.Timestamp)
+	assert.Equal(t, "step", entry.Type)
+	assert.Equal(t, "hello", entry.Message)
+	assert.Equal(t, `{"k":"v"}`, entry.Data)
+}
+
+func TestParsePodLogLine_StructuredJSONWithoutData(t *testing.T) {
+	line := `{"timestamp":"2026-05-01T12:00:00Z","run_id":"r1","type":"finding","message":"saw"}`
+	entry := parsePodLogLine(line, "r1", 1)
+	assert.Equal(t, "finding", entry.Type)
+	assert.Equal(t, "", entry.Data)
+}
+
+func TestParsePodLogLine_InvalidJSONFallsBackToRawText(t *testing.T) {
+	entry := parsePodLogLine("not json at all", "r1", 1)
+	assert.Equal(t, "info", entry.Type, "non-JSON line falls back to type=info")
+	assert.Equal(t, "not json at all", entry.Message, "raw line becomes message")
+	assert.NotEmpty(t, entry.Timestamp, "fallback timestamp is filled")
+}
+
+func TestParsePodLogLine_JSONWithEmptyMessageFallsBack(t *testing.T) {
+	// Valid JSON but empty message — should fall back to the raw line.
+	line := `{"timestamp":"x","run_id":"r1","type":"step","message":""}`
+	entry := parsePodLogLine(line, "r1", 1)
+	assert.Equal(t, "info", entry.Type)
+	assert.Equal(t, line, entry.Message)
+}
+
+func TestParsePodLogLine_TypeDefaultsToInfoWhenJSONOmitsIt(t *testing.T) {
+	line := `{"timestamp":"2026-05-01T00:00:00Z","run_id":"r","message":"x"}`
+	entry := parsePodLogLine(line, "r", 1)
+	assert.Equal(t, "x", entry.Message)
+	assert.Equal(t, "info", entry.Type, "missing type defaults to info")
+}
+
+func TestParsePodLogLine_TimestampDefaultsWhenMissing(t *testing.T) {
+	line := `{"run_id":"r","type":"step","message":"x"}`
+	entry := parsePodLogLine(line, "r", 1)
+	assert.NotEmpty(t, entry.Timestamp, "missing timestamp gets filled")
+}
+
+func TestParsePagination_Defaults(t *testing.T) {
+	r := mustNewGet(t, "/x")
+	got := parsePagination(r)
+	assert.Equal(t, 50, got.Limit)
+	assert.Equal(t, 0, got.Offset)
+}
+
+func TestParsePagination_ExplicitLimitAndOffset(t *testing.T) {
+	r := mustNewGet(t, "/x?limit=10&offset=20")
+	got := parsePagination(r)
+	assert.Equal(t, 10, got.Limit)
+	assert.Equal(t, 20, got.Offset)
+}
+
+func TestParsePagination_LimitCappedAt500(t *testing.T) {
+	r := mustNewGet(t, "/x?limit=99999")
+	got := parsePagination(r)
+	assert.Equal(t, 500, got.Limit, "limit must be capped at 500")
+}
+
+func TestParsePagination_InvalidValuesIgnored(t *testing.T) {
+	r := mustNewGet(t, "/x?limit=abc&offset=-5")
+	got := parsePagination(r)
+	assert.Equal(t, 50, got.Limit, "non-numeric limit falls back to default")
+	assert.Equal(t, 0, got.Offset, "negative offset falls back to default")
+}
+
+func TestStrVal_TableDriven(t *testing.T) {
+	cases := []struct {
+		name  string
+		input map[string]interface{}
+		key   string
+		want  string
+	}{
+		{"present-string", map[string]interface{}{"x": "abc"}, "x", "abc"},
+		{"present-int", map[string]interface{}{"x": 42}, "x", ""},
+		{"present-nil", map[string]interface{}{"x": nil}, "x", ""},
+		{"missing", map[string]interface{}{"y": "v"}, "x", ""},
+		{"empty-map", map[string]interface{}{}, "x", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, strVal(tc.input, tc.key))
+		})
+	}
+}
+
+func TestRandSuffix_LengthAndAlphabet(t *testing.T) {
+	cases := []int{0, 1, 5, 10, 32}
+	const allowed = "abcdefghijklmnopqrstuvwxyz0123456789"
+	for _, n := range cases {
+		got := randSuffix(n)
+		require.Len(t, got, n, "length mismatch for n=%d", n)
+		for _, ch := range got {
+			assert.Contains(t, allowed, string(ch), "out-of-alphabet char in randSuffix")
+		}
+	}
+}

--- a/internal/controller/httpserver/server_extra_test.go
+++ b/internal/controller/httpserver/server_extra_test.go
@@ -1,0 +1,619 @@
+package httpserver_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	clientsetfake "k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1alpha1 "github.com/kube-agent-helper/kube-agent-helper/internal/controller/api/v1alpha1"
+	"github.com/kube-agent-helper/kube-agent-helper/internal/controller/httpserver"
+	"github.com/kube-agent-helper/kube-agent-helper/internal/notification"
+	"github.com/kube-agent-helper/kube-agent-helper/internal/store"
+)
+
+// ── Test doubles ─────────────────────────────────────────────────────────────
+
+// recordingNotifMgr records calls to ReloadFromConfigs / SendTest and is
+// satisfied by httpserver.NotificationManager.
+type recordingNotifMgr struct {
+	mu          sync.Mutex
+	reloadCalls int
+	lastConfigs []*notification.NotificationConfig
+	testCalls   atomic.Int32
+	testErr     error
+	notifyErr   error
+	notifyCalls atomic.Int32
+}
+
+func (m *recordingNotifMgr) Notify(_ context.Context, _ notification.Event) error {
+	m.notifyCalls.Add(1)
+	return m.notifyErr
+}
+
+func (m *recordingNotifMgr) ReloadFromConfigs(cfgs []*notification.NotificationConfig) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.reloadCalls++
+	m.lastConfigs = cfgs
+}
+
+func (m *recordingNotifMgr) SendTest(_ context.Context, _ *notification.NotificationConfig) error {
+	m.testCalls.Add(1)
+	return m.testErr
+}
+
+// fakeK8sClient builds a controller-runtime fake client with the schemes used
+// in this file, optionally seeded with objects.
+func fakeK8sClient(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	return ctrlfake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+}
+
+// fakeClientset returns an empty client-go fake clientset for use as
+// kubernetes.Interface (e.g. for log streaming endpoints not exercised here).
+func fakeClientset() kubernetes.Interface { return clientsetfake.NewSimpleClientset() }
+
+// ── ModelConfigs ─────────────────────────────────────────────────────────────
+
+func TestModelConfigs_GET_NoK8sClient_503(t *testing.T) {
+	fs := &fakeStore{}
+	srv := httpserver.New(fs, nil, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/modelconfigs", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+func TestModelConfigs_GET_ListReturnsMaskedAPIKey(t *testing.T) {
+	mc := &v1alpha1.ModelConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "anthropic-creds", Namespace: "default"},
+		Spec: v1alpha1.ModelConfigSpec{
+			Provider: "anthropic", Model: "claude-sonnet-4-6",
+			APIKeyRef: v1alpha1.SecretKeyRef{Name: "anthropic-creds", Key: "apiKey"},
+		},
+	}
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t, mc), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/modelconfigs", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var got []map[string]interface{}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "anthropic-creds", got[0]["name"])
+	assert.Equal(t, "****", got[0]["apiKey"], "API key must always be masked")
+	assert.Equal(t, "anthropic", got[0]["provider"])
+}
+
+func TestModelConfigs_POST_CreatesCRWithDefaults(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"name":      "ollama-local",
+		"namespace": "default",
+		// provider/model omitted → defaults must apply
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/modelconfigs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+}
+
+func TestModelConfigs_POST_BadJSON_400(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/modelconfigs", bytes.NewReader([]byte("not json")))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestModelConfigs_POST_MissingNamespace_400(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+
+	body, _ := json.Marshal(map[string]interface{}{"name": "x"})
+	req := httptest.NewRequest(http.MethodPost, "/api/modelconfigs", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestModelConfigs_POST_AlreadyExists_409(t *testing.T) {
+	existing := &v1alpha1.ModelConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "dup", Namespace: "default"},
+		Spec:       v1alpha1.ModelConfigSpec{Provider: "anthropic", Model: "x"},
+	}
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t, existing), nil)
+
+	body, _ := json.Marshal(map[string]interface{}{"name": "dup", "namespace": "default"})
+	req := httptest.NewRequest(http.MethodPost, "/api/modelconfigs", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusConflict, w.Code)
+}
+
+func TestModelConfigs_MethodNotAllowed(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodPut, "/api/modelconfigs", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+// ── NotificationConfigs ──────────────────────────────────────────────────────
+
+func TestNotificationConfigs_GET_EmptyReturnsArray(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/notification-configs", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	body := bytes.TrimSpace(w.Body.Bytes())
+	assert.Equal(t, []byte("[]"), body, "empty list should serialise as []")
+}
+
+func TestNotificationConfigs_POST_CreatesAndReloadsManager(t *testing.T) {
+	mgr := &recordingNotifMgr{}
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil, httpserver.WithNotificationManager(mgr))
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"name": "ops-slack", "type": "slack",
+		"webhookURL": "https://example.invalid/hook",
+		"events":     "fix.applied", "enabled": true,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/notification-configs", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	mgr.mu.Lock()
+	assert.Equal(t, 1, mgr.reloadCalls, "reloadNotificationChannels must fire after Create")
+	mgr.mu.Unlock()
+}
+
+func TestNotificationConfigs_POST_InvalidType_400(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"name": "x", "type": "discord", "webhookURL": "http://x",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/notification-configs", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestNotificationConfigs_POST_MissingFields_400(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	body, _ := json.Marshal(map[string]interface{}{"name": "x"})
+	req := httptest.NewRequest(http.MethodPost, "/api/notification-configs", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestNotificationConfigs_POST_BadJSON_400(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/notification-configs", bytes.NewReader([]byte("not json")))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestNotificationConfigs_PUT_UpdatesAndReloads(t *testing.T) {
+	mgr := &recordingNotifMgr{}
+	fs := &fakeStore{
+		notifConfigs: []*store.NotificationConfig{
+			{ID: "n1", Name: "old", Type: "slack", WebhookURL: "https://x"},
+		},
+	}
+	srv := httpserver.New(fs, fakeK8sClient(t), nil, httpserver.WithNotificationManager(mgr))
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"name": "new-name", "type": "slack",
+		"webhookURL": "https://example.invalid/v2",
+		"enabled":    true,
+	})
+	req := httptest.NewRequest(http.MethodPut, "/api/notification-configs/n1", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	mgr.mu.Lock()
+	assert.Equal(t, 1, mgr.reloadCalls, "reload must fire after PUT")
+	mgr.mu.Unlock()
+}
+
+func TestNotificationConfigs_PUT_NotFound_404(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	body, _ := json.Marshal(map[string]interface{}{"name": "x", "type": "slack", "webhookURL": "http://y"})
+	req := httptest.NewRequest(http.MethodPut, "/api/notification-configs/ghost", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestNotificationConfigs_PUT_BadJSON_400(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodPut, "/api/notification-configs/n1", bytes.NewReader([]byte("not json")))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestNotificationConfigs_PUT_MissingFields_400(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	body, _ := json.Marshal(map[string]interface{}{"name": "only-name"})
+	req := httptest.NewRequest(http.MethodPut, "/api/notification-configs/n1", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestNotificationConfigs_DELETE_OK(t *testing.T) {
+	mgr := &recordingNotifMgr{}
+	fs := &fakeStore{
+		notifConfigs: []*store.NotificationConfig{
+			{ID: "n1", Name: "x", Type: "slack", WebhookURL: "https://y"},
+		},
+	}
+	srv := httpserver.New(fs, fakeK8sClient(t), nil, httpserver.WithNotificationManager(mgr))
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/notification-configs/n1", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	mgr.mu.Lock()
+	assert.Equal(t, 1, mgr.reloadCalls, "reload must fire after DELETE")
+	mgr.mu.Unlock()
+}
+
+func TestNotificationConfigs_DELETE_NotFound(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodDelete, "/api/notification-configs/ghost", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestNotificationConfigs_TEST_NoManagerConfigured_500(t *testing.T) {
+	fs := &fakeStore{
+		notifConfigs: []*store.NotificationConfig{
+			{ID: "n1", Name: "x", Type: "slack", WebhookURL: "https://y"},
+		},
+	}
+	// No WithNotificationManager option.
+	srv := httpserver.New(fs, fakeK8sClient(t), nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/notification-configs/n1/test", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestNotificationConfigs_TEST_HappyPath(t *testing.T) {
+	mgr := &recordingNotifMgr{}
+	fs := &fakeStore{
+		notifConfigs: []*store.NotificationConfig{
+			{ID: "n1", Name: "x", Type: "slack", WebhookURL: "https://y"},
+		},
+	}
+	srv := httpserver.New(fs, fakeK8sClient(t), nil, httpserver.WithNotificationManager(mgr))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/notification-configs/n1/test", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, int32(1), mgr.testCalls.Load())
+}
+
+func TestNotificationConfigs_TEST_BackendFailure_502(t *testing.T) {
+	mgr := &recordingNotifMgr{testErr: errors.New("downstream boom")}
+	fs := &fakeStore{
+		notifConfigs: []*store.NotificationConfig{
+			{ID: "n1", Name: "x", Type: "slack", WebhookURL: "https://y"},
+		},
+	}
+	srv := httpserver.New(fs, fakeK8sClient(t), nil, httpserver.WithNotificationManager(mgr))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/notification-configs/n1/test", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadGateway, w.Code)
+}
+
+func TestNotificationConfigs_TEST_NotFound_404(t *testing.T) {
+	mgr := &recordingNotifMgr{}
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil, httpserver.WithNotificationManager(mgr))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/notification-configs/ghost/test", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestNotificationConfigs_PathTooShort_404(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/notification-configs/", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestNotificationConfigs_DetailMethodNotAllowed(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodPatch, "/api/notification-configs/n1", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+// ── handleAPIK8sResources ────────────────────────────────────────────────────
+
+func TestK8sResources_MethodNotAllowed(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/k8s/resources", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+func TestK8sResources_MissingKind_400(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/k8s/resources", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestK8sResources_UnsupportedKind_400(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/k8s/resources?kind=Widget", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestK8sResources_PodMissingNamespace_400(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/k8s/resources?kind=Pod", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestK8sResources_PodNotFound_404(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/k8s/resources?kind=Pod&namespace=default&name=missing", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestK8sResources_PodGetByName_OK(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "default", UID: types.UID("u1")},
+	}
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t, pod), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/k8s/resources?kind=Pod&namespace=default&name=p1", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var got map[string]interface{}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+	meta := got["metadata"].(map[string]interface{})
+	assert.Equal(t, "p1", meta["name"])
+}
+
+func TestK8sResources_PodListInNamespace_OK(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "default"}}
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t, pod), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/k8s/resources?kind=Pod&namespace=default", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var got []map[string]string
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "p1", got[0]["name"])
+}
+
+func TestK8sResources_NamespaceList_FiltersSystemNS(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-public"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-node-lease"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "user-app"}},
+	), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/k8s/resources?kind=Namespace", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var got []map[string]string
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+	names := map[string]bool{}
+	for _, ns := range got {
+		names[ns["name"]] = true
+	}
+	assert.True(t, names["default"])
+	assert.True(t, names["user-app"])
+	assert.False(t, names["kube-system"], "kube-system must be filtered out")
+	assert.False(t, names["kube-public"], "kube-public must be filtered out")
+	assert.False(t, names["kube-node-lease"], "kube-node-lease must be filtered out")
+}
+
+// ── handleAPIFixesBatchReject ────────────────────────────────────────────────
+
+func TestBatchReject_BadJSON_400(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/fixes/batch-reject", bytes.NewReader([]byte("not json")))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestBatchReject_EmptyIDs_400(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	body, _ := json.Marshal(map[string]interface{}{"ids": []string{}})
+	req := httptest.NewRequest(http.MethodPost, "/api/fixes/batch-reject", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestBatchReject_MethodNotAllowed(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/fixes/batch-reject", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+// ── handleInternal (path validation) ─────────────────────────────────────────
+
+func TestInternal_BadPath_404(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodPost, "/internal/runs/abc/wrong-tail", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestInternal_MethodNotAllowed(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodGet, "/internal/runs/abc/findings", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+func TestInternal_BadJSON_400(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodPost, "/internal/runs/run-1/findings", bytes.NewReader([]byte("not json")))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// ── WithNotifier / WithNotificationManager / WithClientset (functional opts) ─
+
+func TestServerOptions_AcceptedAndApplied(t *testing.T) {
+	mgr := &recordingNotifMgr{}
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil,
+		httpserver.WithNotifier(mgr),
+		httpserver.WithNotificationManager(mgr),
+		httpserver.WithClientset(fakeClientset()),
+	)
+	require.NotNil(t, srv)
+
+	// Smoke: a known endpoint still responds (sanity that mux is wired).
+	req := httptest.NewRequest(http.MethodGet, "/api/notification-configs", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// ── handleAPIFixDetail (approve/reject paths) ────────────────────────────────
+
+func TestFixDetail_ApprovePatch_NotifiesAndUpdatesPhase(t *testing.T) {
+	mgr := &recordingNotifMgr{}
+	fs := &fakeStore{fixes: []*store.Fix{{ID: "f-approve", Phase: store.FixPhasePendingApproval}}}
+	srv := httpserver.New(fs, fakeK8sClient(t), nil, httpserver.WithNotifier(mgr))
+
+	body, _ := json.Marshal(map[string]string{"approvedBy": "alice"})
+	req := httptest.NewRequest(http.MethodPatch, "/api/fixes/f-approve/approve", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.GreaterOrEqual(t, mgr.notifyCalls.Load(), int32(1), "notifier must be called on approve")
+}
+
+func TestFixDetail_ApprovePatch_BadJSON_400(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodPatch, "/api/fixes/f1/approve", bytes.NewReader([]byte("not json")))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestFixDetail_RejectPatch_OK(t *testing.T) {
+	mgr := &recordingNotifMgr{}
+	fs := &fakeStore{fixes: []*store.Fix{{ID: "f-reject", Phase: store.FixPhasePendingApproval}}}
+	srv := httpserver.New(fs, fakeK8sClient(t), nil, httpserver.WithNotifier(mgr))
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/fixes/f-reject/reject", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.GreaterOrEqual(t, mgr.notifyCalls.Load(), int32(1), "notifier must be called on reject")
+}
+
+func TestFixDetail_PathTooShort_404(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/fixes/", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// ── handleAPIFindingAction ───────────────────────────────────────────────────
+
+func TestFindingAction_BadPath_404(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/findings/abc/wrong-action", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestFindingAction_MethodNotAllowed(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/findings/abc/generate-fix", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+func TestFindingAction_NoFixGenerator_500(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/findings/abc/generate-fix", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}

--- a/internal/controller/httpserver/server_run_test.go
+++ b/internal/controller/httpserver/server_run_test.go
@@ -1,0 +1,425 @@
+package httpserver_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1alpha1 "github.com/kube-agent-helper/kube-agent-helper/internal/controller/api/v1alpha1"
+	"github.com/kube-agent-helper/kube-agent-helper/internal/controller/httpserver"
+	"github.com/kube-agent-helper/kube-agent-helper/internal/store"
+)
+
+// ── handleAPIRunDetail ───────────────────────────────────────────────────────
+
+func TestRunDetail_GET_HappyPath(t *testing.T) {
+	fs := &fakeStore{
+		runs: []*store.DiagnosticRun{{ID: "r1", Status: store.PhaseSucceeded}},
+	}
+	srv := httpserver.New(fs, fakeK8sClient(t), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/runs/r1", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRunDetail_GET_FallbackToK8sCRWhenNotInStore(t *testing.T) {
+	uid := "uid-fallback-1"
+	cr := &v1alpha1.DiagnosticRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "scheduled-child", UID: types.UID(uid),
+			CreationTimestamp: metav1.NewTime(time.Now()),
+		},
+		Spec: v1alpha1.DiagnosticRunSpec{
+			Schedule: "*/5 * * * *",
+		},
+	}
+
+	fs := &fakeStore{} // not in SQLite
+	srv := httpserver.New(fs, fakeK8sClient(t, cr), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/runs/"+uid, nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "should fall back to runFromK8s")
+
+	var got map[string]interface{}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+	assert.Equal(t, uid, got["ID"])
+	assert.Equal(t, "Scheduled", got["Status"], "Schedule set + empty Status.Phase → 'Scheduled'")
+}
+
+func TestRunDetail_GET_NotFoundEverywhere_404(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/runs/missing", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestRunDetail_GET_FindingsTail_OK(t *testing.T) {
+	fs := &fakeStore{
+		runs: []*store.DiagnosticRun{{ID: "r1", Status: store.PhaseSucceeded}},
+		findings: []*store.Finding{
+			{ID: "f1", RunID: "r1", Title: "foo"},
+		},
+	}
+	srv := httpserver.New(fs, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/runs/r1/findings", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var got []map[string]interface{}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "f1", got[0]["ID"])
+}
+
+func TestRunDetail_MethodNotAllowed(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodDelete, "/api/runs/r1", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+func TestRunDetail_PathTooShort_404(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	// "/api/runs/" with no id strips empty segment → triggers 400 missing ID, not 404
+	req := httptest.NewRequest(http.MethodGet, "/api/runs/", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	// Either 400 or 404 is acceptable — assert both as legitimate "not OK"
+	assert.True(t, w.Code == http.StatusNotFound || w.Code == http.StatusBadRequest,
+		"got %d", w.Code)
+}
+
+// ── handleAPIRunCRD ──────────────────────────────────────────────────────────
+
+func TestRunCRD_LiveCRReturnedAsYAML(t *testing.T) {
+	uid := "crd-uid-1"
+	cr := &v1alpha1.DiagnosticRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "live-run", UID: types.UID(uid),
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(time.Now()),
+		},
+	}
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t, cr), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/runs/"+uid+"/crd", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "text/plain")
+	body := w.Body.String()
+	assert.Contains(t, body, "kind: DiagnosticRun")
+	assert.Contains(t, body, "live-run")
+}
+
+func TestRunCRD_FallbackSyntheticYAMLWhenCRGone(t *testing.T) {
+	fs := &fakeStore{
+		runs: []*store.DiagnosticRun{
+			{ID: "u-deleted", Status: store.PhaseSucceeded, TargetJSON: "{}", SkillsJSON: "[]"},
+		},
+	}
+	srv := httpserver.New(fs, fakeK8sClient(t), nil) // no CR loaded
+
+	req := httptest.NewRequest(http.MethodGet, "/api/runs/u-deleted/crd", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	// syntheticRunYAML produces text starting with "# Run reconstructed..." or similar.
+	assert.NotEmpty(t, body, "synthetic YAML should be returned")
+}
+
+func TestRunCRD_NoCRNoStore_404(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/runs/nope/crd", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// ── handleAPIRunsBatch ───────────────────────────────────────────────────────
+
+func TestRunsBatch_DELETE_OK(t *testing.T) {
+	fs := &fakeStore{
+		runs: []*store.DiagnosticRun{
+			{ID: "r1"}, {ID: "r2"},
+		},
+	}
+	srv := httpserver.New(fs, fakeK8sClient(t), nil)
+
+	body, _ := json.Marshal(map[string]interface{}{"ids": []string{"r1", "r2"}})
+	req := httptest.NewRequest(http.MethodDelete, "/api/runs/batch", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRunsBatch_DELETE_BadJSON_400(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodDelete, "/api/runs/batch", bytes.NewReader([]byte("not json")))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestRunsBatch_MethodNotAllowed(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/runs/batch", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+// ── handleAPIRunsPost — error / edge branches ────────────────────────────────
+
+func TestRunsPost_BadJSON_400(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/runs", bytes.NewReader([]byte("not json")))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// ── handleAPIFixDetail GET ───────────────────────────────────────────────────
+
+func TestFixDetail_GET_HappyPath(t *testing.T) {
+	fs := &fakeStore{fixes: []*store.Fix{{ID: "fx1", Phase: store.FixPhasePendingApproval}}}
+	srv := httpserver.New(fs, fakeK8sClient(t), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/fixes/fx1", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestFixDetail_GET_NotFound_404(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/fixes/missing", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestFixDetail_UnknownAction_404(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodPatch, "/api/fixes/fx1/destroy", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestFixDetail_ApprovePatch_MissingApprovedBy_400(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	body, _ := json.Marshal(map[string]string{}) // missing approvedBy
+	req := httptest.NewRequest(http.MethodPatch, "/api/fixes/fx1/approve", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// ── handleAPISkills (GET filter / DELETE) ────────────────────────────────────
+
+func TestSkills_GET_FilterByDimension(t *testing.T) {
+	fs := &fakeStore{
+		skills: []*store.Skill{
+			{Name: "a", Dimension: "health"},
+			{Name: "b", Dimension: "security"},
+		},
+	}
+	srv := httpserver.New(fs, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/skills", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestSkills_DELETE_Unsupported_405(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodPatch, "/api/skills", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+// ── handleAPIFixes (GET) ─────────────────────────────────────────────────────
+
+func TestFixes_GET_PaginatedFlag(t *testing.T) {
+	fs := &fakeStore{}
+	for i := 0; i < 3; i++ {
+		fs.fixes = append(fs.fixes, &store.Fix{ID: "fx", Phase: store.FixPhasePendingApproval})
+	}
+	srv := httpserver.New(fs, fakeK8sClient(t), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/fixes?page=1&pageSize=10", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestFixes_MethodNotAllowed(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodDelete, "/api/fixes", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+// ── handleAPIRuns ────────────────────────────────────────────────────────────
+
+func TestRuns_GET_LegacyMode(t *testing.T) {
+	fs := &fakeStore{
+		runs: []*store.DiagnosticRun{
+			{ID: "r1", Status: store.PhasePending, TargetJSON: "{}", SkillsJSON: "[]"},
+		},
+	}
+	srv := httpserver.New(fs, fakeK8sClient(t), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/runs?limit=10", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRuns_MethodNotAllowed(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodDelete, "/api/runs", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+// ── handleAPISkillsPost ──────────────────────────────────────────────────────
+
+func TestSkillsPost_BadJSON_400(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/skills", bytes.NewReader([]byte("not json")))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSkillsPost_MissingDimension_400(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	body, _ := json.Marshal(map[string]interface{}{
+		"name": "x", "prompt": "p", "tools": []string{"a"},
+		// dimension omitted
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/skills", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSkillsPost_MissingTools_400(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	body, _ := json.Marshal(map[string]interface{}{
+		"name": "x", "dimension": "health", "prompt": "p", "tools": []string{},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/skills", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSkillsPost_DefaultsAppliedOnSuccess(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	body, _ := json.Marshal(map[string]interface{}{
+		"name": "x", "dimension": "health", "prompt": "p", "tools": []string{"a"},
+		// namespace + priority omitted → defaults: "default", 100
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/skills", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var got v1alpha1.DiagnosticSkill
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+	assert.Equal(t, "default", got.Namespace, "namespace should default to 'default'")
+	require.NotNil(t, got.Spec.Priority)
+	assert.Equal(t, 100, *got.Spec.Priority, "priority should default to 100")
+}
+
+// ── handleAPIEvents ──────────────────────────────────────────────────────────
+
+func TestEvents_GET_LegacyMode(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/events?namespace=default&since=30&limit=10", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestEvents_GET_PaginatedMode(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/events?page=1&pageSize=10", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestEvents_GET_PaginatedPageSizeCapped(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/events?page=1&pageSize=999", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestEvents_BadSince_400(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/events?since=abc", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestEvents_BadLimit_400(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/events?limit=abc", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestEvents_MethodNotAllowed(t *testing.T) {
+	srv := httpserver.New(&fakeStore{}, fakeK8sClient(t), nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/events", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+// ── findFixCRByStoreID — happy path with matching CR ─────────────────────────
+
+func TestFixDetail_RejectPatch_FindsFixCRAndUpdatesStatus(t *testing.T) {
+	uid := "fx-cr-uid-1"
+	fixCR := &v1alpha1.DiagnosticFix{
+		ObjectMeta: metav1.ObjectMeta{Name: "fx-cr", UID: types.UID(uid), Namespace: "default"},
+		Spec:       v1alpha1.DiagnosticFixSpec{FindingID: "fnd-1"},
+	}
+	fs := &fakeStore{fixes: []*store.Fix{{ID: uid, Phase: store.FixPhasePendingApproval}}}
+	srv := httpserver.New(fs, fakeK8sClient(t, fixCR), nil)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/fixes/"+uid+"/reject", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}

--- a/internal/controller/httpserver/test_helpers_test.go
+++ b/internal/controller/httpserver/test_helpers_test.go
@@ -1,0 +1,14 @@
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// mustNewGet builds a *http.Request for unit-level helpers. Lives in `package
+// httpserver` so internal_helpers_test can use it.
+func mustNewGet(t *testing.T, target string) *http.Request {
+	t.Helper()
+	return httptest.NewRequest(http.MethodGet, target, nil)
+}

--- a/internal/controller/reconciler/fix_internal_test.go
+++ b/internal/controller/reconciler/fix_internal_test.go
@@ -1,0 +1,120 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	k8saiV1 "github.com/kube-agent-helper/kube-agent-helper/internal/controller/api/v1alpha1"
+	"github.com/kube-agent-helper/kube-agent-helper/internal/store"
+)
+
+func internalTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(s))
+	require.NoError(t, k8saiV1.AddToScheme(s))
+	require.NoError(t, appsv1.AddToScheme(s))
+	require.NoError(t, corev1.AddToScheme(s))
+	return s
+}
+
+// inMemFixStore is a tiny store stub satisfying the methods rollback() uses.
+// Same package access lets us avoid implementing the entire Store interface.
+type inMemFixStore struct {
+	store.Store
+	updates []phaseUpdate
+}
+
+type phaseUpdate struct {
+	id    string
+	phase store.FixPhase
+	msg   string
+}
+
+func (s *inMemFixStore) UpdateFixPhase(_ context.Context, id string, p store.FixPhase, msg string) error {
+	s.updates = append(s.updates, phaseUpdate{id, p, msg})
+	return nil
+}
+
+func (s *inMemFixStore) UpdateFixSnapshot(_ context.Context, _ string, _ string) error { return nil }
+
+// ── rollback ─────────────────────────────────────────────────────────────────
+
+func TestRollback_RestoresSnapshotAndUpdatesPhase(t *testing.T) {
+	// A pre-existing Deployment with a known snapshot stored on the fix.
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "nginx", Namespace: "default",
+		},
+	}
+	snapBytes, err := json.Marshal(map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]interface{}{"name": "nginx", "namespace": "default"},
+		"spec":       map[string]interface{}{"replicas": 1},
+	})
+	require.NoError(t, err)
+	encoded := base64.StdEncoding.EncodeToString(snapBytes)
+
+	fix := &k8saiV1.DiagnosticFix{
+		ObjectMeta: metav1.ObjectMeta{Name: "fix-rb", Namespace: "default", UID: "uid-rb"},
+		Spec: k8saiV1.DiagnosticFixSpec{
+			Target: k8saiV1.FixTarget{Kind: "Deployment", Namespace: "default", Name: "nginx"},
+		},
+		Status: k8saiV1.DiagnosticFixStatus{RollbackSnapshot: encoded},
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(internalTestScheme(t)).
+		WithObjects(dep, fix).
+		WithStatusSubresource(fix).
+		Build()
+	st := &inMemFixStore{}
+	r := &DiagnosticFixReconciler{Client: cli, Store: st}
+
+	err = r.rollback(context.Background(), fix)
+	require.NoError(t, err)
+
+	assert.Equal(t, "RolledBack", fix.Status.Phase)
+	assert.NotNil(t, fix.Status.CompletedAt)
+	require.Len(t, st.updates, 1)
+	assert.Equal(t, store.FixPhaseRolledBack, st.updates[0].phase)
+}
+
+func TestRollback_BadBase64ReturnsError(t *testing.T) {
+	fix := &k8saiV1.DiagnosticFix{
+		ObjectMeta: metav1.ObjectMeta{Name: "fix-rb-bad", Namespace: "default", UID: "u"},
+		Status:     k8saiV1.DiagnosticFixStatus{RollbackSnapshot: "!!!not-base64!!!"},
+	}
+	cli := fake.NewClientBuilder().WithScheme(internalTestScheme(t)).Build()
+	r := &DiagnosticFixReconciler{Client: cli, Store: &inMemFixStore{}}
+
+	err := r.rollback(context.Background(), fix)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode rollback snapshot")
+}
+
+func TestRollback_BadJSONReturnsError(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString([]byte("not json"))
+	fix := &k8saiV1.DiagnosticFix{
+		ObjectMeta: metav1.ObjectMeta{Name: "fix-rb-bad", Namespace: "default", UID: "u"},
+		Status:     k8saiV1.DiagnosticFixStatus{RollbackSnapshot: encoded},
+	}
+	cli := fake.NewClientBuilder().WithScheme(internalTestScheme(t)).Build()
+	r := &DiagnosticFixReconciler{Client: cli, Store: &inMemFixStore{}}
+
+	err := r.rollback(context.Background(), fix)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal rollback snapshot")
+}

--- a/internal/controller/reconciler/fix_reconciler_extra_test.go
+++ b/internal/controller/reconciler/fix_reconciler_extra_test.go
@@ -1,0 +1,271 @@
+package reconciler_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	k8saiV1 "github.com/kube-agent-helper/kube-agent-helper/internal/controller/api/v1alpha1"
+	"github.com/kube-agent-helper/kube-agent-helper/internal/controller/reconciler"
+	"github.com/kube-agent-helper/kube-agent-helper/internal/notification"
+)
+
+// ── applyPatch happy path via Reconcile ──────────────────────────────────────
+
+func TestFixReconciler_ApplyPatch_StrategicMerge_OK(t *testing.T) {
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx", Namespace: "default"},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "nginx"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "nginx"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "n", Image: "nginx:1.0"}},
+				},
+			},
+		},
+	}
+
+	fix := &k8saiV1.DiagnosticFix{
+		ObjectMeta: metav1.ObjectMeta{Name: "fix-patch", Namespace: "default", UID: types.UID("uid-patch")},
+		Spec: k8saiV1.DiagnosticFixSpec{
+			DiagnosticRunRef: "run-1",
+			FindingTitle:     "scale up",
+			Target:           k8saiV1.FixTarget{Kind: "Deployment", Namespace: "default", Name: "nginx"},
+			Strategy:         "patch",
+			ApprovalRequired: true,
+			Patch: k8saiV1.FixPatch{
+				Type:    "strategic-merge",
+				Content: `{"spec":{"replicas":3}}`,
+			},
+			Rollback: k8saiV1.RollbackConfig{SnapshotBefore: true},
+		},
+		Status: k8saiV1.DiagnosticFixStatus{Phase: "Approved"},
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(dep, fix).
+		WithStatusSubresource(fix).
+		Build()
+
+	r := &reconciler.DiagnosticFixReconciler{Client: cli, Store: newMemStore()}
+	fixReconcileOnce(t, r, "fix-patch", "default")
+
+	var updated k8saiV1.DiagnosticFix
+	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: "fix-patch", Namespace: "default"}, &updated))
+	assert.Equal(t, "Succeeded", updated.Status.Phase)
+	assert.NotEmpty(t, updated.Status.RollbackSnapshot, "snapshot should be captured")
+	assert.NotNil(t, updated.Status.AppliedAt)
+	assert.NotNil(t, updated.Status.CompletedAt)
+}
+
+func TestFixReconciler_ApplyPatch_UnsupportedKind_Fails(t *testing.T) {
+	fix := &k8saiV1.DiagnosticFix{
+		ObjectMeta: metav1.ObjectMeta{Name: "fix-bad-kind", Namespace: "default", UID: types.UID("u")},
+		Spec: k8saiV1.DiagnosticFixSpec{
+			Target:   k8saiV1.FixTarget{Kind: "WidgetCRD", Namespace: "default", Name: "x"},
+			Strategy: "patch",
+			Patch:    k8saiV1.FixPatch{Type: "strategic-merge", Content: `{}`},
+		},
+		Status: k8saiV1.DiagnosticFixStatus{Phase: "Approved"},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(fix).
+		WithStatusSubresource(fix).
+		Build()
+	r := &reconciler.DiagnosticFixReconciler{Client: cli, Store: newMemStore()}
+
+	fixReconcileOnce(t, r, "fix-bad-kind", "default")
+
+	var got k8saiV1.DiagnosticFix
+	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: "fix-bad-kind", Namespace: "default"}, &got))
+	assert.Equal(t, "Failed", got.Status.Phase)
+	assert.Contains(t, got.Status.Message, "unsupported target kind")
+}
+
+func TestFixReconciler_ApplyPatch_MissingTarget_Fails(t *testing.T) {
+	// No Deployment present in the fake client → snapshot Get fails.
+	fix := &k8saiV1.DiagnosticFix{
+		ObjectMeta: metav1.ObjectMeta{Name: "fix-snap", Namespace: "default", UID: types.UID("u")},
+		Spec: k8saiV1.DiagnosticFixSpec{
+			Target:   k8saiV1.FixTarget{Kind: "Deployment", Namespace: "default", Name: "missing"},
+			Strategy: "patch",
+			Patch:    k8saiV1.FixPatch{Type: "strategic-merge", Content: `{"spec":{"replicas":3}}`},
+			Rollback: k8saiV1.RollbackConfig{SnapshotBefore: true},
+		},
+		Status: k8saiV1.DiagnosticFixStatus{Phase: "Approved"},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(fix).
+		WithStatusSubresource(fix).
+		Build()
+	r := &reconciler.DiagnosticFixReconciler{Client: cli, Store: newMemStore()}
+
+	fixReconcileOnce(t, r, "fix-snap", "default")
+
+	var got k8saiV1.DiagnosticFix
+	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: "fix-snap", Namespace: "default"}, &got))
+	assert.Equal(t, "Failed", got.Status.Phase)
+}
+
+// ── Reconcile init branches ──────────────────────────────────────────────────
+
+func TestFixReconciler_NotFound_NoOp(t *testing.T) {
+	cli := fake.NewClientBuilder().WithScheme(testScheme()).Build()
+	r := &reconciler.DiagnosticFixReconciler{Client: cli, Store: newMemStore()}
+	fixReconcileOnce(t, r, "ghost", "default")
+}
+
+func TestFixReconciler_AutoApproveSetsApproved(t *testing.T) {
+	fix := &k8saiV1.DiagnosticFix{
+		ObjectMeta: metav1.ObjectMeta{Name: "auto", Namespace: "default", UID: types.UID("u")},
+		Spec: k8saiV1.DiagnosticFixSpec{
+			Target:           k8saiV1.FixTarget{Kind: "ConfigMap", Namespace: "default", Name: "x"},
+			Strategy:         "patch",
+			ApprovalRequired: false,
+			Patch:            k8saiV1.FixPatch{Type: "strategic-merge", Content: `{}`},
+		},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(fix).
+		WithStatusSubresource(fix).
+		Build()
+	r := &reconciler.DiagnosticFixReconciler{Client: cli, Store: newMemStore()}
+
+	fixReconcileOnce(t, r, "auto", "default")
+
+	var got k8saiV1.DiagnosticFix
+	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: "auto", Namespace: "default"}, &got))
+	assert.Equal(t, "Approved", got.Status.Phase)
+	assert.Contains(t, got.Status.Message, "Auto-approved")
+}
+
+func TestFixReconciler_PendingApprovalIsTerminal(t *testing.T) {
+	fix := &k8saiV1.DiagnosticFix{
+		ObjectMeta: metav1.ObjectMeta{Name: "pa", Namespace: "default", UID: types.UID("u")},
+		Spec: k8saiV1.DiagnosticFixSpec{
+			Target:   k8saiV1.FixTarget{Kind: "ConfigMap", Namespace: "default", Name: "x"},
+			Strategy: "patch",
+			Patch:    k8saiV1.FixPatch{Type: "strategic-merge", Content: `{}`},
+		},
+		Status: k8saiV1.DiagnosticFixStatus{Phase: "PendingApproval"},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(fix).
+		WithStatusSubresource(fix).
+		Build()
+	r := &reconciler.DiagnosticFixReconciler{Client: cli, Store: newMemStore()}
+
+	res := fixReconcileOnce(t, r, "pa", "default")
+	assert.False(t, res.Requeue, "PendingApproval should be a no-op")
+}
+
+// failFix Notifier path
+type fixNotifier struct {
+	calls []notificationEvent
+}
+
+type notificationEvent struct{ Title string }
+
+func (n *fixNotifier) Notify(_ context.Context, e notificationEventForNotifier) error {
+	n.calls = append(n.calls, notificationEvent{Title: e.Title})
+	return nil
+}
+
+// notificationEventForNotifier is a thin alias used only to keep the
+// import surface minimal in this test file.
+type notificationEventForNotifier = notification.Event
+
+func TestFixReconciler_FailFix_NotifierEmitsFailedEvent(t *testing.T) {
+	fix := &k8saiV1.DiagnosticFix{
+		ObjectMeta: metav1.ObjectMeta{Name: "fail-notify", Namespace: "default", UID: types.UID("u")},
+		Spec: k8saiV1.DiagnosticFixSpec{
+			Target:   k8saiV1.FixTarget{Kind: "WidgetCRD", Namespace: "default", Name: "x"},
+			Strategy: "patch",
+			Patch:    k8saiV1.FixPatch{Type: "strategic-merge", Content: `{}`},
+		},
+		Status: k8saiV1.DiagnosticFixStatus{Phase: "Approved"},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(fix).
+		WithStatusSubresource(fix).
+		Build()
+
+	notifier := &fixNotifier{}
+	r := &reconciler.DiagnosticFixReconciler{
+		Client:   cli,
+		Store:    newMemStore(),
+		Notifier: notifier,
+	}
+	fixReconcileOnce(t, r, "fail-notify", "default")
+
+	require.NotEmpty(t, notifier.calls, "notifier must be called when failFix runs")
+	assert.Contains(t, notifier.calls[0].Title, "Fix Failed")
+}
+
+func TestFixReconciler_CreateStrategy_AlreadyExists_Fails(t *testing.T) {
+	npJSON := `{"apiVersion":"networking.k8s.io/v1","kind":"NetworkPolicy","metadata":{"name":"dup","namespace":"default"},"spec":{"podSelector":{}}}`
+
+	fix := &k8saiV1.DiagnosticFix{
+		ObjectMeta: metav1.ObjectMeta{Name: "fix-dup", Namespace: "default", UID: types.UID("u")},
+		Spec: k8saiV1.DiagnosticFixSpec{
+			Target:   k8saiV1.FixTarget{Kind: "NetworkPolicy", Namespace: "default", Name: "dup"},
+			Strategy: "create",
+			Patch:    k8saiV1.FixPatch{Type: "strategic-merge", Content: npJSON},
+		},
+		Status: k8saiV1.DiagnosticFixStatus{Phase: "Approved"},
+	}
+
+	conflictNP := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "dup", Namespace: "default"},
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(fix, conflictNP).
+		WithStatusSubresource(fix).
+		Build()
+	r := &reconciler.DiagnosticFixReconciler{Client: cli, Store: newMemStore()}
+
+	fixReconcileOnce(t, r, "fix-dup", "default")
+
+	var got k8saiV1.DiagnosticFix
+	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: "fix-dup", Namespace: "default"}, &got))
+	assert.Equal(t, "Failed", got.Status.Phase)
+	assert.Contains(t, got.Status.Message, "create resource failed")
+}
+
+func TestFixReconciler_ApplyingRequeues(t *testing.T) {
+	fix := &k8saiV1.DiagnosticFix{
+		ObjectMeta: metav1.ObjectMeta{Name: "applying", Namespace: "default", UID: types.UID("u")},
+		Spec: k8saiV1.DiagnosticFixSpec{
+			Target:   k8saiV1.FixTarget{Kind: "ConfigMap", Namespace: "default", Name: "x"},
+			Strategy: "patch",
+			Patch:    k8saiV1.FixPatch{Type: "strategic-merge", Content: `{}`},
+		},
+		Status: k8saiV1.DiagnosticFixStatus{Phase: "Applying"},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(fix).
+		WithStatusSubresource(fix).
+		Build()
+	r := &reconciler.DiagnosticFixReconciler{Client: cli, Store: newMemStore()}
+
+	res := fixReconcileOnce(t, r, "applying", "default")
+	assert.Greater(t, res.RequeueAfter.Seconds(), 0.0, "Applying should requeue")
+}

--- a/internal/controller/reconciler/run_reconciler_extra_test.go
+++ b/internal/controller/reconciler/run_reconciler_extra_test.go
@@ -1,0 +1,186 @@
+package reconciler_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	clientsetfake "k8s.io/client-go/kubernetes/fake"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	k8saiV1 "github.com/kube-agent-helper/kube-agent-helper/internal/controller/api/v1alpha1"
+	"github.com/kube-agent-helper/kube-agent-helper/internal/controller/reconciler"
+	"github.com/kube-agent-helper/kube-agent-helper/internal/notification"
+	"github.com/kube-agent-helper/kube-agent-helper/internal/store"
+)
+
+func fakeKubeClientset() kubernetes.Interface { return clientsetfake.NewSimpleClientset() }
+
+// recordingNotifier records all events for assertion. Implements
+// reconciler.NotifyDispatcher.
+type recordingNotifier struct {
+	mu     sync.Mutex
+	calls  atomic.Int32
+	events []notification.Event
+}
+
+func (n *recordingNotifier) Notify(_ context.Context, e notification.Event) error {
+	n.calls.Add(1)
+	n.mu.Lock()
+	n.events = append(n.events, e)
+	n.mu.Unlock()
+	return nil
+}
+
+func (n *recordingNotifier) eventTypes() []notification.EventType {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	out := make([]notification.EventType, len(n.events))
+	for i, ev := range n.events {
+		out[i] = ev.Type
+	}
+	return out
+}
+
+// ── completeRun via Reconcile: success notification + critical findings ──────
+
+func TestRunReconciler_SuccessNotificationAndCriticalFindingsEmitted(t *testing.T) {
+	run := testRun()
+	run.Status.Phase = "Running"
+	run.Status.ReportID = "uid-1"
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent-test-run", Namespace: "default"},
+		Status:     batchv1.JobStatus{Succeeded: 1, CompletionTime: &metav1.Time{}},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(run, job).
+		WithStatusSubresource(run).
+		Build()
+
+	ms := newMemStore()
+	// Pre-seed the store with one critical and one info finding.
+	require.NoError(t, ms.CreateFinding(context.Background(), &store.Finding{
+		ID: "f1", RunID: "uid-1", Dimension: "health", Severity: "critical",
+		Title: "Pod OOMKilled", Description: "container memory exceeded",
+		ResourceKind: "Pod", ResourceNamespace: "default", ResourceName: "api",
+	}))
+	require.NoError(t, ms.CreateFinding(context.Background(), &store.Finding{
+		ID: "f2", RunID: "uid-1", Dimension: "health", Severity: "info",
+		Title: "everything fine",
+	}))
+
+	notifier := &recordingNotifier{}
+	r := &reconciler.DiagnosticRunReconciler{
+		Client: cli, Store: ms, Translator: testTranslator(), Notifier: notifier,
+	}
+	reconcileOnce(t, r)
+
+	var got k8saiV1.DiagnosticRun
+	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: "test-run", Namespace: "default"}, &got))
+	assert.Equal(t, "Succeeded", got.Status.Phase)
+
+	// Expect: one EventRunCompleted + one EventCriticalFinding
+	types := notifier.eventTypes()
+	require.GreaterOrEqual(t, len(types), 2, "expected at least RunCompleted + CriticalFinding events")
+	assert.Contains(t, types, notification.EventRunCompleted)
+	assert.Contains(t, types, notification.EventCriticalFinding)
+}
+
+// ── ModelConfigReconciler: empty APIKeyRef.Key + missing Secret ──────────────
+
+func TestModelConfigReconciler_EmptyKeyAndMissingSecret_StillSucceeds(t *testing.T) {
+	mc := &k8saiV1.ModelConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "mc-empty-key", Namespace: "default"},
+		Spec: k8saiV1.ModelConfigSpec{
+			Provider:  "anthropic",
+			Model:     "claude-sonnet-4-6",
+			APIKeyRef: k8saiV1.SecretKeyRef{Name: "no-such-secret"},
+			// Key intentionally empty
+		},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(mc).
+		Build()
+	r := &reconciler.ModelConfigReconciler{Client: cli}
+
+	_, err := r.Reconcile(context.Background(), ctrlReq("mc-empty-key", "default"))
+	require.NoError(t, err, "missing-secret + empty Key must not be a hard error")
+}
+
+// ctrlReq is a tiny helper that defers `ctrl.Request` import noise.
+func ctrlReq(name, namespace string) ctrl.Request {
+	return ctrl.Request{NamespacedName: types.NamespacedName{Name: name, Namespace: namespace}}
+}
+
+// ── collectPodLogs: clientset set, no pods → list path exercised ─────────────
+
+func TestRunReconciler_CompleteWithClientset_NoPodsToCollect(t *testing.T) {
+	run := testRun()
+	run.Status.Phase = "Running"
+	run.Status.ReportID = "uid-1"
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent-test-run", Namespace: "default"},
+		Status:     batchv1.JobStatus{Succeeded: 1, CompletionTime: &metav1.Time{}},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(run, job).
+		WithStatusSubresource(run).
+		Build()
+
+	r := &reconciler.DiagnosticRunReconciler{
+		Client:     cli,
+		Store:      newMemStore(),
+		Translator: testTranslator(),
+		Clientset:  fakeKubeClientset(),
+	}
+	reconcileOnce(t, r)
+
+	var got k8saiV1.DiagnosticRun
+	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: "test-run", Namespace: "default"}, &got))
+	assert.Equal(t, "Succeeded", got.Status.Phase)
+	// We don't assert on collectPodLogs side-effects: with a Clientset set
+	// but zero pods labelled job-name=..., the function exits cleanly.
+}
+
+func TestRunReconciler_FailedRun_EmitsRunFailedNotification(t *testing.T) {
+	run := testRun()
+	run.Status.Phase = "Running"
+	run.Status.ReportID = "uid-1"
+
+	// Job in Failed condition.
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent-test-run", Namespace: "default"},
+		Status: batchv1.JobStatus{
+			Failed: 1,
+			Conditions: []batchv1.JobCondition{
+				{Type: batchv1.JobFailed, Status: "True", Reason: "BackoffLimitExceeded"},
+			},
+		},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(run, job).
+		WithStatusSubresource(run).
+		Build()
+
+	notifier := &recordingNotifier{}
+	r := &reconciler.DiagnosticRunReconciler{
+		Client: cli, Store: newMemStore(), Translator: testTranslator(), Notifier: notifier,
+	}
+	reconcileOnce(t, r)
+
+	assert.Contains(t, notifier.eventTypes(), notification.EventRunFailed)
+}

--- a/internal/controller/reconciler/scheduled_run_reconciler_extra_test.go
+++ b/internal/controller/reconciler/scheduled_run_reconciler_extra_test.go
@@ -1,0 +1,409 @@
+package reconciler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	k8saiV1 "github.com/kube-agent-helper/kube-agent-helper/internal/controller/api/v1alpha1"
+)
+
+// scheduledTestScheme is local because the public testScheme() lives in the
+// external test package; this file is in `package reconciler` so it can
+// access the unexported helpers (buildChildRun, enforceHistoryLimit,
+// appendUnique, removeFromSlice).
+func scheduledTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(s))
+	require.NoError(t, k8saiV1.AddToScheme(s))
+	return s
+}
+
+// ── Reconcile branches ───────────────────────────────────────────────────────
+
+func TestScheduledRun_Reconcile_NotFound_NoOp(t *testing.T) {
+	r := &ScheduledRunReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheduledTestScheme(t)).Build(),
+	}
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "missing", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, res)
+}
+
+func TestScheduledRun_Reconcile_NoSchedule_NoOp(t *testing.T) {
+	run := &k8saiV1.DiagnosticRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: "default"},
+		Spec:       k8saiV1.DiagnosticRunSpec{},
+	}
+	r := &ScheduledRunReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheduledTestScheme(t)).
+			WithObjects(run).
+			Build(),
+	}
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "r1", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, res, "no Schedule should be a no-op")
+}
+
+func TestScheduledRun_Reconcile_InvalidCronIsHandled(t *testing.T) {
+	run := &k8saiV1.DiagnosticRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: "default"},
+		Spec:       k8saiV1.DiagnosticRunSpec{Schedule: "this is not cron"},
+	}
+	r := &ScheduledRunReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheduledTestScheme(t)).
+			WithObjects(run).
+			Build(),
+	}
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "r1", Namespace: "default"},
+	})
+	require.NoError(t, err, "invalid cron must not bubble up as an error")
+	assert.Equal(t, ctrl.Result{}, res)
+}
+
+func TestScheduledRun_Reconcile_InitializesNextRunAt(t *testing.T) {
+	run := &k8saiV1.DiagnosticRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: "default"},
+		Spec:       k8saiV1.DiagnosticRunSpec{Schedule: "*/5 * * * *"},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheduledTestScheme(t)).
+		WithObjects(run).
+		WithStatusSubresource(run).
+		Build()
+	r := &ScheduledRunReconciler{Client: cli}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "r1", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	assert.True(t, res.RequeueAfter > 0, "first reconcile should request requeue at NextRunAt")
+
+	var got k8saiV1.DiagnosticRun
+	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: "r1", Namespace: "default"}, &got))
+	require.NotNil(t, got.Status.NextRunAt, "NextRunAt must be populated on first reconcile")
+}
+
+func TestScheduledRun_Reconcile_NotYetTime_RequeuesWithoutCreatingChild(t *testing.T) {
+	future := metav1.NewTime(time.Now().Add(1 * time.Hour))
+	run := &k8saiV1.DiagnosticRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: "default"},
+		Spec:       k8saiV1.DiagnosticRunSpec{Schedule: "*/5 * * * *"},
+		Status:     k8saiV1.DiagnosticRunStatus{NextRunAt: &future},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheduledTestScheme(t)).
+		WithObjects(run).
+		WithStatusSubresource(run).
+		Build()
+	r := &ScheduledRunReconciler{Client: cli}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "r1", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	assert.Greater(t, res.RequeueAfter, time.Duration(0))
+
+	var children k8saiV1.DiagnosticRunList
+	require.NoError(t, cli.List(context.Background(), &children))
+	assert.Len(t, children.Items, 1, "no child should be created when not yet time")
+}
+
+func TestScheduledRun_Reconcile_TriggerCreatesChildAndAdvances(t *testing.T) {
+	past := metav1.NewTime(time.Now().Add(-1 * time.Minute))
+	run := &k8saiV1.DiagnosticRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "tmpl", Namespace: "default", UID: types.UID("tmpl-uid"),
+		},
+		Spec: k8saiV1.DiagnosticRunSpec{
+			Schedule: "*/1 * * * *",
+			Skills:   []string{"pod-health"},
+		},
+		Status: k8saiV1.DiagnosticRunStatus{NextRunAt: &past},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheduledTestScheme(t)).
+		WithObjects(run).
+		WithStatusSubresource(run).
+		Build()
+	r := &ScheduledRunReconciler{Client: cli}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "tmpl", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	// RequeueAfter may be zero or even negative when the next scheduled minute
+	// has already passed by the time the reactor finishes; we only care that
+	// a child was created and ActiveRuns was updated below.
+
+	var children k8saiV1.DiagnosticRunList
+	require.NoError(t, cli.List(context.Background(), &children))
+	require.Len(t, children.Items, 2, "expect template plus one new child")
+
+	// Find the child (not the template).
+	var child *k8saiV1.DiagnosticRun
+	for i := range children.Items {
+		if children.Items[i].Name != "tmpl" {
+			child = &children.Items[i]
+			break
+		}
+	}
+	require.NotNil(t, child)
+	assert.Equal(t, "tmpl", child.Labels[scheduledByLabel])
+	require.Len(t, child.OwnerReferences, 1)
+	assert.Equal(t, types.UID("tmpl-uid"), child.OwnerReferences[0].UID)
+	assert.Equal(t, []string{"pod-health"}, child.Spec.Skills)
+
+	// Parent ActiveRuns should now contain the child name.
+	var got k8saiV1.DiagnosticRun
+	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: "tmpl", Namespace: "default"}, &got))
+	assert.Contains(t, got.Status.ActiveRuns, child.Name)
+}
+
+// ── buildChildRun ─────────────────────────────────────────────────────────────
+
+func TestBuildChildRun_CopiesSpecAndSetsLabelsAndOwner(t *testing.T) {
+	r := &ScheduledRunReconciler{}
+	timeout := int32(600)
+	parent := &k8saiV1.DiagnosticRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "p", Namespace: "ns", UID: types.UID("p-uid"),
+		},
+		Spec: k8saiV1.DiagnosticRunSpec{
+			Target:         k8saiV1.TargetSpec{Scope: "namespace", Namespaces: []string{"ns"}},
+			Skills:         []string{"a", "b"},
+			ModelConfigRef: "anthropic-creds",
+			TimeoutSeconds: &timeout,
+			OutputLanguage: "zh",
+		},
+	}
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	child := r.buildChildRun(parent, "p-1234", now)
+
+	assert.Equal(t, "p-1234", child.Name)
+	assert.Equal(t, "ns", child.Namespace)
+	assert.Equal(t, "p", child.Labels[scheduledByLabel])
+	require.Len(t, child.OwnerReferences, 1)
+	assert.Equal(t, types.UID("p-uid"), child.OwnerReferences[0].UID)
+	assert.Equal(t, "DiagnosticRun", child.OwnerReferences[0].Kind)
+	require.NotNil(t, child.OwnerReferences[0].Controller)
+	assert.True(t, *child.OwnerReferences[0].Controller)
+
+	assert.Equal(t, parent.Spec.Target, child.Spec.Target)
+	assert.Equal(t, parent.Spec.Skills, child.Spec.Skills)
+	assert.Equal(t, "anthropic-creds", child.Spec.ModelConfigRef)
+	require.NotNil(t, child.Spec.TimeoutSeconds)
+	assert.Equal(t, int32(600), *child.Spec.TimeoutSeconds)
+	assert.Equal(t, "zh", child.Spec.OutputLanguage)
+
+	assert.Empty(t, child.Spec.Schedule, "child must NOT inherit the schedule")
+
+	assert.Equal(t, now.Format(time.RFC3339),
+		child.Annotations["kube-agent-helper.io/triggered-at"])
+}
+
+// ── enforceHistoryLimit ───────────────────────────────────────────────────────
+
+func TestEnforceHistoryLimit_DeletesOldestOverLimit(t *testing.T) {
+	parent := &k8saiV1.DiagnosticRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
+	}
+	limit := int32(2)
+	parent.Spec.HistoryLimit = &limit
+	parent.Status.ActiveRuns = []string{"c1", "c2", "c3"}
+
+	c1 := &k8saiV1.DiagnosticRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "c1", Namespace: "default",
+			Labels:            map[string]string{scheduledByLabel: "p"},
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-3 * time.Hour)),
+		},
+	}
+	c2 := &k8saiV1.DiagnosticRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "c2", Namespace: "default",
+			Labels:            map[string]string{scheduledByLabel: "p"},
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-2 * time.Hour)),
+		},
+	}
+	c3 := &k8saiV1.DiagnosticRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "c3", Namespace: "default",
+			Labels:            map[string]string{scheduledByLabel: "p"},
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
+		},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheduledTestScheme(t)).
+		WithObjects(parent, c1, c2, c3).
+		Build()
+	r := &ScheduledRunReconciler{Client: cli}
+
+	err := r.enforceHistoryLimit(context.Background(), parent)
+	require.NoError(t, err)
+
+	// c1 is oldest and should be deleted; c2 and c3 remain.
+	var list k8saiV1.DiagnosticRunList
+	require.NoError(t, cli.List(context.Background(), &list))
+	names := map[string]bool{}
+	for _, r := range list.Items {
+		names[r.Name] = true
+	}
+	assert.False(t, names["c1"], "oldest child should have been deleted")
+	assert.True(t, names["c2"])
+	assert.True(t, names["c3"])
+	assert.NotContains(t, parent.Status.ActiveRuns, "c1")
+}
+
+func TestEnforceHistoryLimit_UnderLimit_NoOp(t *testing.T) {
+	parent := &k8saiV1.DiagnosticRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
+	}
+	limit := int32(5)
+	parent.Spec.HistoryLimit = &limit
+	parent.Status.ActiveRuns = []string{"c1", "c2"}
+
+	cli := fake.NewClientBuilder().WithScheme(scheduledTestScheme(t)).WithObjects(parent).Build()
+	r := &ScheduledRunReconciler{Client: cli}
+	require.NoError(t, r.enforceHistoryLimit(context.Background(), parent))
+	assert.Equal(t, []string{"c1", "c2"}, parent.Status.ActiveRuns, "under-limit must be no-op")
+}
+
+func TestEnforceHistoryLimit_DefaultLimit(t *testing.T) {
+	parent := &k8saiV1.DiagnosticRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
+	}
+	// HistoryLimit nil → defaults to defaultHistoryLimit (10)
+	parent.Status.ActiveRuns = []string{"c1"}
+
+	cli := fake.NewClientBuilder().WithScheme(scheduledTestScheme(t)).WithObjects(parent).Build()
+	r := &ScheduledRunReconciler{Client: cli}
+	require.NoError(t, r.enforceHistoryLimit(context.Background(), parent))
+	assert.Equal(t, []string{"c1"}, parent.Status.ActiveRuns)
+}
+
+// ── appendUnique / removeFromSlice ────────────────────────────────────────────
+
+func TestAppendUnique(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		add  string
+		want []string
+	}{
+		{"empty", nil, "a", []string{"a"}},
+		{"new-element", []string{"a", "b"}, "c", []string{"a", "b", "c"}},
+		{"duplicate", []string{"a", "b"}, "a", []string{"a", "b"}},
+		{"duplicate-middle", []string{"a", "b", "c"}, "b", []string{"a", "b", "c"}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := appendUnique(tc.in, tc.add)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestRemoveFromSlice(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		rm   string
+		want []string
+	}{
+		{"empty", []string{}, "a", []string{}},
+		{"present", []string{"a", "b", "c"}, "b", []string{"a", "c"}},
+		{"absent", []string{"a", "b"}, "z", []string{"a", "b"}},
+		{"all-duplicates", []string{"a", "a", "a"}, "a", []string{}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := removeFromSlice(tc.in, tc.rm)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// ── kindToGVK ────────────────────────────────────────────────────────────────
+
+func TestKindToGVK(t *testing.T) {
+	cases := []struct {
+		kind  string
+		group string
+		v     string
+	}{
+		{"Deployment", "apps", "v1"},
+		{"StatefulSet", "apps", "v1"},
+		{"DaemonSet", "apps", "v1"},
+		{"Pod", "", "v1"},
+		{"Service", "", "v1"},
+		{"ConfigMap", "", "v1"},
+		{"Secret", "", "v1"},
+		{"ServiceAccount", "", "v1"},
+		{"Namespace", "", "v1"},
+		{"PersistentVolumeClaim", "", "v1"},
+		{"ResourceQuota", "", "v1"},
+		{"LimitRange", "", "v1"},
+		{"Job", "batch", "v1"},
+		{"CronJob", "batch", "v1"},
+		{"Ingress", "networking.k8s.io", "v1"},
+		{"NetworkPolicy", "networking.k8s.io", "v1"},
+		{"PodDisruptionBudget", "policy", "v1"},
+		{"HorizontalPodAutoscaler", "autoscaling", "v2"},
+		{"ClusterRole", "rbac.authorization.k8s.io", "v1"},
+		{"ClusterRoleBinding", "rbac.authorization.k8s.io", "v1"},
+		{"Role", "rbac.authorization.k8s.io", "v1"},
+		{"RoleBinding", "rbac.authorization.k8s.io", "v1"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.kind, func(t *testing.T) {
+			gvk := kindToGVK(tc.kind)
+			assert.Equal(t, tc.group, gvk.Group)
+			assert.Equal(t, tc.v, gvk.Version)
+			assert.Equal(t, tc.kind, gvk.Kind)
+		})
+	}
+}
+
+func TestKindToGVK_UnknownReturnsEmpty(t *testing.T) {
+	gvk := kindToGVK("WidgetCRD")
+	assert.Empty(t, gvk.Kind)
+	assert.Empty(t, gvk.Group)
+}
+
+// ── childRunName ─────────────────────────────────────────────────────────────
+
+func TestChildRunName_TruncatesLongNames(t *testing.T) {
+	long := ""
+	for i := 0; i < 300; i++ {
+		long += "x"
+	}
+	got := childRunName(long, time.Unix(1234567890, 0))
+	assert.LessOrEqual(t, len(got), 253, "name must be truncated to 253 bytes max")
+	assert.NotEmpty(t, got)
+}
+
+func TestChildRunName_ShortNamesUnaffected(t *testing.T) {
+	got := childRunName("parent", time.Unix(1234567890, 0))
+	assert.Equal(t, "parent-1234567890", got)
+}

--- a/internal/k8sclient/clients_test.go
+++ b/internal/k8sclient/clients_test.go
@@ -1,0 +1,65 @@
+package k8sclient
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+// resolveTestKubeconfig returns a *Resolved built from minimalKubeconfig.
+func resolveTestKubeconfig(t *testing.T) *Resolved {
+	t.Helper()
+	dir := t.TempDir()
+	kc := filepath.Join(dir, "kubeconfig")
+	require.NoError(t, os.WriteFile(kc, []byte(minimalKubeconfig), 0o600))
+	r, err := Resolve(Flags{Kubeconfig: kc})
+	require.NoError(t, err)
+	return r
+}
+
+func TestBuild_HappyPathNoPrometheus(t *testing.T) {
+	r := resolveTestKubeconfig(t)
+
+	c, err := Build(r, "")
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	assert.NotNil(t, c.Typed, "typed client should be constructed")
+	assert.NotNil(t, c.Dynamic, "dynamic client should be constructed")
+	assert.NotNil(t, c.Mapper, "mapper should be constructed")
+	assert.Same(t, r, c.Resolved, "Resolved should be carried through")
+	// Metrics may be non-nil even without metrics-server because NewForConfig
+	// only fails on a malformed config; we just assert no panic.
+	assert.Nil(t, c.Prometheus, "prometheus must be nil when promURL=\"\"")
+}
+
+func TestBuild_HappyPathWithPrometheus(t *testing.T) {
+	r := resolveTestKubeconfig(t)
+
+	c, err := Build(r, "http://prom.example:9090")
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	assert.NotNil(t, c.Prometheus, "prometheus client should be constructed when promURL set")
+}
+
+func TestBuild_BadPrometheusURL(t *testing.T) {
+	r := resolveTestKubeconfig(t)
+
+	// Control characters in URLs make promapi.NewClient fail.
+	_, err := Build(r, "http://prom.example\x7f:9090")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "prometheus client")
+}
+
+func TestBuild_BadRestConfigHostFailsTypedClient(t *testing.T) {
+	// A rest.Config with a malformed host triggers the typed-client error path.
+	r := &Resolved{RESTConfig: &rest.Config{Host: "://broken"}}
+
+	_, err := Build(r, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "typed client")
+}

--- a/internal/k8sclient/mapper_test.go
+++ b/internal/k8sclient/mapper_test.go
@@ -1,0 +1,120 @@
+package k8sclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+)
+
+// fakeDiscoveryWithResources builds a discovery client populated with the
+// resource lists needed for ResolveGVR tests.
+func fakeDiscoveryWithResources(t *testing.T) *fakediscovery.FakeDiscovery {
+	t.Helper()
+	cs := fake.NewSimpleClientset()
+	disc, ok := cs.Discovery().(*fakediscovery.FakeDiscovery)
+	require.True(t, ok, "expected *fakediscovery.FakeDiscovery")
+
+	disc.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "pods", SingularName: "pod", Namespaced: true, Kind: "Pod"},
+				{Name: "namespaces", SingularName: "namespace", Namespaced: false, Kind: "Namespace"},
+			},
+		},
+		{
+			GroupVersion: "apps/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "deployments", SingularName: "deployment", Namespaced: true, Kind: "Deployment"},
+				{Name: "statefulsets", SingularName: "statefulset", Namespaced: true, Kind: "StatefulSet"},
+			},
+		},
+	}
+	return disc
+}
+
+// newMapperWithDiscovery mirrors NewMapper's internals but skips the
+// rest.Config requirement so tests can inject a fake discovery client.
+// Same-package access keeps this purely a test concern.
+func newMapperWithDiscovery(d discovery.DiscoveryInterface) *Mapper {
+	return &Mapper{
+		discovery: d,
+		mapper:    restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(d)),
+	}
+}
+
+func TestNewMapper_ConstructsFromConfig(t *testing.T) {
+	r := resolveTestKubeconfig(t)
+	m, err := NewMapper(r.RESTConfig)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	assert.NotNil(t, m.Discovery())
+}
+
+func TestNewMapper_BadHostReturnsError(t *testing.T) {
+	_, err := NewMapper(&rest.Config{Host: "://broken"})
+	require.Error(t, err)
+}
+
+func TestResolveGVR_NamespacedKindNoApiVersion(t *testing.T) {
+	m := newMapperWithDiscovery(fakeDiscoveryWithResources(t))
+
+	gvr, namespaced, err := m.ResolveGVR("Pod", "")
+	require.NoError(t, err)
+	assert.Equal(t, "pods", gvr.Resource)
+	assert.Equal(t, "v1", gvr.Version)
+	assert.True(t, namespaced)
+}
+
+func TestResolveGVR_ClusterScopedKind(t *testing.T) {
+	m := newMapperWithDiscovery(fakeDiscoveryWithResources(t))
+
+	gvr, namespaced, err := m.ResolveGVR("Namespace", "")
+	require.NoError(t, err)
+	assert.Equal(t, "namespaces", gvr.Resource)
+	assert.False(t, namespaced)
+}
+
+func TestResolveGVR_WithExplicitApiVersion(t *testing.T) {
+	m := newMapperWithDiscovery(fakeDiscoveryWithResources(t))
+
+	gvr, namespaced, err := m.ResolveGVR("Deployment", "apps/v1")
+	require.NoError(t, err)
+	assert.Equal(t, "apps", gvr.Group)
+	assert.Equal(t, "v1", gvr.Version)
+	assert.Equal(t, "deployments", gvr.Resource)
+	assert.True(t, namespaced)
+}
+
+func TestResolveGVR_UnknownKind(t *testing.T) {
+	m := newMapperWithDiscovery(fakeDiscoveryWithResources(t))
+
+	_, _, err := m.ResolveGVR("WidgetCRD", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no mapping for WidgetCRD")
+}
+
+func TestResolveGVR_MalformedApiVersion(t *testing.T) {
+	m := newMapperWithDiscovery(fakeDiscoveryWithResources(t))
+
+	// "a/b/c" trips schema.ParseGroupVersion.
+	_, _, err := m.ResolveGVR("Pod", "a/b/c")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse apiVersion")
+}
+
+func TestMapper_DiscoveryReturnsUnderlyingClient(t *testing.T) {
+	disc := fakeDiscoveryWithResources(t)
+	m := newMapperWithDiscovery(disc)
+
+	got := m.Discovery()
+	assert.Same(t, disc, got, "Discovery() must return the underlying client")
+}

--- a/internal/store/sqlite/sqlite_extra_test.go
+++ b/internal/store/sqlite/sqlite_extra_test.go
@@ -1,0 +1,476 @@
+package sqlite_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kube-agent-helper/kube-agent-helper/internal/store"
+)
+
+// ── Skills ───────────────────────────────────────────────────────────────────
+
+func TestListSkills_OrderedByPriority(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// Insert in mixed priority order; ListSkills should return ASC by priority.
+	for _, sk := range []*store.Skill{
+		{Name: "third", Dimension: "perf", Priority: 30, UpdatedAt: time.Now()},
+		{Name: "first", Dimension: "health", Priority: 10, UpdatedAt: time.Now()},
+		{Name: "second", Dimension: "security", Priority: 20, UpdatedAt: time.Now()},
+	} {
+		require.NoError(t, s.UpsertSkill(ctx, sk))
+	}
+
+	got, err := s.ListSkills(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	assert.Equal(t, "first", got[0].Name)
+	assert.Equal(t, "second", got[1].Name)
+	assert.Equal(t, "third", got[2].Name)
+}
+
+func TestListSkills_Empty(t *testing.T) {
+	s := newTestStore(t)
+	got, err := s.ListSkills(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, got, 0)
+}
+
+// ── Run logs ─────────────────────────────────────────────────────────────────
+
+func TestRunLog_AppendAndListInOrder(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	run := &store.DiagnosticRun{TargetJSON: "{}", SkillsJSON: "[]", Status: store.PhaseRunning}
+	require.NoError(t, s.CreateRun(ctx, run))
+
+	for i, msg := range []string{"first", "second", "third"} {
+		require.NoError(t, s.AppendRunLog(ctx, store.RunLog{
+			RunID:     run.ID,
+			Timestamp: time.Now().Format(time.RFC3339Nano),
+			Type:      "step",
+			Message:   msg,
+			Data:      "",
+		}), "append #%d", i)
+	}
+
+	all, err := s.ListRunLogs(ctx, run.ID, 0)
+	require.NoError(t, err)
+	require.Len(t, all, 3)
+	assert.Equal(t, "first", all[0].Message)
+	assert.Equal(t, "second", all[1].Message)
+	assert.Equal(t, "third", all[2].Message)
+	assert.True(t, all[0].ID < all[1].ID && all[1].ID < all[2].ID)
+}
+
+func TestRunLog_ListAfterID(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	run := &store.DiagnosticRun{TargetJSON: "{}", SkillsJSON: "[]", Status: store.PhaseRunning}
+	require.NoError(t, s.CreateRun(ctx, run))
+
+	for _, msg := range []string{"a", "b", "c"} {
+		require.NoError(t, s.AppendRunLog(ctx, store.RunLog{
+			RunID:     run.ID,
+			Timestamp: time.Now().Format(time.RFC3339Nano),
+			Type:      "info",
+			Message:   msg,
+		}))
+	}
+
+	all, err := s.ListRunLogs(ctx, run.ID, 0)
+	require.NoError(t, err)
+	require.Len(t, all, 3)
+
+	// Tail strictly after the first entry.
+	tail, err := s.ListRunLogs(ctx, run.ID, all[0].ID)
+	require.NoError(t, err)
+	assert.Len(t, tail, 2)
+	assert.Equal(t, "b", tail[0].Message)
+	assert.Equal(t, "c", tail[1].Message)
+}
+
+func TestRunLog_ListUnknownRunReturnsEmpty(t *testing.T) {
+	s := newTestStore(t)
+	got, err := s.ListRunLogs(context.Background(), "nonexistent", 0)
+	require.NoError(t, err)
+	assert.Len(t, got, 0)
+}
+
+// ── Paginated runs ──────────────────────────────────────────────────────────
+
+func seedRuns(t *testing.T, s store.Store, n int) []*store.DiagnosticRun {
+	t.Helper()
+	ctx := context.Background()
+	out := make([]*store.DiagnosticRun, 0, n)
+	for i := 0; i < n; i++ {
+		r := &store.DiagnosticRun{
+			TargetJSON: "{}",
+			SkillsJSON: "[]",
+			Status:     store.PhasePending,
+		}
+		require.NoError(t, s.CreateRun(ctx, r))
+		out = append(out, r)
+		// Ensure created_at differs so ORDER BY is deterministic.
+		time.Sleep(2 * time.Millisecond)
+	}
+	return out
+}
+
+func TestListRunsPaginated_DefaultPageAndSize(t *testing.T) {
+	s := newTestStore(t)
+	seedRuns(t, s, 3)
+
+	page, err := s.ListRunsPaginated(context.Background(), store.ListOpts{})
+	require.NoError(t, err)
+	assert.Equal(t, 3, page.Total)
+	assert.Equal(t, 1, page.Page)
+	assert.Equal(t, 20, page.PageSize)
+	assert.Len(t, page.Items, 3)
+}
+
+func TestListRunsPaginated_MultiPage(t *testing.T) {
+	s := newTestStore(t)
+	seedRuns(t, s, 5)
+	ctx := context.Background()
+
+	p1, err := s.ListRunsPaginated(ctx, store.ListOpts{Page: 1, PageSize: 2, SortOrder: "desc"})
+	require.NoError(t, err)
+	assert.Equal(t, 5, p1.Total)
+	assert.Len(t, p1.Items, 2)
+
+	p2, err := s.ListRunsPaginated(ctx, store.ListOpts{Page: 2, PageSize: 2, SortOrder: "desc"})
+	require.NoError(t, err)
+	assert.Len(t, p2.Items, 2)
+
+	p3, err := s.ListRunsPaginated(ctx, store.ListOpts{Page: 3, PageSize: 2, SortOrder: "desc"})
+	require.NoError(t, err)
+	assert.Len(t, p3.Items, 1)
+
+	// No overlap across pages.
+	seen := map[string]bool{}
+	for _, r := range append(append(p1.Items, p2.Items...), p3.Items...) {
+		assert.False(t, seen[r.ID], "duplicate id %q across pages", r.ID)
+		seen[r.ID] = true
+	}
+}
+
+func TestListRunsPaginated_ASCOrder(t *testing.T) {
+	s := newTestStore(t)
+	runs := seedRuns(t, s, 3)
+	ctx := context.Background()
+
+	asc, err := s.ListRunsPaginated(ctx, store.ListOpts{Page: 1, PageSize: 10, SortOrder: "asc"})
+	require.NoError(t, err)
+	require.Len(t, asc.Items, 3)
+	// First seeded should be the earliest (oldest first).
+	assert.Equal(t, runs[0].ID, asc.Items[0].ID)
+}
+
+func TestListRunsPaginated_PageSizeCappedAt100(t *testing.T) {
+	s := newTestStore(t)
+	seedRuns(t, s, 5)
+
+	page, err := s.ListRunsPaginated(context.Background(), store.ListOpts{Page: 1, PageSize: 9999})
+	require.NoError(t, err)
+	assert.Equal(t, 100, page.PageSize, "PageSize > 100 should be capped to 100")
+}
+
+func TestListRunsPaginated_SortByWhitelist(t *testing.T) {
+	s := newTestStore(t)
+	seedRuns(t, s, 2)
+
+	// Bogus SortBy must silently fall back to created_at — not panic, not error.
+	page, err := s.ListRunsPaginated(context.Background(), store.ListOpts{
+		Page:     1,
+		PageSize: 10,
+		SortBy:   "; DROP TABLE diagnostic_runs;--",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, page.Total, "table must still be intact after malicious SortBy")
+}
+
+func TestListRunsPaginated_FilterByPhase(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	r1 := &store.DiagnosticRun{TargetJSON: "{}", SkillsJSON: "[]", Status: store.PhasePending}
+	r2 := &store.DiagnosticRun{TargetJSON: "{}", SkillsJSON: "[]", Status: store.PhaseRunning}
+	require.NoError(t, s.CreateRun(ctx, r1))
+	require.NoError(t, s.CreateRun(ctx, r2))
+
+	page, err := s.ListRunsPaginated(ctx, store.ListOpts{
+		Page: 1, PageSize: 10,
+		Filters: map[string]string{"phase": string(store.PhaseRunning)},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, page.Total)
+	require.Len(t, page.Items, 1)
+	assert.Equal(t, r2.ID, page.Items[0].ID)
+}
+
+func TestListRunsPaginated_FilterByCluster(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	r1 := &store.DiagnosticRun{ClusterName: "prod", TargetJSON: "{}", SkillsJSON: "[]", Status: store.PhasePending}
+	r2 := &store.DiagnosticRun{ClusterName: "dev", TargetJSON: "{}", SkillsJSON: "[]", Status: store.PhasePending}
+	require.NoError(t, s.CreateRun(ctx, r1))
+	require.NoError(t, s.CreateRun(ctx, r2))
+
+	page, err := s.ListRunsPaginated(ctx, store.ListOpts{Page: 1, PageSize: 10, ClusterName: "prod"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, page.Total)
+	assert.Equal(t, r1.ID, page.Items[0].ID)
+}
+
+// ── Paginated fixes ──────────────────────────────────────────────────────────
+
+func TestListFixesPaginated_FilterByPhaseAndNamespace(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	for _, f := range []*store.Fix{
+		{TargetKind: "Deployment", TargetNamespace: "default", TargetName: "a", Phase: store.FixPhasePendingApproval},
+		{TargetKind: "Deployment", TargetNamespace: "default", TargetName: "b", Phase: store.FixPhaseSucceeded},
+		{TargetKind: "Deployment", TargetNamespace: "kube-system", TargetName: "c", Phase: store.FixPhaseSucceeded},
+	} {
+		require.NoError(t, s.CreateFix(ctx, f))
+	}
+
+	page, err := s.ListFixesPaginated(ctx, store.ListOpts{
+		Page: 1, PageSize: 10,
+		Filters: map[string]string{
+			"phase":     string(store.FixPhaseSucceeded),
+			"namespace": "default",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, page.Total)
+	require.Len(t, page.Items, 1)
+	assert.Equal(t, "b", page.Items[0].TargetName)
+}
+
+func TestListFixesPaginated_DefaultsAndCap(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		require.NoError(t, s.CreateFix(ctx, &store.Fix{
+			TargetKind: "Deployment", TargetName: "x", Phase: store.FixPhasePendingApproval,
+		}))
+	}
+	page, err := s.ListFixesPaginated(ctx, store.ListOpts{PageSize: 9999})
+	require.NoError(t, err)
+	assert.Equal(t, 1, page.Page)
+	assert.Equal(t, 100, page.PageSize)
+	assert.Equal(t, 3, page.Total)
+}
+
+// ── Paginated events ─────────────────────────────────────────────────────────
+
+func TestListEventsPaginated_PageAndFilters(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	now := time.Now()
+	events := []*store.Event{
+		{UID: "u1", Namespace: "ns1", Kind: "Pod", Name: "p1", Reason: "BackOff", Type: "Warning", Count: 1, FirstTime: now, LastTime: now},
+		{UID: "u2", Namespace: "ns1", Kind: "Pod", Name: "p2", Reason: "BackOff", Type: "Warning", Count: 1, FirstTime: now, LastTime: now},
+		{UID: "u3", Namespace: "ns2", Kind: "Pod", Name: "p3", Reason: "Created", Type: "Normal", Count: 1, FirstTime: now, LastTime: now},
+	}
+	for _, ev := range events {
+		require.NoError(t, s.UpsertEvent(ctx, ev))
+	}
+
+	page, err := s.ListEventsPaginated(ctx, store.ListEventsOpts{Namespace: "ns1"}, 1, 10)
+	require.NoError(t, err)
+	assert.Equal(t, 2, page.Total)
+	assert.Len(t, page.Items, 2)
+
+	// Multi-page split.
+	p1, err := s.ListEventsPaginated(ctx, store.ListEventsOpts{}, 1, 2)
+	require.NoError(t, err)
+	assert.Equal(t, 3, p1.Total)
+	assert.Len(t, p1.Items, 2)
+	p2, err := s.ListEventsPaginated(ctx, store.ListEventsOpts{}, 2, 2)
+	require.NoError(t, err)
+	assert.Len(t, p2.Items, 1)
+}
+
+func TestListEventsPaginated_SinceMinutes(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	require.NoError(t, s.UpsertEvent(ctx, &store.Event{
+		UID: "old", Namespace: "ns", Kind: "Pod", Name: "p", Reason: "X", Type: "Warning",
+		FirstTime: now.Add(-2 * time.Hour), LastTime: now.Add(-2 * time.Hour), Count: 1,
+	}))
+	require.NoError(t, s.UpsertEvent(ctx, &store.Event{
+		UID: "new", Namespace: "ns", Kind: "Pod", Name: "p", Reason: "Y", Type: "Warning",
+		FirstTime: now, LastTime: now, Count: 1,
+	}))
+
+	// Last 30 minutes only.
+	page, err := s.ListEventsPaginated(ctx, store.ListEventsOpts{SinceMinutes: 30}, 1, 10)
+	require.NoError(t, err)
+	assert.Equal(t, 1, page.Total)
+	assert.Equal(t, "new", page.Items[0].UID)
+}
+
+func TestListEventsPaginated_DefaultsAndCap(t *testing.T) {
+	s := newTestStore(t)
+	page, err := s.ListEventsPaginated(context.Background(), store.ListEventsOpts{}, 0, 9999)
+	require.NoError(t, err)
+	assert.Equal(t, 1, page.Page)
+	assert.Equal(t, 100, page.PageSize)
+}
+
+// ── Notification configs ────────────────────────────────────────────────────
+
+func TestNotificationConfig_LifecycleAndIDAutoFill(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	cfg := &store.NotificationConfig{
+		Name: "ops-slack", Type: "slack",
+		WebhookURL: "https://slack.example/hook",
+		Events:     "fix.applied,run.failed",
+		Enabled:    true,
+	}
+	require.NoError(t, s.CreateNotificationConfig(ctx, cfg))
+	assert.NotEmpty(t, cfg.ID, "ID should be auto-filled")
+
+	got, err := s.GetNotificationConfig(ctx, cfg.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "ops-slack", got.Name)
+	assert.True(t, got.Enabled)
+
+	// Update.
+	cfg.Name = "ops-slack-v2"
+	cfg.Enabled = false
+	require.NoError(t, s.UpdateNotificationConfig(ctx, cfg))
+
+	got, err = s.GetNotificationConfig(ctx, cfg.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "ops-slack-v2", got.Name)
+	assert.False(t, got.Enabled)
+
+	// List shows it.
+	all, err := s.ListNotificationConfigs(ctx)
+	require.NoError(t, err)
+	require.Len(t, all, 1)
+	assert.Equal(t, cfg.ID, all[0].ID)
+
+	// Delete.
+	require.NoError(t, s.DeleteNotificationConfig(ctx, cfg.ID))
+	_, err = s.GetNotificationConfig(ctx, cfg.ID)
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestNotificationConfig_GetOrUpdateOrDeleteMissing(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := s.GetNotificationConfig(ctx, "ghost")
+	assert.ErrorIs(t, err, store.ErrNotFound)
+
+	err = s.UpdateNotificationConfig(ctx, &store.NotificationConfig{ID: "ghost", Name: "x", Type: "slack"})
+	assert.ErrorIs(t, err, store.ErrNotFound)
+
+	err = s.DeleteNotificationConfig(ctx, "ghost")
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestNotificationConfig_ListEmpty(t *testing.T) {
+	s := newTestStore(t)
+	all, err := s.ListNotificationConfigs(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, all)
+}
+
+// ── Batch operations ────────────────────────────────────────────────────────
+
+func TestDeleteRuns_CascadesToChildTables(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	run := &store.DiagnosticRun{TargetJSON: "{}", SkillsJSON: "[]", Status: store.PhaseSucceeded}
+	require.NoError(t, s.CreateRun(ctx, run))
+	require.NoError(t, s.CreateFinding(ctx, &store.Finding{
+		RunID: run.ID, Dimension: "health", Severity: "high", Title: "t",
+	}))
+	require.NoError(t, s.CreateFix(ctx, &store.Fix{
+		RunID: run.ID, TargetKind: "Deployment", TargetName: "x", Phase: store.FixPhaseSucceeded,
+	}))
+	require.NoError(t, s.AppendRunLog(ctx, store.RunLog{
+		RunID: run.ID, Timestamp: time.Now().Format(time.RFC3339Nano), Type: "info", Message: "hi",
+	}))
+
+	require.NoError(t, s.DeleteRuns(ctx, []string{run.ID}))
+
+	_, err := s.GetRun(ctx, run.ID)
+	assert.ErrorIs(t, err, store.ErrNotFound)
+
+	logs, err := s.ListRunLogs(ctx, run.ID, 0)
+	require.NoError(t, err)
+	assert.Empty(t, logs, "child run_logs should be cascaded")
+
+	findings, err := s.ListFindings(ctx, run.ID)
+	require.NoError(t, err)
+	assert.Empty(t, findings, "child findings should be cascaded")
+
+	fixes, err := s.ListFixesByRun(ctx, run.ID)
+	require.NoError(t, err)
+	assert.Empty(t, fixes, "child fixes should be cascaded")
+}
+
+func TestDeleteRuns_EmptyIsNoop(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.DeleteRuns(context.Background(), nil))
+	require.NoError(t, s.DeleteRuns(context.Background(), []string{}))
+}
+
+func TestDeleteRuns_UnknownIDsAreIdempotent(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.DeleteRuns(context.Background(), []string{"nope-1", "nope-2"}))
+}
+
+func TestBatchUpdateFixPhase_UpdatesAllListed(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	f1 := &store.Fix{TargetKind: "Deployment", TargetName: "a", Phase: store.FixPhasePendingApproval}
+	f2 := &store.Fix{TargetKind: "Deployment", TargetName: "b", Phase: store.FixPhasePendingApproval}
+	f3 := &store.Fix{TargetKind: "Deployment", TargetName: "c", Phase: store.FixPhasePendingApproval}
+	require.NoError(t, s.CreateFix(ctx, f1))
+	require.NoError(t, s.CreateFix(ctx, f2))
+	require.NoError(t, s.CreateFix(ctx, f3))
+
+	require.NoError(t, s.BatchUpdateFixPhase(ctx,
+		[]string{f1.ID, f2.ID}, store.FixPhaseApproved, "ok by user"))
+
+	got, _ := s.GetFix(ctx, f1.ID)
+	assert.Equal(t, store.FixPhaseApproved, got.Phase)
+	assert.Equal(t, "ok by user", got.Message)
+
+	got, _ = s.GetFix(ctx, f2.ID)
+	assert.Equal(t, store.FixPhaseApproved, got.Phase)
+
+	// f3 untouched.
+	got, _ = s.GetFix(ctx, f3.ID)
+	assert.Equal(t, store.FixPhasePendingApproval, got.Phase)
+}
+
+func TestBatchUpdateFixPhase_EmptyIsNoop(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.BatchUpdateFixPhase(context.Background(), nil, store.FixPhaseFailed, ""))
+	require.NoError(t, s.BatchUpdateFixPhase(context.Background(), []string{}, store.FixPhaseFailed, ""))
+}


### PR DESCRIPTION
## Summary

Raises unit-test coverage on the **8 highest-risk packages** (Go + Python)
identified as critical-path / bug-prone. **No production code changes** —
test files only.

| # | Package | Before | After |
|---|---|---|---|
| 1 | \`internal/agent\` | 0.0% | **100.0%** |
| 2 | \`internal/k8sclient\` | 34.3% | **87.1%** |
| 3 | \`internal/store/sqlite\` | 44.0% | **85.4%** |
| 4 | \`internal/collector\` | 19.8% | **80.2%** |
| 5 | \`internal/controller/httpserver\` | 58.9% | **81.4%** |
| 6 | \`internal/controller/reconciler\` | 49.1% | **79.5%** ¹ |
| 7 | \`agent-runtime/runtime/tracer.py\` | 53% | **100%** |
| 8 | \`agent-runtime/runtime/fix_main.py\` | 0% | **99%** ² |

¹ Within the design's 5-point allowance for exempt code (6 \`SetupWithManager\` methods at 0%).
² Only the \`if __name__ == "__main__":\` sentinel uncovered.

**Python total:** 68% → **91%**.

## What was added

- \`docs/superpowers/specs/2026-05-01-critical-path-test-coverage-design.md\` — full design
- 8 test commits, one per target package, in bottom-up order:
  1. \`test(agent): cover EmitEvent log emission\` — captures stdout, asserts JSON shape, locks LogType\* constants
  2. \`test(k8sclient): cover Build and Mapper\` — fake discovery + injected REST mapper
  3. \`test(sqlite): cover paginated/notification/log/batch ops\` — \`AppendRunLog\`, \`*Paginated\`, \`sanitizeSortOrder\` (incl. SQL-injection regression), 5 NotificationConfig CRUDs, \`DeleteRuns\` cascade, \`BatchUpdateFixPhase\`
  4. \`test(collector): cover watch/scrape/purge/Start\` — fake clientset event watcher, stub Prometheus API, real sqlite store
  5. \`test(httpserver): cover 0% handlers and weak branches\` — ModelConfigs, NotificationConfigs (5 CRUDs + test endpoint), K8sResources, FixDetail approve/reject, Runs/RunCRD, plus internal helper tests for \`parsePodLogLine\`, \`parsePagination\`, \`strVal\`, \`randSuffix\`
  6. \`test(reconciler): cover fix/scheduled/run weak paths\` — \`applyPatch\`/\`rollback\`/\`kindToGVK\`, scheduled run \`Reconcile\` + \`buildChildRun\` + \`enforceHistoryLimit\` + \`appendUnique\`/\`removeFromSlice\`, run completion notifications + critical-finding emission
  7. \`test(tracer.py): cover init/sanitize/Tracer degradation paths\` — \`init()\` / \`init_fix()\` env handling, \`sanitize_messages\` block-by-block, \`_Tracer.generation/span/flush\` degradation
  8. \`test(fix_main.py): cover apply/rollback/CLI\` — \`_stream_llm_call\` SSE parsing, \`main()\` happy path / create branch / LLM failure / invalid JSON / fallback paths

## Constraints honoured

- Existing test style preserved: \`fake.NewClientBuilder()\` (controller-runtime), \`fake.NewSimpleClientset()\` (client-go), real SQLite tmpfile, \`httptest\`, \`pytest + monkeypatch + unittest.mock\`. No new test deps.
- 0 production code changes. Where a seam was thought to be needed (clock injection in scheduled_run_reconciler, metrics lister extraction), tests were structured to avoid the change instead.
- CI coverage thresholds unchanged — to be revisited after merge based on new baseline.

## Test plan

- [x] \`go test -race -count=1 ./...\` — all green locally
- [x] \`pytest agent-runtime/tests/\` — 120 passed
- [x] \`go vet ./...\` — clean
- [ ] CI Go + Python coverage report
- [ ] Reviewer eyeballs the design spec at \`docs/superpowers/specs/2026-05-01-critical-path-test-coverage-design.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)