### PR TITLE
chore: rebrand to KubeDoctor (facade only, internal identifiers preserved)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# kube-agent-helper
+# KubeDoctor
 
 > Kubernetes 原生 AI 诊断 Operator，支持自动修复建议
 
-**kube-agent-helper** 是运行在 Kubernetes 集群内的 AI 智能体。声明一个 `DiagnosticRun` CR，控制器即刻拉起隔离的 Agent Pod，通过 MCP 工具调用 Claude，输出结构化诊断结论，并可选生成 `DiagnosticFix` CR（含 patch 或新资源 manifest）。支持定时调度诊断、K8s 事件采集、Prometheus 指标快照。
+**KubeDoctor** 是运行在 Kubernetes 集群内的 AI 智能体。声明一个 `DiagnosticRun` CR，控制器即刻拉起隔离的 Agent Pod，通过 MCP 工具调用 Claude，输出结构化诊断结论，并可选生成 `DiagnosticFix` CR（含 patch 或新资源 manifest）。支持定时调度诊断、K8s 事件采集、Prometheus 指标快照。
 
 [![CI](https://github.com/googs1025/kube-agent-helper/actions/workflows/ci.yml/badge.svg)](https://github.com/googs1025/kube-agent-helper/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
@@ -64,9 +64,12 @@ spec:
   model: claude-3-5-sonnet-20241022
   baseURL: "https://my-proxy.example.com"   # 可选，省略则直连 Anthropic API
   retries: 3                                # 可选，默认 0；代理抖动严重时设 1-3
+  # apiKeyRef 引用 Step 1 创建的 Secret，等价于：
+  #   kubectl create secret generic anthropic-credentials \
+  #     -n kube-agent-helper --from-literal=apiKey=sk-ant-...
   apiKeyRef:
-    name: anthropic-credentials
-    key: apiKey
+    name: anthropic-credentials   # ← Secret 名称（与 Step 1 一致）
+    key: apiKey                   # ← Secret 中存放 API Key 的 data key
 ```
 
 `spec.baseURL` 允许每个 ModelConfig 指定独立的 API 代理端点。`spec.retries` 控制单模型瞬时错误（5xx / 429 / 网络超时）的重试次数，0 表示不重试。Translator 在创建 Agent Job 时从 ModelConfig CR 中解析 `baseURL` 和 `apiKeyRef`，而非全局控制器配置。

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,8 +1,8 @@
-# kube-agent-helper
+# KubeDoctor
 
 > Kubernetes-native AI diagnostic operator with auto-fix capabilities
 
-**kube-agent-helper** is an AI agent that runs inside your Kubernetes cluster, diagnoses workload issues, and generates actionable fix suggestions. Declare a `DiagnosticRun` CR, and the controller spins up an isolated agent Pod that calls Claude via MCP tools, writes structured findings, and optionally produces `DiagnosticFix` CRs with patches or new resource manifests. Supports scheduled diagnostics, K8s event collection, and Prometheus metric snapshots.
+**KubeDoctor** is an AI agent that runs inside your Kubernetes cluster, diagnoses workload issues, and generates actionable fix suggestions. Declare a `DiagnosticRun` CR, and the controller spins up an isolated agent Pod that calls Claude via MCP tools, writes structured findings, and optionally produces `DiagnosticFix` CRs with patches or new resource manifests. Supports scheduled diagnostics, K8s event collection, and Prometheus metric snapshots.
 
 [![CI](https://github.com/googs1025/kube-agent-helper/actions/workflows/ci.yml/badge.svg)](https://github.com/googs1025/kube-agent-helper/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
@@ -64,9 +64,12 @@ spec:
   model: claude-3-5-sonnet-20241022
   baseURL: "https://my-proxy.example.com"   # optional, omit for direct Anthropic API
   retries: 3                                # optional, default 0; set 1-3 if proxy is flaky
+  # apiKeyRef references the Secret created in Step 1, equivalent to:
+  #   kubectl create secret generic anthropic-credentials \
+  #     -n kube-agent-helper --from-literal=apiKey=sk-ant-...
   apiKeyRef:
-    name: anthropic-credentials
-    key: apiKey
+    name: anthropic-credentials   # ← Secret name (matches Step 1)
+    key: apiKey                   # ← data key in the Secret holding the API key
 ```
 
 `spec.baseURL` lets each ModelConfig specify its own API proxy endpoint. The Translator resolves `baseURL` and `apiKeyRef` from the referenced ModelConfig CR when creating each agent Job, rather than from global controller config. `spec.retries` controls per-endpoint retries on transient errors (5xx / 429 / network timeout); 0 disables retries.

--- a/cmd/kah/cmd/root.go
+++ b/cmd/kah/cmd/root.go
@@ -22,7 +22,7 @@ func SetVersionInfo(version, commit string) {
 
 var rootCmd = &cobra.Command{
 	Use:   "kah",
-	Short: "Kube Agent Helper CLI",
+	Short: "KubeDoctor CLI",
 	Long:  "CLI tool for interacting with the kube-agent-helper controller API",
 }
 

--- a/dashboard/src/app/about/page.tsx
+++ b/dashboard/src/app/about/page.tsx
@@ -11,7 +11,7 @@ export default function AboutPage() {
     <div className="space-y-8">
       <div>
         <h1 className="text-2xl font-bold">{t("about.title")}</h1>
-        <p className="mt-1 text-sm text-muted-foreground">Kube Agent Helper — AI-powered Kubernetes diagnostics</p>
+        <p className="mt-1 text-sm text-muted-foreground">KubeDoctor — AI-powered Kubernetes diagnostics</p>
       </div>
 
       {/* Architecture */}

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -81,7 +81,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="zh" suppressHydrationWarning>
       <head>
-        <title>Kube Agent Helper</title>
+        <title>KubeDoctor</title>
         <script dangerouslySetInnerHTML={{ __html: preHydrationScript }} />
       </head>
       <body className="min-h-screen bg-background">

--- a/dashboard/src/i18n/en.json
+++ b/dashboard/src/i18n/en.json
@@ -1,6 +1,6 @@
 {
   "nav": {
-    "brand": "Kube Agent Helper",
+    "brand": "KubeDoctor",
     "runs": "Runs",
     "skills": "Skills",
     "fixes": "Fixes",

--- a/dashboard/src/i18n/zh.json
+++ b/dashboard/src/i18n/zh.json
@@ -1,6 +1,6 @@
 {
   "nav": {
-    "brand": "Kube Agent Helper",
+    "brand": "KubeDoctor",
     "runs": "诊断任务",
     "skills": "技能",
     "fixes": "修复建议",

--- a/deploy/grafana/kube-agent-helper-dashboard.json
+++ b/deploy/grafana/kube-agent-helper-dashboard.json
@@ -632,7 +632,7 @@
   "time": { "from": "now-1h", "to": "now" },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Kube Agent Helper",
+  "title": "KubeDoctor",
   "uid": "kube-agent-helper",
   "version": 1
 }

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: kube-agent-helper
+name: kube-doctor
 description: Kubernetes AI diagnostic operator
 type: application
 version: 0.1.0

--- a/deploy/helm/VALUES.md
+++ b/deploy/helm/VALUES.md
@@ -1,4 +1,4 @@
-# Kube Agent Helper — Helm Values Reference
+# KubeDoctor — Helm Values Reference
 
 Complete reference for all configurable parameters in the `kube-agent-helper` Helm chart.
 

--- a/deploy/helm/grafana/kube-agent-helper-dashboard.json
+++ b/deploy/helm/grafana/kube-agent-helper-dashboard.json
@@ -632,7 +632,7 @@
   "time": { "from": "now-1h", "to": "now" },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Kube Agent Helper",
+  "title": "KubeDoctor",
   "uid": "kube-agent-helper",
   "version": 1
 }

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,5 +1,5 @@
 # =============================================================================
-# Kube Agent Helper Helm Chart Values
+# KubeDoctor Helm Chart Values
 # Full reference: VALUES.md
 # =============================================================================
 

--- a/docs/grafana-dashboard.md
+++ b/docs/grafana-dashboard.md
@@ -17,7 +17,7 @@ helm upgrade --install kah ./deploy/helm \
   --set grafana.dashboard.enabled=true
 ```
 
-The ConfigMap is labeled with `grafana_dashboard: "1"`. The Grafana sidecar detects this label and provisions the dashboard automatically. It typically appears in Grafana within 60 seconds under the title **Kube Agent Helper**.
+The ConfigMap is labeled with `grafana_dashboard: "1"`. The Grafana sidecar detects this label and provisions the dashboard automatically. It typically appears in Grafana within 60 seconds under the title **KubeDoctor**.
 
 ### Custom annotations
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,6 +1,6 @@
 # Notification / Webhook Setup Guide
 
-Kube Agent Helper can send real-time notifications when diagnostic runs complete, critical findings are detected, or fixes change status. Four notification channels are supported out of the box.
+KubeDoctor can send real-time notifications when diagnostic runs complete, critical findings are detected, or fixes change status. Four notification channels are supported out of the box.
 
 ## Architecture
 

--- a/internal/notification/manager.go
+++ b/internal/notification/manager.go
@@ -184,7 +184,7 @@ func (m *Manager) SendTest(ctx context.Context, cfg *NotificationConfig) error {
 		Type:      "test",
 		Severity:  "info",
 		Title:     "Test Notification",
-		Message:   fmt.Sprintf("This is a test notification from Kube Agent Helper (%s channel: %s)", cfg.Type, cfg.Name),
+		Message:   fmt.Sprintf("This is a test notification from KubeDoctor (%s channel: %s)", cfg.Type, cfg.Name),
 		Timestamp: time.Now(),
 	})
 }


### PR DESCRIPTION
## Summary
- Rebrand user-visible brand strings to **KubeDoctor** across READMEs (zh/en), Dashboard UI (i18n + layout title + about page), Helm chart name + values headers, CLI \`--help\`, Grafana dashboard title, notification test message, and related docs.
- **All internal identifiers preserved**: Go module path, CRD group (\`k8sai.io\`), K8s namespace (\`kube-agent-helper\`), CLI binary (\`kah\`), Docker image names (\`ghcr.io/kube-agent-helper/*\`), Grafana \`uid\`, file paths, Helm release name, metrics prefix (\`kah_*\`). No breaking changes for existing deployments.
- README also adds inline \`kubectl create secret\` reminder and \`apiKeyRef\` field comments to make the Step 1 → Step 2 binding explicit.

## Files changed (15)
- \`README.md\`, \`README_EN.md\`
- \`dashboard/src/i18n/{zh,en}.json\` (\`nav.brand\`)
- \`dashboard/src/app/{layout,about/page}.tsx\`
- \`deploy/helm/Chart.yaml\` (chart \`name\` only — release name unaffected)
- \`deploy/helm/values.yaml\`, \`deploy/helm/VALUES.md\`
- \`deploy/{helm/,}grafana/kube-agent-helper-dashboard.json\` (\`title\` only — \`uid\` preserved)
- \`cmd/kah/cmd/root.go\` (\`Short\` description)
- \`internal/notification/manager.go\` (test notification message)
- \`docs/grafana-dashboard.md\`, \`docs/notifications.md\`

## Test plan
- [ ] \`kah --help\` shows \"KubeDoctor CLI\"
- [ ] Dashboard nav, browser tab title, and About page show \"KubeDoctor\"
- [ ] \`helm install kah deploy/helm\` still works (release name unchanged; chart \`name\` is metadata)
- [ ] Grafana auto-provisioned dashboard appears under title \"KubeDoctor\" (uid \`kube-agent-helper\` preserved → existing links still work)
- [ ] \`kubectl ... -n kube-agent-helper\` commands still work (namespace unchanged)
- [ ] Test notification body reads \"... from KubeDoctor (...)\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)