### PR TITLE
fix(release): pin values.yaml image tags to release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,13 +84,24 @@ jobs:
         with:
           version: v3.14.0
 
-      - name: Pin Chart.yaml version & appVersion to tag
+      - name: Pin Chart.yaml + values.yaml image tags to release tag
         run: |
           v="${{ steps.ver.outputs.version }}"
+          # Chart metadata
           sed -i.bak -E "s/^version: .*/version: ${v}/" deploy/helm/Chart.yaml
           sed -i.bak -E "s/^appVersion: .*/appVersion: \"${v}\"/" deploy/helm/Chart.yaml
-          rm -f deploy/helm/Chart.yaml.bak
+          # Image tags in values.yaml (controller / agent-runtime / dashboard)
+          # so the released chart references the matching image versions out of
+          # the box, without requiring users to pass --set image.* overrides.
+          for name in controller agent-runtime dashboard; do
+            sed -i.bak -E "s|kube-doctor-${name}:[^[:space:]]+|kube-doctor-${name}:${v}|g" \
+              deploy/helm/values.yaml
+          done
+          rm -f deploy/helm/Chart.yaml.bak deploy/helm/values.yaml.bak
+          echo '--- Chart.yaml ---'
           cat deploy/helm/Chart.yaml
+          echo '--- values.yaml (image section) ---'
+          grep -A 10 '^image:' deploy/helm/values.yaml | head -12
 
       - name: Helm lint
         run: helm lint deploy/helm

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -12,13 +12,15 @@ replicaCount: 1
 # =============================================================================
 image:
   # -- Controller container image (repository:tag).
-  # Tag is pinned to chart appVersion; override to use :latest or a custom build.
-  controller: ghcr.io/googs1025/kube-doctor-controller:0.1.0
+  # Released chart packages have these tags rewritten to the release version
+  # (see .github/workflows/release.yml). The :latest default below is for
+  # local-source installs (`helm install ... deploy/helm`).
+  controller: ghcr.io/googs1025/kube-doctor-controller:latest
   # -- Agent runtime image. The Translator spawns this image as a Job for each
   # diagnostic run.
-  agent: ghcr.io/googs1025/kube-doctor-agent-runtime:0.1.0
+  agent: ghcr.io/googs1025/kube-doctor-agent-runtime:latest
   # -- Dashboard (Next.js) container image.
-  dashboard: ghcr.io/googs1025/kube-doctor-dashboard:0.1.0
+  dashboard: ghcr.io/googs1025/kube-doctor-dashboard:latest
   # -- Image pull policy applied to all containers.
   # Valid values: Always, IfNotPresent, Never
   pullPolicy: IfNotPresent


### PR DESCRIPTION
## Problem

打 v0.1.0-rc1 时发现：chart 里 `values.yaml` 的 image tag 硬编码 `:0.1.0`，**没跟 chart `appVersion` 走**。所以 `helm install ... --version 0.1.0-rc1` 会去拉不存在的 `:0.1.0` 镜像，用户被迫 `--set image.controller=...:0.1.0-rc1` 等三个覆盖。

minikube 实测：override 后 pods 能 Running ✅，但 UX 不能接受。

## Fix

- `values.yaml`：默认改 `:latest`（本地源码安装场景一直能拉到，因为每个 release 也 push `:latest`）
- `release.yml`：在 package chart 前加一个循环 sed，把 3 个 `kube-doctor-{controller,agent-runtime,dashboard}` 的 tag 重写成 release tag。用 3 个独立 sed 而不是 `(a|b|c)` 正则因为 BSD sed (macOS) 不吃 alternation

## Test plan

- [x] 本地 sed 验证（macOS）：`:latest` → `:0.1.0-rc2` 三个 image 都正确替换
- [x] `helm lint deploy/helm` ✅
- [x] `helm template` 默认渲染出 `:latest`
- [ ] 合并后打 v0.1.0-rc2 验证 workflow 真的把 chart 内的 tag 改成 `:0.1.0-rc2`
- [ ] minikube 不带 `--set` 直接 `helm install --version 0.1.0-rc2` 验证 pods Running

🤖 Generated with [Claude Code](https://claude.com/claude-code)