### PR TITLE
fix(modelconfig): stop silent fallback when modelConfigRef points at missing CR

### DIFF
--- a/dashboard/src/app/diagnose/page.tsx
+++ b/dashboard/src/app/diagnose/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useI18n } from "@/i18n/context";
 import { useK8sNamespaces, useK8sResources, getK8sResourceDetail, createRun, useRuns, useModelConfigs } from "@/lib/api";
@@ -33,6 +33,15 @@ export default function DiagnosePage() {
   const { data: modelConfigs } = useModelConfigs();
   const { data: resources } = useK8sResources(resourceType, namespace);
   const { data: runs } = useRuns();
+
+  // Auto-select first available ModelConfig once SWR resolves the list, so
+  // submitting before the user touches the picker still uses a real config
+  // (instead of the previous "anthropic-credentials" hard-coded fallback).
+  useEffect(() => {
+    if (!modelConfigRef && modelConfigs && modelConfigs.length > 0) {
+      setModelConfigRef(modelConfigs[0].name);
+    }
+  }, [modelConfigs, modelConfigRef]);
 
   const toggleSymptom = (id: string) => {
     if (id === "full-check") {
@@ -85,7 +94,7 @@ export default function DiagnosePage() {
           labelSelector,
         },
         skills: symptomsToSkills(symptoms),
-        modelConfigRef: modelConfigRef || (modelConfigs?.[0]?.name ?? "anthropic-credentials"),
+        modelConfigRef: modelConfigRef || (modelConfigs?.[0]?.name ?? ""),
         fallbackModelConfigRefs: fallbackModelConfigRefs.length > 0 ? fallbackModelConfigRefs : undefined,
         outputLanguage: outputLang,
         ...(schedule ? { schedule } : {}),

--- a/dashboard/src/components/create-run-dialog.tsx
+++ b/dashboard/src/components/create-run-dialog.tsx
@@ -16,7 +16,7 @@
  */
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { DialogRoot, DialogTrigger, DialogPortal, DialogBackdrop, DialogPopup, DialogTitle, DialogClose } from "@/components/ui/dialog";
@@ -43,12 +43,25 @@ export function CreateRunDialog({ onCreated }: Props) {
   const [namespaces, setNamespaces] = useState<string[]>([]);
   const [labelSelector, setLabelSelector] = useState<string[]>([]);
   const [skills, setSkills] = useState<string[]>([]);
-  const [modelConfigRef, setModelConfigRef] = useState("anthropic-credentials");
+  // Empty initially — populated by the effect below once modelConfigs loads.
+  // Hard-coding a default here caused a silent UI desync: the <select> in
+  // ModelConfigPicker would visually show the first available option (because
+  // the hard-coded default doesn't match), but the form state stayed wrong
+  // unless the user actively re-picked.
+  const [modelConfigRef, setModelConfigRef] = useState("");
   const [fallbackModelConfigRefs, setFallbackModelConfigRefs] = useState<string[]>([]);
   const [timeoutSeconds, setTimeoutSeconds] = useState<string>("");
   const [outputLanguage, setOutputLanguage] = useState<"zh" | "en">(lang);
   const [schedule, setSchedule] = useState("");
   const [historyLimit, setHistoryLimit] = useState<string>("");
+
+  // Auto-select first available ModelConfig once SWR resolves the list, so the
+  // submitted modelConfigRef always matches what the user sees in the picker.
+  useEffect(() => {
+    if (!modelConfigRef && modelConfigs && modelConfigs.length > 0) {
+      setModelConfigRef(modelConfigs[0].name);
+    }
+  }, [modelConfigs, modelConfigRef]);
 
   function parseLabelSelector(tags: string[]): Record<string, string> {
     const result: Record<string, string> = {};

--- a/dashboard/src/components/model-config-picker.tsx
+++ b/dashboard/src/components/model-config-picker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { useI18n } from "@/i18n/context";
 import type { ModelConfig } from "@/lib/types";
@@ -49,6 +49,18 @@ export function ModelConfigPicker({
   const candidates = visible
     .map((c) => c.name)
     .filter((n) => n !== primary && !fallbacks.includes(n));
+
+  // Defensive: if the parent passed a primary that doesn't match any visible
+  // config (typically a stale hard-coded default like "anthropic-credentials"),
+  // the <select> would visually show the first option without firing onChange,
+  // and the form state would silently desync. Snap to the first visible config
+  // so what the user sees is what gets submitted.
+  const primaryMissing = !!primary && !visible.some((c) => c.name === primary);
+  useEffect(() => {
+    if (primaryMissing && visible.length > 0) {
+      onChange(visible[0].name, fallbacks);
+    }
+  }, [primaryMissing, visible, fallbacks, onChange]);
 
   if (visible.length === 0) {
     return (

--- a/internal/controller/translator/resolve_model_chain_internal_test.go
+++ b/internal/controller/translator/resolve_model_chain_internal_test.go
@@ -43,7 +43,10 @@ func TestResolveModelChain_PrimaryOnly(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "default"},
 		Spec:       k8saiV1.DiagnosticRunSpec{ModelConfigRef: "primary"},
 	}
-	chain := tr.resolveModelChain(context.Background(), run)
+	chain, err := tr.resolveModelChain(context.Background(), run)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if len(chain) != 1 || chain[0].Name != "primary" {
 		t.Fatalf("expected [primary], got %+v", chain)
 	}
@@ -63,7 +66,10 @@ func TestResolveModelChain_PrimaryWithFallbacks(t *testing.T) {
 			FallbackModelConfigRefs: []string{"f1", "f2"},
 		},
 	}
-	chain := tr.resolveModelChain(context.Background(), run)
+	chain, err := tr.resolveModelChain(context.Background(), run)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	got := []string{}
 	for _, mc := range chain {
 		got = append(got, mc.Name)
@@ -86,7 +92,10 @@ func TestResolveModelChain_MissingFallbackSkipped(t *testing.T) {
 			FallbackModelConfigRefs: []string{"missing"},
 		},
 	}
-	chain := tr.resolveModelChain(context.Background(), run)
+	chain, err := tr.resolveModelChain(context.Background(), run)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if len(chain) != 1 {
 		t.Fatalf("expected primary only when fallback missing, got %d", len(chain))
 	}
@@ -98,8 +107,32 @@ func TestResolveModelChain_NoClient(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "default"},
 		Spec:       k8saiV1.DiagnosticRunSpec{ModelConfigRef: "primary"},
 	}
-	chain := tr.resolveModelChain(context.Background(), run)
+	chain, err := tr.resolveModelChain(context.Background(), run)
+	if err != nil {
+		t.Fatalf("expected nil error without k8s client (legacy path), got %v", err)
+	}
 	if len(chain) != 0 {
 		t.Fatalf("expected empty chain without k8s client, got %d", len(chain))
+	}
+}
+
+// TestResolveModelChain_PrimaryNotFound asserts that a typoed or stale
+// modelConfigRef is surfaced as a hard error rather than silently degrading
+// to the global-flag fallback (which used to produce a confusing 401 from
+// the LLM provider when the legacy Secret didn't exist either).
+func TestResolveModelChain_PrimaryNotFound(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(resolveTestScheme()).Build()
+	tr := NewWithClient(Config{}, emptyProvider{}, c)
+
+	run := &k8saiV1.DiagnosticRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "default"},
+		Spec:       k8saiV1.DiagnosticRunSpec{ModelConfigRef: "does-not-exist"},
+	}
+	chain, err := tr.resolveModelChain(context.Background(), run)
+	if err == nil {
+		t.Fatalf("expected error when primary ModelConfig is missing, got chain=%v", chain)
+	}
+	if len(chain) != 0 {
+		t.Fatalf("expected empty chain on error, got %d entries", len(chain))
 	}
 }

--- a/internal/controller/translator/translator.go
+++ b/internal/controller/translator/translator.go
@@ -28,6 +28,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -99,11 +100,16 @@ func (t *Translator) Compile(ctx context.Context, run *k8saiV1.DiagnosticRun) ([
 	cm := t.buildConfigMap(cmName, runID, selected)
 	rb := t.buildRoleBinding(saName, runID, run.Namespace)
 
-	chain := t.resolveModelChain(ctx, run)
+	chain, err := t.resolveModelChain(ctx, run)
+	if err != nil {
+		return nil, err
+	}
 	if len(chain) == 0 {
-		// Legacy path: no client or primary missing. Synthesize a single-element
-		// chain from global flags + treat ModelConfigRef as a Secret name with
-		// key "apiKey" (pre-ModelConfig-CR behavior).
+		// Legacy path: client unavailable (test scenarios) or no ModelConfigRef
+		// specified at all. Synthesize a single-element chain from global flags
+		// + treat ModelConfigRef as a Secret name with key "apiKey"
+		// (pre-ModelConfig-CR behavior). NOT entered when ref points to a
+		// missing CR — that's a hard failure surfaced via the err above.
 		chain = []*k8saiV1.ModelConfig{{
 			Spec: k8saiV1.ModelConfigSpec{
 				Model:     t.cfg.Model,
@@ -364,18 +370,28 @@ func (t *Translator) resolveModelConfig(ctx context.Context, run *k8saiV1.Diagno
 // resolveModelChain returns the ordered list of ModelConfigs to try: the
 // primary at index 0, then each fallback in spec order. Missing fallbacks
 // are silently skipped (a fallback that no longer exists must not block the
-// run). Returns an empty slice if the k8s client is unavailable or the
-// primary ModelConfig is missing — callers should handle the empty-chain
-// case as a hard failure or fall back to legacy single-Secret behavior.
-func (t *Translator) resolveModelChain(ctx context.Context, run *k8saiV1.DiagnosticRun) []*k8saiV1.ModelConfig {
+// run).
+//
+// Returns:
+//   - (empty, nil) when the k8s client is unavailable or no primary ref is
+//     specified — callers may fall back to legacy single-Secret behavior.
+//   - (empty, error) when a primary ref is specified but the CR cannot be
+//     fetched (NotFound or any other client error). This surfaces user-visible
+//     mistakes such as a typoed modelConfigRef rather than silently degrading
+//     to legacy mode and producing a confusing 401 from the LLM.
+func (t *Translator) resolveModelChain(ctx context.Context, run *k8saiV1.DiagnosticRun) ([]*k8saiV1.ModelConfig, error) {
 	chain := []*k8saiV1.ModelConfig{}
 	if t.k8s == nil || run.Spec.ModelConfigRef == "" {
-		return chain
+		return chain, nil
 	}
 	var primary k8saiV1.ModelConfig
-	if err := t.k8s.Get(ctx, client.ObjectKey{Namespace: run.Namespace, Name: run.Spec.ModelConfigRef}, &primary); err == nil {
-		chain = append(chain, &primary)
+	if err := t.k8s.Get(ctx, client.ObjectKey{Namespace: run.Namespace, Name: run.Spec.ModelConfigRef}, &primary); err != nil {
+		if apierrors.IsNotFound(err) {
+			return chain, fmt.Errorf("ModelConfig %q not found in namespace %q", run.Spec.ModelConfigRef, run.Namespace)
+		}
+		return chain, fmt.Errorf("get ModelConfig %q: %w", run.Spec.ModelConfigRef, err)
 	}
+	chain = append(chain, &primary)
 	for _, name := range run.Spec.FallbackModelConfigRefs {
 		var fb k8saiV1.ModelConfig
 		if err := t.k8s.Get(ctx, client.ObjectKey{Namespace: run.Namespace, Name: name}, &fb); err != nil {
@@ -383,6 +399,6 @@ func (t *Translator) resolveModelChain(ctx context.Context, run *k8saiV1.Diagnos
 		}
 		chain = append(chain, &fb)
 	}
-	return chain
+	return chain, nil
 }
 


### PR DESCRIPTION
## Bug

用户在 Dashboard 创建 Run 时，picker 里选了 `minimax-modelconfig`，但生成的 CR 里 `modelConfigRef` 是 `anthropic-credentials`。Controller 静默 fallback 到全局 flag，用 fake key → Anthropic 401，Run Failed。

## Root cause

经典 React 受控 select 坑：
- `create-run-dialog.tsx:46` 把 `modelConfigRef` 初始化成 `useState(\"anthropic-credentials\")` 写死
- ModelConfig 列表里只有 `minimax-modelconfig`，select 的 `value=\"anthropic-credentials\"` 无匹配 option
- 浏览器策略：value 找不到匹配 → 视觉上显示第一个 option（`minimax-modelconfig`）
- 用户看到「已选好」→ **没去点** → onChange 不触发
- 提交时 form state 仍然是 `anthropic-credentials`

后端在 `resolveModelChain` 里 Get 失败时返回空 chain，让 Compile fall back 到 legacy path（用 `ModelConfigRef` 当 Secret name），最终 401。

## Fix（4 处，3 前端 + 1 后端）

### 1. `create-run-dialog.tsx`
- 初始 `useState(\"\")`
- `useEffect` 监听 `modelConfigs` 加载，自动填第一个

### 2. `model-config-picker.tsx`（防御性同步）
- 当 parent 传的 `primary` 不在 visible 列表里时，自动 `onChange(visible[0].name)`
- 未来其他 parent 同样犯错也能自愈

### 3. `diagnose/page.tsx`
- 同 #1，加 useEffect 自动填
- 移除提交时的 `\"anthropic-credentials\"` 硬编码兜底

### 4. `translator.resolveModelChain`（后端 fail-fast）
- 区分「无 client / 无 ref」(返回 nil error，走 legacy) 和「ref 指向不存在的 CR」(返回明确 error)
- `Compile` 把错误传上去，`DiagnosticRunReconciler.failRun` 把它写进 CR `status.message`
- 下次前端再有 bug 或用户手 typo，Run 立即 Failed 并明确说 `ModelConfig 'X' not found in namespace 'Y'`，不再被一个分钟之后的 LLM 401 误导排查方向

## Test plan

- [x] `go test ./internal/controller/translator/...` — 新增 `TestResolveModelChain_PrimaryNotFound`，全绿
- [x] `go test ./internal/... ./cmd/...` — 全绿
- [x] `npx vitest run` — 36/36 全绿（含原有 picker tests）
- [x] `npm run typecheck` — 0 错误
- [x] `npm run lint` — 0 错误
- [ ] 合并后在 minikube 重装 chart，dashboard 创建 Run 不指定 modelConfigRef → 期望 CR 里写入第一个可用 ModelConfig 的名字（不是 \"anthropic-credentials\"）

## Issue 报告

修这个 bug 时，用户在体验 v0.1.0-rc2 的 dashboard 创建 Run 时发现的。

🤖 Generated with [Claude Code](https://claude.com/claude-code)