### PR TITLE
chore(release): wire up v0.1.0 release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,161 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  REGISTRY_NS: ${{ github.repository_owner }}
+
+jobs:
+  build-images:
+    name: Build & Push ${{ matrix.image.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - name: kube-doctor-controller
+            context: .
+            dockerfile: Dockerfile
+          - name: kube-doctor-agent-runtime
+            context: .
+            dockerfile: agent-runtime/Dockerfile
+          - name: kube-doctor-dashboard
+            context: dashboard
+            dockerfile: dashboard/Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REGISTRY_NS }}/${{ matrix.image.name }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build & push image
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.image.context }}
+          file: ${{ matrix.image.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.image.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}
+
+  push-helm-chart:
+    name: Push Helm Chart (OCI)
+    runs-on: ubuntu-latest
+    needs: build-images
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Derive chart version from tag
+        id: ver
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.0
+
+      - name: Pin Chart.yaml version & appVersion to tag
+        run: |
+          v="${{ steps.ver.outputs.version }}"
+          sed -i.bak -E "s/^version: .*/version: ${v}/" deploy/helm/Chart.yaml
+          sed -i.bak -E "s/^appVersion: .*/appVersion: \"${v}\"/" deploy/helm/Chart.yaml
+          rm -f deploy/helm/Chart.yaml.bak
+          cat deploy/helm/Chart.yaml
+
+      - name: Helm lint
+        run: helm lint deploy/helm
+
+      - name: Package chart
+        run: |
+          mkdir -p /tmp/chart
+          helm package deploy/helm -d /tmp/chart
+
+      - name: Login to GHCR (Helm)
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | helm registry login ${{ env.REGISTRY }} \
+                -u ${{ github.actor }} --password-stdin
+
+      - name: Push chart to OCI registry
+        run: |
+          pkg=$(ls /tmp/chart/*.tgz)
+          helm push "${pkg}" oci://${{ env.REGISTRY }}/${{ env.REGISTRY_NS }}/charts
+
+  github-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [build-images, push-helm-chart]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Derive version
+        id: ver
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract release notes from CHANGELOG
+        run: |
+          v="${{ steps.ver.outputs.version }}"
+          if [ -f CHANGELOG.md ]; then
+            awk -v v="$v" '
+              $0 ~ "^## \\[" v "\\]" { found=1; next }
+              found && /^## \[/                   { exit }
+              found                                { print }
+            ' CHANGELOG.md > /tmp/notes.md
+          fi
+          [ -s /tmp/notes.md ] || echo "Release ${GITHUB_REF_NAME}." > /tmp/notes.md
+          cat >> /tmp/notes.md <<EOF
+
+          ## Container Images
+
+          - \`${{ env.REGISTRY }}/${{ env.REGISTRY_NS }}/kube-doctor-controller:${{ steps.ver.outputs.version }}\`
+          - \`${{ env.REGISTRY }}/${{ env.REGISTRY_NS }}/kube-doctor-agent-runtime:${{ steps.ver.outputs.version }}\`
+          - \`${{ env.REGISTRY }}/${{ env.REGISTRY_NS }}/kube-doctor-dashboard:${{ steps.ver.outputs.version }}\`
+
+          ## Helm Chart
+
+          \`\`\`bash
+          helm install kah oci://${{ env.REGISTRY }}/${{ env.REGISTRY_NS }}/charts/kube-doctor \\
+            --version ${{ steps.ver.outputs.version }} \\
+            --namespace kube-agent-helper --create-namespace
+          \`\`\`
+          EOF
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${GITHUB_REF_NAME}" \
+            --notes-file /tmp/notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,84 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-05-02
+
+First public release of **KubeDoctor** (formerly `kube-agent-helper`).
+
+### Added
+
+#### Operator core (Phase 1)
+- 5 CRDs: `DiagnosticRun`, `DiagnosticSkill`, `ModelConfig`, `DiagnosticFix`, `ClusterConfig`.
+- Controller binary (`cmd/controller`) with reconcilers for each CRD.
+- Translator: compiles `DiagnosticRun` → ServiceAccount + RoleBinding + ConfigMap + Job.
+- SkillRegistry with dual-source loading (`skills/*.md` + `DiagnosticSkill` CR).
+- SQLite-backed Store for findings, fixes, skills, events, metrics.
+- 10 built-in Skills covering health, security, cost, reliability, network, node,
+  rollout, storage, config-drift, alert-response.
+
+#### MCP tools
+- 16 MCP tools exposed via `k8s-mcp-server` (stdio transport, mcp-go):
+  `kubectl_get/describe/logs/explain/rollout_status`, `events_list/events_history`,
+  `top_pods/top_nodes`, `prometheus_query/prometheus_alerts/metric_history`,
+  `network_policy_check`, `node_status_summary`, `pvc_status`, `list_api_resources`.
+- Audit wrapper with parameter whitelist sanitization for every tool call.
+- Output sanitizer (`internal/sanitize`) and trimmer (`internal/trimmer`) to
+  redact Secrets and cap response size before returning to the agent.
+
+#### Dashboard (Phase 2)
+- Next.js 14 dashboard with i18n (zh/en) and dark/light theme.
+- Pages: runs, findings, skills, fixes, diagnose, events, CRD YAML viewer.
+- Skill registry UI (enable/disable, priority, source badge).
+
+#### Fix workflow (Phase 3)
+- `DiagnosticFix` CR with strategies `auto` / `dry-run` / `create`.
+- LLM-driven patch / manifest generation via short-lived FixGenerator Job.
+- Before/After diff viewer in Dashboard.
+- Human-in-the-loop approval flow:
+  `PendingApproval → Approved → Applying → Succeeded | Failed → RolledBack`.
+- Automatic rollback on health-check failure with snapshot restore.
+
+#### Symptom-driven diagnosis (Phase 3.5)
+- `/diagnose` page: select namespace + symptoms → controller picks matching skills.
+- Schedule presets: one-shot / hourly / daily 08:00 / weekly Mon 08:00 / custom cron.
+
+#### Phase 4 — Production hardening
+- **Scheduled diagnostics**: `spec.schedule` (cron) + `historyLimit` on
+  `DiagnosticRun`; controller creates child runs and prunes history.
+- **EventCollector**: background K8s Warning event watcher + Prometheus metric
+  scraper, persisted to SQLite (`events_history` and `metric_history` tools).
+- **Multi-cluster support**: `ClusterConfig` CR registers remote clusters via
+  kubeconfig Secret; `DiagnosticRun.spec.clusterRef` targets a specific cluster.
+- **Per-run model proxy**: `ModelConfig.spec.baseURL` allows each Run to use a
+  different LLM endpoint.
+- **Retry + Fallback chain**: `ModelConfig.spec.retries` for transient errors
+  (5xx / 429 / network) plus `DiagnosticRun.spec.fallbackModelConfigRefs` for
+  multi-model fallback with full message-history preservation across switches.
+- **Notification webhooks**: generic JSON, Slack, DingTalk, Feishu with HMAC
+  signing and 5-minute deduplication window.
+- **Output language control**: `DiagnosticRun.spec.outputLanguage: zh|en`.
+- **Langfuse integration**: optional self-hosted or cloud LLM observability.
+- **Grafana dashboard ConfigMap** auto-provisioned via sidecar pattern.
+- **Prometheus `/metrics` endpoint** + ServiceMonitor template.
+
+#### Tooling
+- `kah` CLI for local interaction with the controller HTTP API.
+- Helm Chart with full `VALUES.md` reference.
+- Comprehensive CI: unit + envtest + e2e + kind smoke + helm lint + skill lint
+  + CRD consistency + Go/Python coverage reporting.
+
+### Known Limitations
+
+- Single-instance controller (SQLite, no HA — use `replicaCount: 1`).
+- Anthropic-only LLM provider (proxy-compatible endpoints supported via `baseURL`).
+- No multi-tenancy / RBAC for Dashboard users (intended for trusted ops teams).
+- Streaming MCP tool responses not supported (request/response only).
+
+[Unreleased]: https://github.com/googs1025/kube-agent-helper/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/googs1025/kube-agent-helper/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -80,19 +80,25 @@ spec:
 
 > 完整参数列表和部署场景请参阅 [Helm Values Reference](deploy/helm/VALUES.md)。
 
+Chart 已发布到 GitHub Container Registry（OCI），无需 `git clone` 即可安装：
+
 ```bash
-helm install kah deploy/helm \
-  --namespace kube-agent-helper
+helm install kah oci://ghcr.io/googs1025/charts/kube-doctor \
+  --version 0.1.0 \
+  --namespace kube-agent-helper --create-namespace
 ```
 
 使用自定义代理和模型：
 
 ```bash
-helm install kah deploy/helm \
-  --namespace kube-agent-helper \
+helm install kah oci://ghcr.io/googs1025/charts/kube-doctor \
+  --version 0.1.0 \
+  --namespace kube-agent-helper --create-namespace \
   --set anthropic.baseURL=https://my-proxy.example.com \
   --set anthropic.model=claude-3-5-sonnet-20241022
 ```
+
+> 想从本地源码安装（开发场景），见下方「本地开发」段。
 
 ### 4. 访问 Dashboard
 
@@ -262,6 +268,9 @@ make image
 
 # 启动 Dashboard 开发服务器
 cd dashboard && npm run dev
+
+# 从本地源码安装 Helm Chart（不走 OCI 仓库）
+helm install kah deploy/helm --namespace kube-agent-helper --create-namespace
 ```
 
 ## 项目结构

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -12,12 +12,13 @@ replicaCount: 1
 # =============================================================================
 image:
   # -- Controller container image (repository:tag).
-  controller: ghcr.io/kube-agent-helper/controller:latest
+  # Tag is pinned to chart appVersion; override to use :latest or a custom build.
+  controller: ghcr.io/googs1025/kube-doctor-controller:0.1.0
   # -- Agent runtime image. The Translator spawns this image as a Job for each
   # diagnostic run.
-  agent: ghcr.io/kube-agent-helper/agent-runtime:latest
+  agent: ghcr.io/googs1025/kube-doctor-agent-runtime:0.1.0
   # -- Dashboard (Next.js) container image.
-  dashboard: ghcr.io/kube-agent-helper/dashboard:latest
+  dashboard: ghcr.io/googs1025/kube-doctor-dashboard:0.1.0
   # -- Image pull policy applied to all containers.
   # Valid values: Always, IfNotPresent, Never
   pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary

为 v0.1.0 首次发版准备**完整发布管道**，让用户无需 `git clone` 即可装上 KubeDoctor。

- **`.github/workflows/release.yml`**（新）— `v*` tag 触发：buildx 多架构（amd64/arm64）push 三个镜像到 GHCR，package + OCI push Helm chart，自动创建 GitHub Release（说明从 CHANGELOG.md 抽取）
- **`deploy/helm/values.yaml`** — 默认镜像从占位的 `ghcr.io/kube-agent-helper/*:latest` 改为 `ghcr.io/googs1025/kube-doctor-{controller,agent-runtime,dashboard}:0.1.0`
- **`CHANGELOG.md`**（新）— 首版 release notes，按 Keep a Changelog 格式列出 Phase 1-4 全部功能与已知限制
- **`README.md`** — 主安装路径改为 `helm install oci://ghcr.io/googs1025/charts/kube-doctor`，本地源码安装挪到「本地开发」段

闭环了 Issue #53 之外的发布前置项。

## Test plan

- [x] `helm lint deploy/helm` ✅ 通过
- [x] `helm template` 渲染输出确认镜像 = `ghcr.io/googs1025/kube-doctor-controller:0.1.0` 和 `kube-doctor-dashboard:0.1.0`
- [x] `release.yml` YAML 语法校验通过（`yaml.safe_load`）
- [ ] 合并后**先打 `v0.1.0-rc1`** tag 跑一遍 workflow 验证管道，绿后再打正式 `v0.1.0`
- [ ] 首次 push 后到 GitHub Packages 把 4 个 package（3 image + 1 chart）visibility 改为 Public
- [ ] 确认 repo Settings → Actions → Workflow permissions 是 "Read and write"（否则 GHCR push 会 401）

## 备注

- 不在本 PR 范围（用户明确不做）：CONTRIBUTING / SECURITY / 多架构以外的供应链增强 / Roadmap 更新
- Helm chart 的 `version` / `appVersion` 在 release.yml 内会按 tag 自动 sed 同步，不需手工维护

🤖 Generated with [Claude Code](https://claude.com/claude-code)