### PR TITLE
docs(readme): clarify KubeDoctor vs kube-agent-helper naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 [English](README_EN.md)
 
+> **这个项目有两个名字：** **KubeDoctor** 是新名字，`kube-agent-helper` 是老名字 —— 仓库 URL、`kubectl` 命令、镜像路径里还能看到老名字，是同一个项目。
+
 ## 功能特性
 
 - **CRD 驱动** — 用 `DiagnosticRun` 声明诊断任务，用 `DiagnosticSkill` CR 扩展技能

--- a/README_EN.md
+++ b/README_EN.md
@@ -9,6 +9,8 @@
 
 [中文](README.md)
 
+> **This project has two names:** **KubeDoctor** is the new name; `kube-agent-helper` is the old one that still shows up in the repo URL, `kubectl` commands, and image paths. Same project.
+
 ## Features
 
 - **CRD-driven diagnostics** — declare tasks with `DiagnosticRun`; extend with `DiagnosticSkill` CRs


### PR DESCRIPTION
## Summary
Short callout near the top of both READMEs (zh + en) so readers don't get confused when they encounter both names — \`KubeDoctor\` (new brand) shows up in titles/dashboard/Helm chart, while \`kube-agent-helper\` (legacy name) still appears in the repo URL, \`kubectl\` commands, image paths, Go module path, and CLI binary \`kah\`.

This was originally part of PR #51 but landed after the merge, so opening it as a follow-up.

## Test plan
- [ ] Render both READMEs on GitHub and confirm the callout reads naturally
- [ ] No links/badges/code blocks broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)